### PR TITLE
Distributed stream processing

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  build-and-test:
+    name: Build And Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore src/Pipelinez.sln
+
+      - name: Build
+        run: dotnet build src/Pipelinez.sln --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test src/Pipelinez.sln --configuration Release --no-build --logger "console;verbosity=minimal"

--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -1,0 +1,43 @@
+name: PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  build-and-test:
+    name: Build And Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore src/Pipelinez.sln
+
+      - name: Build
+        run: dotnet build src/Pipelinez.sln --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test src/Pipelinez.sln --configuration Release --no-build --logger "console;verbosity=minimal"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Pipelinez is a small .NET 8 framework for building record-processing pipelines w
 - pluggable sources, segments, and destinations
 - async startup and completion
 - fault tracking and configurable error policies
+- optional distributed execution for transport-backed sources
 - transport extensions such as Kafka
 
 ## How It Works
@@ -118,6 +119,42 @@ The repo also includes:
 - a Kafka data generator in [`src/examples/Example.Kafka.DataGen`](src/examples/Example.Kafka.DataGen)
 - Docker-backed Kafka integration tests in [`src/tests/Pipelinez.Kafka.Tests`](src/tests/Pipelinez.Kafka.Tests)
 
+## Distributed Execution
+
+Pipelinez can run in `SingleProcess` mode or in explicit `Distributed` mode for distributed-capable sources such as Kafka.
+
+In distributed mode, the runtime surfaces:
+
+- worker identity through `PipelineHostOptions`
+- current owned partitions through `GetRuntimeContext()`
+- worker lifecycle and rebalance events
+- record-level distribution context on completion and fault events
+
+Example shape:
+
+```csharp
+using Pipelinez.Core.Distributed;
+
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .UseHostOptions(new PipelineHostOptions
+    {
+        ExecutionMode = PipelineExecutionMode.Distributed,
+        InstanceId = Environment.MachineName,
+        WorkerId = $"orders-{Guid.NewGuid():N}"
+    })
+    .WithKafkaSource(...)
+    .WithKafkaDestination(...)
+    .Build();
+
+pipeline.OnPartitionsAssigned += (_, args) =>
+{
+    Console.WriteLine(
+        $"Worker {args.RuntimeContext.WorkerId} now owns {args.RuntimeContext.OwnedPartitions.Count} partitions.");
+};
+```
+
+Kafka-backed distributed execution is validated by multi-worker integration tests that scale workers in and out against a real Docker-hosted broker.
+
 ## Error Handling
 
 Pipelinez supports explicit fault handling through `WithErrorHandler(...)`.
@@ -136,6 +173,10 @@ Public events include:
 - `OnPipelineRecordCompleted`
 - `OnPipelineRecordFaulted`
 - `OnPipelineFaulted`
+- `OnWorkerStarted`
+- `OnPartitionsAssigned`
+- `OnPartitionsRevoked`
+- `OnWorkerStopping`
 
 ## Project Layout
 
@@ -187,8 +228,9 @@ Current implemented capabilities include:
 - segment execution history
 - configurable error policies
 - async destination execution
+- distributed runtime mode and worker/partition observability
 - Kafka source and destination support
-- Docker-backed Kafka integration coverage
+- Docker-backed Kafka integration coverage, including multi-worker distributed tests
 
 ## License
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -49,6 +49,7 @@ The core builder currently supports:
 - `AddSegment(...)`
 - `WithDestination(...)`
 - `WithInMemoryDestination(...)`
+- `UseHostOptions(...)`
 - `UseLogger(...)`
 - `WithErrorHandler(...)`
 
@@ -58,6 +59,7 @@ Kafka integrates through extension methods in `Pipelinez.Kafka`, not through par
 - `WithKafkaDestination(...)`
 
 `Build()` validates that a source and destination exist, creates a `Pipeline<T>`, links all blocks, and initializes the source and destination.
+If distributed execution is requested, `Build()` also validates that the configured source implements the distributed source contract.
 
 ### Record Model
 
@@ -147,6 +149,78 @@ Important current semantics:
 - `Completed`
 - `Faulted`
 
+## Distributed Execution Model
+
+Pipelinez now has an explicit distributed execution model for transport-backed sources.
+
+### Host Options
+
+Distributed behavior is enabled through `UseHostOptions(...)` and `PipelineHostOptions`.
+
+Supported execution modes:
+
+- `SingleProcess`
+- `Distributed`
+
+The runtime resolves and stores:
+
+- `ExecutionMode`
+- `InstanceId`
+- `WorkerId`
+
+If a caller does not supply instance or worker identity, the runtime generates reasonable defaults so logs, status output, and event payloads still identify the active worker.
+
+### Runtime Context
+
+`Pipeline<T>.GetRuntimeContext()` returns a `PipelineRuntimeContext` containing:
+
+- pipeline name
+- execution mode
+- instance ID
+- worker ID
+- currently owned transport partitions or leases
+
+This gives host applications a simple way to understand what the current worker owns without having to parse transport-specific client objects.
+
+### Distributed Source Contract
+
+Sources that support distributed ownership implement `IDistributedPipelineSource<T>`.
+
+The contract lets the core runtime:
+
+- validate distributed-mode compatibility at build time
+- surface current ownership through transport-agnostic `PipelinePartitionLease` objects
+- keep the core runtime free of Kafka-specific public types
+
+Kafka is the first source implementation that fully supports this model.
+
+### Distributed Events
+
+The public event surface now includes worker lifecycle and rebalance hooks:
+
+- `OnWorkerStarted`
+- `OnPartitionsAssigned`
+- `OnPartitionsRevoked`
+- `OnWorkerStopping`
+
+These events carry `PipelineRuntimeContext` and lease data so host applications can log worker startup, assignment changes, drain behavior, and shutdown explicitly.
+
+### Record-Level Distribution Context
+
+`OnPipelineRecordCompleted` and `OnPipelineRecordFaulted` now include `PipelineRecordDistributionContext`.
+
+For Kafka-backed distributed execution, that context includes:
+
+- instance ID
+- worker ID
+- transport name
+- lease ID
+- partition key
+- partition ID
+- offset
+
+This makes per-record ownership and replay diagnostics available directly to consumers without forcing them to inspect raw metadata collections.
+
 ## Fault Handling And Error Policies
 
 Fault handling is now a first-class part of the runtime.
@@ -211,6 +285,15 @@ Reported execution status is derived from task state and runtime fault state:
 - `Faulted`
 - `Unknown`
 
+`PipelineStatus` now also carries `DistributedStatus`, which includes:
+
+- execution mode
+- instance ID
+- worker ID
+- currently owned partitions or leases
+
+For distributed sources, this status reflects live ownership while the worker is active. For Kafka specifically, owned partitions are cleared on shutdown when the consumer leaves the group and revocation is observed.
+
 Logging is managed through the internal `LoggingManager`, which wraps an `ILoggerFactory`. If the caller never supplies a logger factory, the runtime falls back to a null logger factory.
 
 ## Kafka Integration
@@ -236,6 +319,9 @@ This keeps `PipelineBuilder<T>` owned by the core assembly and keeps Kafka-speci
 - maps Kafka key/value pairs into a pipeline record
 - copies Kafka headers into `PipelineRecord.Headers`
 - stores source topic, partition, and offset in container metadata
+- maps topic/partition ownership into `PipelinePartitionLease` values
+- reports partition assignment and revocation back into the core runtime
+- populates record-level distribution metadata for completed and faulted events
 
 When a record completes successfully, the source handles the internal container-completed event and stores the next Kafka offset.
 
@@ -245,6 +331,7 @@ Important consumer behavior:
 - `EnableAutoOffsetStore = false`
 
 So completion is tied to explicit offset storage rather than immediate consume-time storage.
+The Kafka consumer now relies on the broker's normal consumer-group offset behavior: committed offsets are resumed when they exist, while `StartOffsetFromBeginning` controls the `AutoOffsetReset` behavior for new groups without stored offsets.
 
 ### Kafka Destination
 
@@ -317,6 +404,9 @@ The solution now includes two test layers.
 - destination fault handling
 - record-fault and pipeline-fault event behavior
 - offset commit and replay behavior across pipeline runs
+- distributed worker startup, rebalance, and shutdown behavior across multiple pipeline instances
+- record-level worker and partition context on successful and faulted records
+- partition reassignment when one distributed worker leaves the consumer group
 
 At the time of this overview update, `dotnet test src\\Pipelinez.sln` passes with both the core and Kafka integration suites green.
 
@@ -332,6 +422,7 @@ The major architectural work called out in the earlier planning docs has been im
 - nullability cleanup in production code
 - Kafka split into a real `Pipelinez.Kafka` assembly
 - Docker-backed Kafka integration tests
+- explicit distributed execution mode with worker identity, partition ownership, and rebalance events
 
 The remaining work is mostly future evolution work rather than foundational cleanup. Likely areas include broader transport coverage, schema-registry integration tests, and further runtime ergonomics.
 

--- a/src/Pipelinez.Kafka/Kafka/Client/Consumer/KafkaConsumer.cs
+++ b/src/Pipelinez.Kafka/Kafka/Client/Consumer/KafkaConsumer.cs
@@ -47,11 +47,12 @@ internal class KafkaConsumer<TMessageKey, TMessageValue> : IKafkaConsumer<TMessa
         builder.SetPartitionsRevokedHandler((c, partitions) =>
             {
                 _logger.LogInformation("consumer {MemberId} had partitions {Partitions} revoked", c.MemberId, string.Join(",", partitions));
+                PartitionsRevoked?.Invoke(partitions.Select(partition => partition.TopicPartition).ToArray());
             })
             .SetPartitionsAssignedHandler((c, partitions) =>
             {
                 _logger.LogInformation("consumer {MemberId} had partitions {Partitions} assigned", c.MemberId, string.Join(",", partitions));
-                return partitions.Select(tp => new TopicPartitionOffset(tp, _options.StartOffsetFromBeginning ? Offset.Beginning : Offset.Stored));
+                PartitionsAssigned?.Invoke(partitions.ToArray());
             })
             .SetOffsetsCommittedHandler((c, committedOffsets) =>
             {
@@ -146,6 +147,10 @@ internal class KafkaConsumer<TMessageKey, TMessageValue> : IKafkaConsumer<TMessa
 
     #region IKafkaConsumer
 
+    public event Action<IReadOnlyList<TopicPartition>>? PartitionsAssigned;
+
+    public event Action<IReadOnlyList<TopicPartition>>? PartitionsRevoked;
+
     public string Name
     {
         get { return Consumer.Name; }
@@ -173,6 +178,11 @@ internal class KafkaConsumer<TMessageKey, TMessageValue> : IKafkaConsumer<TMessa
     public void StoreOffset(TopicPartitionOffset topicPartitionOffset)
     {
         Consumer.StoreOffset(topicPartitionOffset);
+    }
+
+    public void Close()
+    {
+        Consumer.Close();
     }
 
     #endregion

--- a/src/Pipelinez.Kafka/Kafka/Client/IKafkaConsumer.cs
+++ b/src/Pipelinez.Kafka/Kafka/Client/IKafkaConsumer.cs
@@ -7,9 +7,12 @@ public interface IKafkaConsumer<TMessageKey, TMessageValue>
     public string Name { get; }
     public List<string> Subscription { get; }
     public string MemberId { get; }
+    public event Action<IReadOnlyList<TopicPartition>>? PartitionsAssigned;
+    public event Action<IReadOnlyList<TopicPartition>>? PartitionsRevoked;
     
     public void Subscribe(string topicName);
     
     public ConsumeResult<TMessageKey, TMessageValue> Consume(TimeSpan timeout);
     void StoreOffset(TopicPartitionOffset topicPartitionOffset);
+    void Close();
 }

--- a/src/Pipelinez.Kafka/Kafka/Configuration/KafkaConfigurationExtensions.cs
+++ b/src/Pipelinez.Kafka/Kafka/Configuration/KafkaConfigurationExtensions.cs
@@ -29,7 +29,9 @@ internal static class KafkaConfigurationExtensions
             ClientId = $"{pipelineName}-con",
             EnableAutoCommit = true,
             EnableAutoOffsetStore = false,
-            AutoOffsetReset = AutoOffsetReset.Earliest
+            AutoOffsetReset = options.StartOffsetFromBeginning
+                ? AutoOffsetReset.Earliest
+                : AutoOffsetReset.Latest
         };
 
         if (options.AutoCommitIntervalMs.HasValue)

--- a/src/Pipelinez.Kafka/Kafka/Record/KafkaMetadataExtensions.cs
+++ b/src/Pipelinez.Kafka/Kafka/Record/KafkaMetadataExtensions.cs
@@ -1,4 +1,5 @@
 using Confluent.Kafka;
+using Pipelinez.Core.Distributed;
 using Pipelinez.Core.Record.Metadata;
 
 namespace Pipelinez.Kafka.Record;
@@ -14,12 +15,29 @@ public static class KafkaMetadataExtensions
     public static MetadataCollection ExtractMetadata(this TopicPartitionOffset topicPartitionOffset)
     {
         var metadata = new MetadataCollection();
+        var partitionKey = BuildPartitionKey(topicPartitionOffset.Topic, topicPartitionOffset.Partition.Value);
+        var leaseId = BuildLeaseId(topicPartitionOffset.Topic, topicPartitionOffset.Partition.Value);
         
         // Add the metadata records to support transactional processing
         metadata.Add(new MetadataRecord(KafkaMetadataKeys.SOURCE_TOPIC_NAME, topicPartitionOffset.Topic));
         metadata.Add(new MetadataRecord(KafkaMetadataKeys.SOURCE_PARTITION, Convert.ToString(topicPartitionOffset.Partition.Value)));
         metadata.Add(new MetadataRecord(KafkaMetadataKeys.SOURCE_OFFSET, Convert.ToString(topicPartitionOffset.Offset.Value)));
+        metadata.Add(new MetadataRecord(DistributedMetadataKeys.TransportName, "Kafka"));
+        metadata.Add(new MetadataRecord(DistributedMetadataKeys.LeaseId, leaseId));
+        metadata.Add(new MetadataRecord(DistributedMetadataKeys.PartitionKey, partitionKey));
+        metadata.Add(new MetadataRecord(DistributedMetadataKeys.PartitionId, Convert.ToString(topicPartitionOffset.Partition.Value)));
+        metadata.Add(new MetadataRecord(DistributedMetadataKeys.Offset, Convert.ToString(topicPartitionOffset.Offset.Value)));
 
         return metadata;
+    }
+
+    public static string BuildPartitionKey(string topicName, int partitionId)
+    {
+        return $"{topicName}:{partitionId}";
+    }
+
+    public static string BuildLeaseId(string topicName, int partitionId)
+    {
+        return $"kafka:{topicName}:{partitionId}";
     }
 }

--- a/src/Pipelinez.Kafka/Kafka/Source/KafkaPipelineSource.cs
+++ b/src/Pipelinez.Kafka/Kafka/Source/KafkaPipelineSource.cs
@@ -1,4 +1,5 @@
 using Confluent.Kafka;
+using Pipelinez.Core.Distributed;
 using Microsoft.Extensions.Logging;
 using Pipelinez.Core.Eventing;
 using Pipelinez.Core.Logging;
@@ -11,13 +12,16 @@ using Pipelinez.Kafka.Record;
 
 namespace Pipelinez.Kafka.Source;
 
-public class KafkaPipelineSource<T, TRecordKey, TRecordValue> : PipelineSourceBase<T> where T : PipelineRecord where TRecordKey : class where TRecordValue : class
+public class KafkaPipelineSource<T, TRecordKey, TRecordValue> : PipelineSourceBase<T>, IDistributedPipelineSource<T> where T : PipelineRecord where TRecordKey : class where TRecordValue : class
 {
+    private static readonly TimeSpan ConsumerPollTimeout = TimeSpan.FromMilliseconds(250);
     private readonly string _pipelineName;
     private readonly KafkaSourceOptions _options;
     private readonly Func<TRecordKey, TRecordValue, T> _recordMapper; // Maps Kafka key/value into a pipeline record.
     private IKafkaConsumer<TRecordKey, TRecordValue>? _consumer;
     private readonly ILogger<KafkaPipelineSource<T, TRecordKey, TRecordValue>> _logger;
+    private readonly object _leaseLock = new();
+    private IReadOnlyList<PipelinePartitionLease> _ownedPartitions = Array.Empty<PipelinePartitionLease>();
     
     public KafkaPipelineSource(string pipelineName, KafkaSourceOptions options, 
         Func<TRecordKey, TRecordValue, T> recordMapper)
@@ -32,6 +36,8 @@ public class KafkaPipelineSource<T, TRecordKey, TRecordValue> : PipelineSourceBa
     {
         _logger.LogInformation("Initializing KafkaPipelineSource");
         _consumer = KafkaClientFactory.CreateConsumer<TRecordKey, TRecordValue>(this._pipelineName, this._options);
+        Consumer.PartitionsAssigned += HandlePartitionsAssigned;
+        Consumer.PartitionsRevoked += HandlePartitionsRevoked;
     }
     
     protected override async Task MainLoop(CancellationTokenSource cancellationToken)
@@ -40,57 +46,76 @@ public class KafkaPipelineSource<T, TRecordKey, TRecordValue> : PipelineSourceBa
         
         await Task.Run(async () =>
         {
-            Consumer.Subscribe(_options.TopicName);
-            _logger.LogInformation("KafkaPipelineSource Consumer subscribed to topic [{Topic}]", _options.TopicName);
-            
-            while (!cancellationToken.IsCancellationRequested && Completion.IsCompleted == false)
+            try
             {
-                ConsumeResult<TRecordKey, TRecordValue>? consumeResult;
+                Consumer.Subscribe(_options.TopicName);
+                _logger.LogInformation("KafkaPipelineSource Consumer subscribed to topic [{Topic}]", _options.TopicName);
                 
-                try
+                while (!cancellationToken.IsCancellationRequested && Completion.IsCompleted == false)
                 {
-                    _logger.LogTrace("Consume Heartbeat: Name[{@Name}], Sub[{@Subscription}], Id[{@MemberId}]", Consumer.Name, Consumer.Subscription, Consumer.MemberId);
-                    consumeResult = Consumer.Consume(TimeSpan.FromSeconds(5));
-                }
-                catch (ConsumeException exception)
-                {
-                    _logger.LogError(exception, "Error consuming {@Exception}", exception);
-                    throw;
-                }
-
-                if (consumeResult == null || consumeResult.Message == null)
-                {
-                    // We got nothing - keep going
-                    continue;
-                }
-
-                try
-                {
-                    // Convert the message using the record mapper
-                    var record = _recordMapper(consumeResult.Message.Key, consumeResult.Message.Value);
-                
-                    // Add any headers from the source record
-                    if (consumeResult.Message.Headers != null)
+                    ConsumeResult<TRecordKey, TRecordValue>? consumeResult;
+                    
+                    try
                     {
-                        foreach (var header in consumeResult.Message.Headers)
-                        {
-                            record.Headers.Add(header.ToPipelineRecordHeader());
-                        }
+                        _logger.LogTrace("Consume Heartbeat: Name[{@Name}], Sub[{@Subscription}], Id[{@MemberId}]", Consumer.Name, Consumer.Subscription, Consumer.MemberId);
+                        consumeResult = Consumer.Consume(ConsumerPollTimeout);
                     }
+                    catch (ConsumeException exception)
+                    {
+                        _logger.LogError(exception, "Error consuming {@Exception}", exception);
+                        throw;
+                    }
+
+                    if (consumeResult == null || consumeResult.Message == null)
+                    {
+                        // We got nothing - keep going
+                        continue;
+                    }
+
+                    try
+                    {
+                        // Convert the message using the record mapper
+                        var record = _recordMapper(consumeResult.Message.Key, consumeResult.Message.Value);
                 
-                    // Note: that if the time spent in this section exceeds the max.poll.timeout
-                    // this consumer will get removed from the group and a rebalance will occur
-                    await PublishAsync(record, consumeResult.TopicPartitionOffset.ExtractMetadata()).ConfigureAwait(false);
-                }
-                catch (Exception e)
-                {
-                    _logger.LogError(e, "Error processing the record {@Record} from Kafka", consumeResult.Message);
-                    throw;
-                }
+                        // Add any headers from the source record
+                        if (consumeResult.Message.Headers != null)
+                        {
+                            foreach (var header in consumeResult.Message.Headers)
+                            {
+                                record.Headers.Add(header.ToPipelineRecordHeader());
+                            }
+                        }
                 
+                        // Note: that if the time spent in this section exceeds the max.poll.timeout
+                        // this consumer will get removed from the group and a rebalance will occur
+                        await PublishAsync(record, consumeResult.TopicPartitionOffset.ExtractMetadata()).ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e, "Error processing the record {@Record} from Kafka", consumeResult.Message);
+                        throw;
+                    }
+                }
             }
-            
-            _logger.LogInformation("Dropping out of consume loop");
+            finally
+            {
+                try
+                {
+                    Consumer.Close();
+                }
+                catch (Exception exception)
+                {
+                    _logger.LogWarning(exception, "Error while closing Kafka consumer during shutdown.");
+                }
+
+                var remainingLeases = ClearOwnedPartitions();
+                if (remainingLeases.Count > 0)
+                {
+                    ParentPipeline.ReportRevokedPartitions(remainingLeases);
+                }
+
+                _logger.LogInformation("Dropping out of consume loop");
+            }
         });
     }
 
@@ -124,6 +149,18 @@ public class KafkaPipelineSource<T, TRecordKey, TRecordValue> : PipelineSourceBa
     private IKafkaConsumer<TRecordKey, TRecordValue> Consumer =>
         _consumer ?? throw new InvalidOperationException("Kafka consumer has not been initialized.");
 
+    public bool SupportsDistributedExecution => true;
+
+    public string TransportName => "Kafka";
+
+    public IReadOnlyList<PipelinePartitionLease> GetOwnedPartitions()
+    {
+        lock (_leaseLock)
+        {
+            return _ownedPartitions.ToArray();
+        }
+    }
+
     private static TopicPartitionOffset? TryGetSourceTopicPartitionOffset(MetadataCollection metadata)
     {
         var topicName = metadata.GetByKey(KafkaMetadataKeys.SOURCE_TOPIC_NAME)?.Value;
@@ -139,5 +176,70 @@ public class KafkaPipelineSource<T, TRecordKey, TRecordValue> : PipelineSourceBa
 
         var topicPartition = new TopicPartition(topicName, new Partition(partition));
         return new TopicPartitionOffset(topicPartition, new Offset(offset) + 1);
+    }
+
+    private void HandlePartitionsAssigned(IReadOnlyList<TopicPartition> partitions)
+    {
+        var leases = partitions
+            .Select(partition => CreateLease(partition.Topic, partition.Partition.Value))
+            .ToArray();
+
+        lock (_leaseLock)
+        {
+            _ownedPartitions = _ownedPartitions
+                .Concat(leases)
+                .GroupBy(lease => lease.LeaseId, StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.Last())
+                .ToArray();
+        }
+
+        ParentPipeline.ReportAssignedPartitions(leases);
+    }
+
+    private void HandlePartitionsRevoked(IReadOnlyList<TopicPartition> partitions)
+    {
+        var leases = partitions
+            .Select(partition => CreateLease(partition.Topic, partition.Partition.Value))
+            .ToArray();
+
+        RemoveOwnedPartitions(leases);
+
+        ParentPipeline.ReportRevokedPartitions(leases);
+    }
+
+    private PipelinePartitionLease CreateLease(string topicName, int partitionId)
+    {
+        var runtimeContext = ParentPipeline.GetRuntimeContext();
+        return new PipelinePartitionLease(
+            KafkaMetadataExtensions.BuildLeaseId(topicName, partitionId),
+            TransportName,
+            KafkaMetadataExtensions.BuildPartitionKey(topicName, partitionId),
+            runtimeContext.InstanceId,
+            runtimeContext.WorkerId,
+            partitionId);
+    }
+
+    private IReadOnlyList<PipelinePartitionLease> ClearOwnedPartitions()
+    {
+        lock (_leaseLock)
+        {
+            var ownedPartitions = _ownedPartitions;
+            _ownedPartitions = Array.Empty<PipelinePartitionLease>();
+            return ownedPartitions;
+        }
+    }
+
+    private void RemoveOwnedPartitions(IReadOnlyList<PipelinePartitionLease> revokedLeases)
+    {
+        lock (_leaseLock)
+        {
+            var revokedIds = revokedLeases
+                .Select(lease => lease.LeaseId)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            _ownedPartitions = _ownedPartitions
+                .Where(lease => !revokedIds.Contains(lease.LeaseId))
+                .ToArray();
+        }
     }
 }

--- a/src/Pipelinez/Core/Distributed/DistributedMetadataKeys.cs
+++ b/src/Pipelinez/Core/Distributed/DistributedMetadataKeys.cs
@@ -1,0 +1,10 @@
+namespace Pipelinez.Core.Distributed;
+
+public static class DistributedMetadataKeys
+{
+    public const string TransportName = "pipelinez.distribution.transport.name";
+    public const string LeaseId = "pipelinez.distribution.lease.id";
+    public const string PartitionKey = "pipelinez.distribution.partition.key";
+    public const string PartitionId = "pipelinez.distribution.partition.id";
+    public const string Offset = "pipelinez.distribution.offset";
+}

--- a/src/Pipelinez/Core/Distributed/PipelineDistributedStatus.cs
+++ b/src/Pipelinez/Core/Distributed/PipelineDistributedStatus.cs
@@ -1,0 +1,26 @@
+using Ardalis.GuardClauses;
+
+namespace Pipelinez.Core.Distributed;
+
+public sealed class PipelineDistributedStatus
+{
+    public PipelineDistributedStatus(
+        PipelineExecutionMode executionMode,
+        string instanceId,
+        string workerId,
+        IReadOnlyList<PipelinePartitionLease>? ownedPartitions = null)
+    {
+        ExecutionMode = executionMode;
+        InstanceId = Guard.Against.NullOrWhiteSpace(instanceId, nameof(instanceId));
+        WorkerId = Guard.Against.NullOrWhiteSpace(workerId, nameof(workerId));
+        OwnedPartitions = ownedPartitions?.ToArray() ?? Array.Empty<PipelinePartitionLease>();
+    }
+
+    public PipelineExecutionMode ExecutionMode { get; }
+
+    public string InstanceId { get; }
+
+    public string WorkerId { get; }
+
+    public IReadOnlyList<PipelinePartitionLease> OwnedPartitions { get; }
+}

--- a/src/Pipelinez/Core/Distributed/PipelineExecutionMode.cs
+++ b/src/Pipelinez/Core/Distributed/PipelineExecutionMode.cs
@@ -1,0 +1,7 @@
+namespace Pipelinez.Core.Distributed;
+
+public enum PipelineExecutionMode
+{
+    SingleProcess,
+    Distributed
+}

--- a/src/Pipelinez/Core/Distributed/PipelineHostOptions.cs
+++ b/src/Pipelinez/Core/Distributed/PipelineHostOptions.cs
@@ -1,0 +1,12 @@
+namespace Pipelinez.Core.Distributed;
+
+public sealed class PipelineHostOptions
+{
+    public PipelineExecutionMode ExecutionMode { get; init; } = PipelineExecutionMode.SingleProcess;
+
+    public string? InstanceId { get; init; }
+
+    public string? WorkerId { get; init; }
+
+    public bool RequireTransportOwnership { get; init; } = true;
+}

--- a/src/Pipelinez/Core/Distributed/PipelinePartitionLease.cs
+++ b/src/Pipelinez/Core/Distributed/PipelinePartitionLease.cs
@@ -1,0 +1,34 @@
+using Ardalis.GuardClauses;
+
+namespace Pipelinez.Core.Distributed;
+
+public sealed class PipelinePartitionLease
+{
+    public PipelinePartitionLease(
+        string leaseId,
+        string transportName,
+        string partitionKey,
+        string instanceId,
+        string workerId,
+        int? partitionId = null)
+    {
+        LeaseId = Guard.Against.NullOrWhiteSpace(leaseId, nameof(leaseId));
+        TransportName = Guard.Against.NullOrWhiteSpace(transportName, nameof(transportName));
+        PartitionKey = Guard.Against.NullOrWhiteSpace(partitionKey, nameof(partitionKey));
+        InstanceId = Guard.Against.NullOrWhiteSpace(instanceId, nameof(instanceId));
+        WorkerId = Guard.Against.NullOrWhiteSpace(workerId, nameof(workerId));
+        PartitionId = partitionId;
+    }
+
+    public string LeaseId { get; }
+
+    public string TransportName { get; }
+
+    public string PartitionKey { get; }
+
+    public string InstanceId { get; }
+
+    public string WorkerId { get; }
+
+    public int? PartitionId { get; }
+}

--- a/src/Pipelinez/Core/Distributed/PipelineRecordDistributionContext.cs
+++ b/src/Pipelinez/Core/Distributed/PipelineRecordDistributionContext.cs
@@ -1,0 +1,38 @@
+using Ardalis.GuardClauses;
+
+namespace Pipelinez.Core.Distributed;
+
+public sealed class PipelineRecordDistributionContext
+{
+    public PipelineRecordDistributionContext(
+        string instanceId,
+        string workerId,
+        string? transportName,
+        string? leaseId,
+        string? partitionKey,
+        int? partitionId,
+        long? offset)
+    {
+        InstanceId = Guard.Against.NullOrWhiteSpace(instanceId, nameof(instanceId));
+        WorkerId = Guard.Against.NullOrWhiteSpace(workerId, nameof(workerId));
+        TransportName = transportName;
+        LeaseId = leaseId;
+        PartitionKey = partitionKey;
+        PartitionId = partitionId;
+        Offset = offset;
+    }
+
+    public string InstanceId { get; }
+
+    public string WorkerId { get; }
+
+    public string? TransportName { get; }
+
+    public string? LeaseId { get; }
+
+    public string? PartitionKey { get; }
+
+    public int? PartitionId { get; }
+
+    public long? Offset { get; }
+}

--- a/src/Pipelinez/Core/Distributed/PipelineRuntimeContext.cs
+++ b/src/Pipelinez/Core/Distributed/PipelineRuntimeContext.cs
@@ -1,0 +1,30 @@
+using Ardalis.GuardClauses;
+
+namespace Pipelinez.Core.Distributed;
+
+public sealed class PipelineRuntimeContext
+{
+    public PipelineRuntimeContext(
+        string pipelineName,
+        PipelineExecutionMode executionMode,
+        string instanceId,
+        string workerId,
+        IReadOnlyList<PipelinePartitionLease>? ownedPartitions = null)
+    {
+        PipelineName = Guard.Against.NullOrWhiteSpace(pipelineName, nameof(pipelineName));
+        ExecutionMode = executionMode;
+        InstanceId = Guard.Against.NullOrWhiteSpace(instanceId, nameof(instanceId));
+        WorkerId = Guard.Against.NullOrWhiteSpace(workerId, nameof(workerId));
+        OwnedPartitions = ownedPartitions?.ToArray() ?? Array.Empty<PipelinePartitionLease>();
+    }
+
+    public string PipelineName { get; }
+
+    public PipelineExecutionMode ExecutionMode { get; }
+
+    public string InstanceId { get; }
+
+    public string WorkerId { get; }
+
+    public IReadOnlyList<PipelinePartitionLease> OwnedPartitions { get; }
+}

--- a/src/Pipelinez/Core/Eventing/Eventing.cs
+++ b/src/Pipelinez/Core/Eventing/Eventing.cs
@@ -1,4 +1,5 @@
 using Ardalis.GuardClauses;
+using Pipelinez.Core.Distributed;
 using Pipelinez.Core.FaultHandling;
 using Pipelinez.Core.Record;
 
@@ -31,10 +32,15 @@ public delegate void PipelineRecordCompletedEventHandler<T>(object sender, Pipel
 public sealed class PipelineRecordCompletedEventHandlerArgs<T>
 {
     public T Record { get; }
-    
-    public PipelineRecordCompletedEventHandlerArgs(T record)
+
+    public PipelineRecordDistributionContext? Distribution { get; }
+
+    public PipelineRecordCompletedEventHandlerArgs(
+        T record,
+        PipelineRecordDistributionContext? distribution = null)
     {
         Record = record;
+        Distribution = distribution;
     }
 }
 
@@ -47,11 +53,13 @@ public sealed class PipelineRecordFaultedEventArgs<T> where T : PipelineRecord
     public PipelineRecordFaultedEventArgs(
         T record,
         PipelineContainer<T> container,
-        PipelineFaultState fault)
+        PipelineFaultState fault,
+        PipelineRecordDistributionContext? distribution = null)
     {
         Record = Guard.Against.Null(record, nameof(record));
         Container = Guard.Against.Null(container, nameof(container));
         Fault = Guard.Against.Null(fault, nameof(fault));
+        Distribution = distribution;
     }
 
     public T Record { get; }
@@ -59,6 +67,8 @@ public sealed class PipelineRecordFaultedEventArgs<T> where T : PipelineRecord
     public PipelineContainer<T> Container { get; }
 
     public PipelineFaultState Fault { get; }
+
+    public PipelineRecordDistributionContext? Distribution { get; }
 }
 
 public delegate void PipelineFaultedEventHandler(object sender, PipelineFaultedEventArgs args);
@@ -80,4 +90,66 @@ public sealed class PipelineFaultedEventArgs
     public string ComponentName => Fault.ComponentName;
 
     public PipelineComponentKind ComponentKind => Fault.ComponentKind;
+}
+
+public delegate void PipelineWorkerStartedEventHandler(object sender, PipelineWorkerStartedEventArgs args);
+
+public sealed class PipelineWorkerStartedEventArgs
+{
+    public PipelineWorkerStartedEventArgs(PipelineRuntimeContext runtimeContext)
+    {
+        RuntimeContext = Guard.Against.Null(runtimeContext, nameof(runtimeContext));
+    }
+
+    public PipelineRuntimeContext RuntimeContext { get; }
+}
+
+public delegate void PipelineWorkerStoppingEventHandler(object sender, PipelineWorkerStoppingEventArgs args);
+
+public sealed class PipelineWorkerStoppingEventArgs
+{
+    public PipelineWorkerStoppingEventArgs(PipelineRuntimeContext runtimeContext)
+    {
+        RuntimeContext = Guard.Against.Null(runtimeContext, nameof(runtimeContext));
+    }
+
+    public PipelineRuntimeContext RuntimeContext { get; }
+}
+
+public delegate void PipelinePartitionsAssignedEventHandler(object sender, PipelinePartitionsAssignedEventArgs args);
+
+public sealed class PipelinePartitionsAssignedEventArgs
+{
+    public PipelinePartitionsAssignedEventArgs(
+        PipelineRuntimeContext runtimeContext,
+        IReadOnlyList<PipelinePartitionLease> partitions)
+    {
+        RuntimeContext = Guard.Against.Null(runtimeContext, nameof(runtimeContext));
+        Partitions = Guard.Against.Null(partitions, nameof(partitions)).ToArray();
+    }
+
+    public PipelineRuntimeContext RuntimeContext { get; }
+
+    public string WorkerId => RuntimeContext.WorkerId;
+
+    public IReadOnlyList<PipelinePartitionLease> Partitions { get; }
+}
+
+public delegate void PipelinePartitionsRevokedEventHandler(object sender, PipelinePartitionsRevokedEventArgs args);
+
+public sealed class PipelinePartitionsRevokedEventArgs
+{
+    public PipelinePartitionsRevokedEventArgs(
+        PipelineRuntimeContext runtimeContext,
+        IReadOnlyList<PipelinePartitionLease> partitions)
+    {
+        RuntimeContext = Guard.Against.Null(runtimeContext, nameof(runtimeContext));
+        Partitions = Guard.Against.Null(partitions, nameof(partitions)).ToArray();
+    }
+
+    public PipelineRuntimeContext RuntimeContext { get; }
+
+    public string WorkerId => RuntimeContext.WorkerId;
+
+    public IReadOnlyList<PipelinePartitionLease> Partitions { get; }
 }

--- a/src/Pipelinez/Core/IPipeline.cs
+++ b/src/Pipelinez/Core/IPipeline.cs
@@ -1,3 +1,4 @@
+using Pipelinez.Core.Distributed;
 using Pipelinez.Core.Eventing;
 using Pipelinez.Core.Record;
 using Pipelinez.Core.Status;
@@ -29,6 +30,8 @@ public interface IPipeline<T> where T : PipelineRecord
     Task Completion { get; }
 
     PipelineStatus GetStatus();
+
+    PipelineRuntimeContext GetRuntimeContext();
     
     #region Eventing
     
@@ -46,6 +49,26 @@ public interface IPipeline<T> where T : PipelineRecord
     /// Event that is raised when the pipeline transitions into a faulted state.
     /// </summary>
     event PipelineFaultedEventHandler OnPipelineFaulted;
+
+    /// <summary>
+    /// Event that is raised when a distributed worker starts.
+    /// </summary>
+    event PipelineWorkerStartedEventHandler OnWorkerStarted;
+
+    /// <summary>
+    /// Event that is raised when partitions are assigned to the current worker.
+    /// </summary>
+    event PipelinePartitionsAssignedEventHandler OnPartitionsAssigned;
+
+    /// <summary>
+    /// Event that is raised when partitions are revoked from the current worker.
+    /// </summary>
+    event PipelinePartitionsRevokedEventHandler OnPartitionsRevoked;
+
+    /// <summary>
+    /// Event that is raised when a distributed worker is stopping.
+    /// </summary>
+    event PipelineWorkerStoppingEventHandler OnWorkerStopping;
 
     #endregion
 }

--- a/src/Pipelinez/Core/Pipeline.cs
+++ b/src/Pipelinez/Core/Pipeline.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks.Dataflow;
 using Ardalis.GuardClauses;
 using Microsoft.Extensions.Logging;
+using Pipelinez.Core.Distributed;
 using Pipelinez.Core.Destination;
 using Pipelinez.Core.ErrorHandling;
 using Pipelinez.Core.Eventing;
@@ -47,13 +48,20 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     private readonly IList<IPipelineSegment<TPipelineRecord>> _segments;
     private readonly IPipelineDestination<TPipelineRecord> _destination;
     private readonly PipelineErrorHandler<TPipelineRecord>? _errorHandler;
+    private readonly PipelineHostOptions _hostOptions;
+    private readonly string _instanceId;
+    private readonly string _workerId;
     private readonly object _stateLock = new();
+    private readonly object _distributionLock = new();
     private readonly TaskCompletionSource _completionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private CancellationTokenSource? _runtimeCancellationTokenSource;
     private CancellationTokenRegistration _cancellationRegistration;
     private PipelineRuntimeState _state = PipelineRuntimeState.NotStarted;
     private PipelineFaultState? _pipelineFault;
+    private IReadOnlyList<PipelinePartitionLease> _ownedPartitions = Array.Empty<PipelinePartitionLease>();
+    private bool _workerStartedRaised;
+    private bool _workerStoppingRaised;
     
     #endregion
     
@@ -89,6 +97,26 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     public event PipelineFaultedEventHandler? OnPipelineFaulted;
 
     /// <summary>
+    /// Occurs when the distributed worker starts.
+    /// </summary>
+    public event PipelineWorkerStartedEventHandler? OnWorkerStarted;
+
+    /// <summary>
+    /// Occurs when partitions are assigned to the current distributed worker.
+    /// </summary>
+    public event PipelinePartitionsAssignedEventHandler? OnPartitionsAssigned;
+
+    /// <summary>
+    /// Occurs when partitions are revoked from the current distributed worker.
+    /// </summary>
+    public event PipelinePartitionsRevokedEventHandler? OnPartitionsRevoked;
+
+    /// <summary>
+    /// Occurs when the distributed worker begins stopping.
+    /// </summary>
+    public event PipelineWorkerStoppingEventHandler? OnWorkerStopping;
+
+    /// <summary>
     /// Occurs when the pipeline container has completed traversing the pipeline
     /// </summary>
     internal event PipelineContainerCompletedEventHandler<PipelineContainer<TPipelineRecord>>?
@@ -103,7 +131,11 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         // 1 - lets the source know that the record has completed so it can apply any transactional commits if needed
         // 2 - lets pipeline users know that the record has completed
         OnPipelineContainerCompelted?.Invoke(this, evt);
-        OnPipelineRecordCompleted?.Invoke(this, new PipelineRecordCompletedEventHandlerArgs<TPipelineRecord>(evt.Container.Record));
+        OnPipelineRecordCompleted?.Invoke(
+            this,
+            new PipelineRecordCompletedEventHandlerArgs<TPipelineRecord>(
+                evt.Container.Record,
+                BuildDistributionContext(evt.Container.Metadata)));
     }
 
     internal async Task<PipelineErrorAction> HandleFaultedContainerAsync(PipelineContainer<TPipelineRecord> container)
@@ -117,7 +149,11 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
 
         OnPipelineRecordFaulted?.Invoke(
             this,
-            new PipelineRecordFaultedEventArgs<TPipelineRecord>(container.Record, container, container.Fault));
+            new PipelineRecordFaultedEventArgs<TPipelineRecord>(
+                container.Record,
+                container,
+                container.Fault,
+                BuildDistributionContext(container.Metadata)));
 
         var action = await ResolveErrorActionAsync(container, container.Fault).ConfigureAwait(false);
 
@@ -144,8 +180,13 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
 
     #region Construction
     
-    internal Pipeline(string name, IPipelineSource<TPipelineRecord> source, IPipelineDestination<TPipelineRecord> destination, 
-        IList<IPipelineSegment<TPipelineRecord>> segments, PipelineErrorHandler<TPipelineRecord>? errorHandler = null)
+    internal Pipeline(
+        string name,
+        IPipelineSource<TPipelineRecord> source,
+        IPipelineDestination<TPipelineRecord> destination,
+        IList<IPipelineSegment<TPipelineRecord>> segments,
+        PipelineErrorHandler<TPipelineRecord>? errorHandler = null,
+        PipelineHostOptions? hostOptions = null)
     {
         Guard.Against.NullOrEmpty(name, message: "Pipeline must have a name");
         Guard.Against.Null(source, message: "Pipeline must have a valid source");
@@ -158,6 +199,13 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         this._destination = destination;
         this._segments = segments;
         this._errorHandler = errorHandler;
+        _hostOptions = hostOptions ?? new PipelineHostOptions();
+        _instanceId = string.IsNullOrWhiteSpace(_hostOptions.InstanceId)
+            ? Environment.MachineName
+            : _hostOptions.InstanceId;
+        _workerId = string.IsNullOrWhiteSpace(_hostOptions.WorkerId)
+            ? $"{_name}-{Guid.NewGuid():N}"
+            : _hostOptions.WorkerId;
     }
 
     internal void LinkPipeline()
@@ -235,7 +283,14 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
             }
         }
 
-        Logger.LogInformation("Pipeline started: {PipelineName}", _name);
+        Logger.LogInformation(
+            "Pipeline started: {PipelineName}, Mode: {ExecutionMode}, InstanceId: {InstanceId}, WorkerId: {WorkerId}",
+            _name,
+            _hostOptions.ExecutionMode,
+            _instanceId,
+            _workerId);
+
+        RaiseWorkerStartedIfNeeded();
         return Task.CompletedTask;
     }
 
@@ -314,7 +369,21 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         components.Add(new PipelineComponentStatus(_destination.GetType().Name, _destination.Completion.Status.ToPipelineExecutionStatus()));
         return new PipelineStatus(
             components,
-            _state == PipelineRuntimeState.Faulted ? PipelineExecutionStatus.Faulted : null);
+            _state == PipelineRuntimeState.Faulted ? PipelineExecutionStatus.Faulted : null,
+            GetDistributedStatus());
+    }
+
+    public PipelineRuntimeContext GetRuntimeContext()
+    {
+        lock (_distributionLock)
+        {
+            return new PipelineRuntimeContext(
+                _name,
+                _hostOptions.ExecutionMode,
+                _instanceId,
+                _workerId,
+                _ownedPartitions);
+        }
     }
 
     private void EnsurePipelineStartedForPublish()
@@ -329,6 +398,65 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         }
     }
 
+    internal void ReportAssignedPartitions(IReadOnlyList<PipelinePartitionLease> assignedPartitions)
+    {
+        Guard.Against.Null(assignedPartitions, nameof(assignedPartitions));
+
+        PipelineRuntimeContext runtimeContext;
+
+        lock (_distributionLock)
+        {
+            var activeLeases = _ownedPartitions
+                .Concat(assignedPartitions)
+                .GroupBy(lease => lease.LeaseId, StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.Last())
+                .ToArray();
+
+            _ownedPartitions = activeLeases;
+            runtimeContext = new PipelineRuntimeContext(
+                _name,
+                _hostOptions.ExecutionMode,
+                _instanceId,
+                _workerId,
+                _ownedPartitions);
+        }
+
+        if (assignedPartitions.Count > 0)
+        {
+            OnPartitionsAssigned?.Invoke(this, new PipelinePartitionsAssignedEventArgs(runtimeContext, assignedPartitions));
+        }
+    }
+
+    internal void ReportRevokedPartitions(IReadOnlyList<PipelinePartitionLease> revokedPartitions)
+    {
+        Guard.Against.Null(revokedPartitions, nameof(revokedPartitions));
+
+        PipelineRuntimeContext runtimeContext;
+
+        lock (_distributionLock)
+        {
+            var revokedLeaseIds = revokedPartitions
+                .Select(lease => lease.LeaseId)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            _ownedPartitions = _ownedPartitions
+                .Where(lease => !revokedLeaseIds.Contains(lease.LeaseId))
+                .ToArray();
+
+            runtimeContext = new PipelineRuntimeContext(
+                _name,
+                _hostOptions.ExecutionMode,
+                _instanceId,
+                _workerId,
+                _ownedPartitions);
+        }
+
+        if (revokedPartitions.Count > 0)
+        {
+            OnPartitionsRevoked?.Invoke(this, new PipelinePartitionsRevokedEventArgs(runtimeContext, revokedPartitions));
+        }
+    }
+
     private void HandleCancellationRequested()
     {
         lock (_stateLock)
@@ -338,6 +466,8 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
                 _state = PipelineRuntimeState.Completing;
             }
         }
+
+        RaiseWorkerStoppingIfNeeded();
 
         try
         {
@@ -467,6 +597,96 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
             FaultPipeline(handlerFault);
             throw;
         }
+    }
+
+    private PipelineDistributedStatus GetDistributedStatus()
+    {
+        lock (_distributionLock)
+        {
+            return new PipelineDistributedStatus(
+                _hostOptions.ExecutionMode,
+                _instanceId,
+                _workerId,
+                _ownedPartitions);
+        }
+    }
+
+    private PipelineRecordDistributionContext BuildDistributionContext(Pipelinez.Core.Record.Metadata.MetadataCollection metadata)
+    {
+        return new PipelineRecordDistributionContext(
+            _instanceId,
+            _workerId,
+            metadata.GetValue(DistributedMetadataKeys.TransportName),
+            metadata.GetValue(DistributedMetadataKeys.LeaseId),
+            metadata.GetValue(DistributedMetadataKeys.PartitionKey),
+            TryParseInt(metadata.GetValue(DistributedMetadataKeys.PartitionId)),
+            TryParseLong(metadata.GetValue(DistributedMetadataKeys.Offset)));
+    }
+
+    private void RaiseWorkerStartedIfNeeded()
+    {
+        if (_hostOptions.ExecutionMode != PipelineExecutionMode.Distributed)
+        {
+            return;
+        }
+
+        PipelineRuntimeContext? runtimeContext = null;
+
+        lock (_distributionLock)
+        {
+            if (_workerStartedRaised)
+            {
+                return;
+            }
+
+            _workerStartedRaised = true;
+            runtimeContext = new PipelineRuntimeContext(
+                _name,
+                _hostOptions.ExecutionMode,
+                _instanceId,
+                _workerId,
+                _ownedPartitions);
+        }
+
+        OnWorkerStarted?.Invoke(this, new PipelineWorkerStartedEventArgs(runtimeContext));
+    }
+
+    private void RaiseWorkerStoppingIfNeeded()
+    {
+        if (_hostOptions.ExecutionMode != PipelineExecutionMode.Distributed)
+        {
+            return;
+        }
+
+        PipelineRuntimeContext? runtimeContext = null;
+
+        lock (_distributionLock)
+        {
+            if (_workerStoppingRaised)
+            {
+                return;
+            }
+
+            _workerStoppingRaised = true;
+            runtimeContext = new PipelineRuntimeContext(
+                _name,
+                _hostOptions.ExecutionMode,
+                _instanceId,
+                _workerId,
+                _ownedPartitions);
+        }
+
+        OnWorkerStopping?.Invoke(this, new PipelineWorkerStoppingEventArgs(runtimeContext));
+    }
+
+    private static int? TryParseInt(string? value)
+    {
+        return int.TryParse(value, out var parsed) ? parsed : null;
+    }
+
+    private static long? TryParseLong(string? value)
+    {
+        return long.TryParse(value, out var parsed) ? parsed : null;
     }
 
     private PipelineFaultState CreatePipelineFaultFromTasks(

--- a/src/Pipelinez/Core/PipelineBuilder.cs
+++ b/src/Pipelinez/Core/PipelineBuilder.cs
@@ -1,5 +1,6 @@
 using Ardalis.GuardClauses;
 using Microsoft.Extensions.Logging;
+using Pipelinez.Core.Distributed;
 using Pipelinez.Core.Destination;
 using Pipelinez.Core.ErrorHandling;
 using Pipelinez.Core.Logging;
@@ -20,6 +21,7 @@ public class PipelineBuilder<T>(string pipelineName)
     private IList<IPipelineSegment<T>> _segments = new List<IPipelineSegment<T>>();
     private IPipelineDestination<T>? _destination;
     private PipelineErrorHandler<T>? _errorHandler;
+    private PipelineHostOptions _hostOptions = new();
     
     #endregion
     
@@ -72,6 +74,16 @@ public class PipelineBuilder<T>(string pipelineName)
     }
     
     #endregion
+
+    #region Hosting
+
+    public PipelineBuilder<T> UseHostOptions(PipelineHostOptions options)
+    {
+        _hostOptions = Guard.Against.Null(options, nameof(options));
+        return this;
+    }
+
+    #endregion
     
     #region Error Handling
     
@@ -97,10 +109,19 @@ public class PipelineBuilder<T>(string pipelineName)
         // Validate that we have at least a source and destination
         Guard.Against.Null(this._source, message: "Pipeline must have a source defined before it is built");
         Guard.Against.Null(this._destination, message: "Pipeline must have a destination defined before it is built");
+
+        if (_hostOptions.ExecutionMode == PipelineExecutionMode.Distributed)
+        {
+            if (_source is not IDistributedPipelineSource<T> distributedSource || !distributedSource.SupportsDistributedExecution)
+            {
+                throw new InvalidOperationException(
+                    $"Pipeline '{PipelineName}' is configured for distributed execution, but source '{_source.GetType().Name}' does not support distributed ownership.");
+            }
+        }
         
         // Create a 'Pipeline' object passing all components and linking them
         // i.e. build the pipeline by linking source->segments->destination
-        var pipeline = new Pipeline<T>(pipelineName, this._source, this._destination, this._segments, _errorHandler);
+        var pipeline = new Pipeline<T>(pipelineName, this._source, this._destination, this._segments, _errorHandler, _hostOptions);
         pipeline.LinkPipeline();
         pipeline.InitializePipeline();
         //return the pipeline

--- a/src/Pipelinez/Core/Record/Metadata/MetadataCollection.cs
+++ b/src/Pipelinez/Core/Record/Metadata/MetadataCollection.cs
@@ -81,6 +81,23 @@ public class MetadataCollection : IList<MetadataRecord>
         return null;
     }
 
+    public string? GetValue(string key)
+    {
+        return GetByKey(key)?.Value;
+    }
+
+    public void Set(string key, string value)
+    {
+        var existingRecord = GetByKey(key);
+        if (existingRecord is not null)
+        {
+            existingRecord.Value = value;
+            return;
+        }
+
+        Add(new MetadataRecord(key, value));
+    }
+
     public MetadataRecord this[int index]
     {
         get => _internalList[index];

--- a/src/Pipelinez/Core/Source/IDistributedPipelineSource.cs
+++ b/src/Pipelinez/Core/Source/IDistributedPipelineSource.cs
@@ -1,0 +1,13 @@
+using Pipelinez.Core.Distributed;
+using Pipelinez.Core.Record;
+
+namespace Pipelinez.Core.Source;
+
+public interface IDistributedPipelineSource<T> : IPipelineSource<T> where T : PipelineRecord
+{
+    bool SupportsDistributedExecution { get; }
+
+    string TransportName { get; }
+
+    IReadOnlyList<PipelinePartitionLease> GetOwnedPartitions();
+}

--- a/src/Pipelinez/Core/Source/PipelineSource.cs
+++ b/src/Pipelinez/Core/Source/PipelineSource.cs
@@ -126,4 +126,7 @@ public abstract class PipelineSourceBase<T> : IPipelineSource<T> where T : Pipel
     protected abstract void Initialize();
     
     #endregion
+
+    protected Pipeline<T> ParentPipeline =>
+        _parentPipeline ?? throw new InvalidOperationException("Pipeline source has not been initialized.");
 }

--- a/src/Pipelinez/Core/Status/PipelineStatus.cs
+++ b/src/Pipelinez/Core/Status/PipelineStatus.cs
@@ -1,16 +1,23 @@
+using Pipelinez.Core.Distributed;
+
 namespace Pipelinez.Core.Status;
 
 public class PipelineStatus
 {
-    public PipelineStatus(IList<PipelineComponentStatus> components, PipelineExecutionStatus? runtimeStatus = null)
+    public PipelineStatus(
+        IList<PipelineComponentStatus> components,
+        PipelineExecutionStatus? runtimeStatus = null,
+        PipelineDistributedStatus? distributedStatus = null)
     {
         Components = components;
         RuntimeStatus = runtimeStatus;
+        DistributedStatus = distributedStatus;
     }
     
     public PipelineExecutionStatus Status => GetStatus();
     public IList<PipelineComponentStatus> Components { get; }
     public PipelineExecutionStatus? RuntimeStatus { get; }
+    public PipelineDistributedStatus? DistributedStatus { get; }
     
     private PipelineExecutionStatus GetStatus()
     {

--- a/src/tests/Pipelinez.Kafka.Tests/EndToEnd/KafkaPipelineDistributedTests.cs
+++ b/src/tests/Pipelinez.Kafka.Tests/EndToEnd/KafkaPipelineDistributedTests.cs
@@ -1,0 +1,218 @@
+using System.Collections.Concurrent;
+using Pipelinez.Core;
+using Pipelinez.Core.Distributed;
+using Pipelinez.Core.Eventing;
+using Pipelinez.Core.Status;
+using Pipelinez.Kafka;
+using Pipelinez.Kafka.Tests.Infrastructure;
+using Pipelinez.Kafka.Tests.Models;
+using Xunit;
+
+namespace Pipelinez.Kafka.Tests.EndToEnd;
+
+[Collection(KafkaIntegrationCollection.Name)]
+public sealed class KafkaPipelineDistributedTests(KafkaTestCluster cluster)
+{
+    [Fact]
+    public async Task KafkaPipeline_Distributed_Mode_Populates_Status_Events_And_Record_Distribution_Context()
+    {
+        var scenarioName = nameof(KafkaPipeline_Distributed_Mode_Populates_Status_Events_And_Record_Distribution_Context);
+        var sourceTopic = await cluster.CreateTopicAsync($"{scenarioName}-source", partitions: 1).ConfigureAwait(false);
+        var consumerGroup = KafkaTopicNameFactory.CreateConsumerGroupName("pipelinez", scenarioName);
+
+        PipelineRuntimeContext? workerStarted = null;
+        PipelineRuntimeContext? workerStopping = null;
+        var assignedPartitions = new ConcurrentQueue<IReadOnlyList<PipelinePartitionLease>>();
+        PipelineRecordCompletedEventHandlerArgs<TestKafkaRecord>? completedArgs = null;
+
+        var pipeline = Pipeline<TestKafkaRecord>.New(scenarioName)
+            .UseHostOptions(new PipelineHostOptions
+            {
+                ExecutionMode = PipelineExecutionMode.Distributed,
+                InstanceId = "kafka-instance-a",
+                WorkerId = "kafka-worker-a"
+            })
+            .WithKafkaSource(
+                cluster.CreateSourceOptions(sourceTopic, consumerGroup),
+                (string key, string value) => new TestKafkaRecord
+                {
+                    Key = key,
+                    Value = value
+                })
+            .WithInMemoryDestination("config")
+            .Build();
+
+        pipeline.OnWorkerStarted += (_, args) => workerStarted = args.RuntimeContext;
+        pipeline.OnWorkerStopping += (_, args) => workerStopping = args.RuntimeContext;
+        pipeline.OnPartitionsAssigned += (_, args) => assignedPartitions.Enqueue(args.Partitions);
+        pipeline.OnPipelineRecordCompleted += (_, args) => completedArgs = args;
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+
+        await KafkaPipelineTestHelpers.WaitForConditionAsync(
+            () => pipeline.GetRuntimeContext().OwnedPartitions.Count == 1,
+            cluster.ConsumeTimeout).ConfigureAwait(false);
+
+        await cluster.ProduceAsync(
+            sourceTopic,
+            new[]
+            {
+                KafkaPipelineTestHelpers.CreateMessage("alpha", "value-1")
+            }).ConfigureAwait(false);
+
+        await KafkaPipelineTestHelpers.WaitForConditionAsync(
+            () => completedArgs is not null,
+            cluster.ConsumeTimeout).ConfigureAwait(false);
+
+        var activeDistributedStatus = pipeline.GetStatus().DistributedStatus;
+        Assert.NotNull(activeDistributedStatus);
+        Assert.Equal(PipelineExecutionMode.Distributed, activeDistributedStatus!.ExecutionMode);
+        Assert.Equal("kafka-worker-a", activeDistributedStatus.WorkerId);
+        Assert.Single(activeDistributedStatus.OwnedPartitions);
+
+        await pipeline.CompleteAsync().ConfigureAwait(false);
+        await pipeline.Completion.ConfigureAwait(false);
+
+        Assert.NotNull(workerStarted);
+        Assert.NotNull(workerStopping);
+        Assert.NotEmpty(assignedPartitions);
+        Assert.NotNull(completedArgs);
+        Assert.NotNull(completedArgs!.Distribution);
+
+        Assert.Equal(PipelineExecutionMode.Distributed, workerStarted!.ExecutionMode);
+        Assert.Equal("kafka-instance-a", workerStarted.InstanceId);
+        Assert.Equal("kafka-worker-a", workerStarted.WorkerId);
+
+        Assert.Equal("kafka-worker-a", completedArgs.Distribution!.WorkerId);
+        Assert.Equal("kafka-instance-a", completedArgs.Distribution.InstanceId);
+        Assert.Equal("Kafka", completedArgs.Distribution.TransportName);
+        Assert.Equal(0, completedArgs.Distribution.PartitionId);
+        Assert.Equal(0, completedArgs.Distribution.Offset);
+
+        var distributedStatus = pipeline.GetStatus().DistributedStatus;
+        Assert.NotNull(distributedStatus);
+        Assert.Equal(PipelineExecutionMode.Distributed, distributedStatus!.ExecutionMode);
+        Assert.Equal("kafka-worker-a", distributedStatus.WorkerId);
+        Assert.Empty(distributedStatus.OwnedPartitions);
+        Assert.Equal(PipelineExecutionStatus.Completed, pipeline.GetStatus().Status);
+    }
+
+    [Fact]
+    public async Task KafkaPipeline_Distributed_Mode_Rebalances_Across_Workers_And_Reassigns_On_Shutdown()
+    {
+        var scenarioName = nameof(KafkaPipeline_Distributed_Mode_Rebalances_Across_Workers_And_Reassigns_On_Shutdown);
+        var sourceTopic = await cluster.CreateTopicAsync($"{scenarioName}-source", partitions: 2).ConfigureAwait(false);
+        var consumerGroup = KafkaTopicNameFactory.CreateConsumerGroupName("pipelinez", scenarioName);
+
+        var worker1Completions = new ConcurrentQueue<PipelineRecordCompletedEventHandlerArgs<TestKafkaRecord>>();
+        var worker2Completions = new ConcurrentQueue<PipelineRecordCompletedEventHandlerArgs<TestKafkaRecord>>();
+        var worker1Revocations = new ConcurrentQueue<IReadOnlyList<PipelinePartitionLease>>();
+
+        var pipeline1 = Pipeline<TestKafkaRecord>.New($"{scenarioName}-worker-1")
+            .UseHostOptions(new PipelineHostOptions
+            {
+                ExecutionMode = PipelineExecutionMode.Distributed,
+                InstanceId = "instance-1",
+                WorkerId = "worker-1"
+            })
+            .WithKafkaSource(
+                cluster.CreateSourceOptions(sourceTopic, consumerGroup),
+                (string key, string value) => new TestKafkaRecord
+                {
+                    Key = key,
+                    Value = value
+                })
+            .WithInMemoryDestination("config")
+            .Build();
+
+        var pipeline2 = Pipeline<TestKafkaRecord>.New($"{scenarioName}-worker-2")
+            .UseHostOptions(new PipelineHostOptions
+            {
+                ExecutionMode = PipelineExecutionMode.Distributed,
+                InstanceId = "instance-2",
+                WorkerId = "worker-2"
+            })
+            .WithKafkaSource(
+                cluster.CreateSourceOptions(sourceTopic, consumerGroup),
+                (string key, string value) => new TestKafkaRecord
+                {
+                    Key = key,
+                    Value = value
+                })
+            .WithInMemoryDestination("config")
+            .Build();
+
+        pipeline1.OnPipelineRecordCompleted += (_, args) => worker1Completions.Enqueue(args);
+        pipeline2.OnPipelineRecordCompleted += (_, args) => worker2Completions.Enqueue(args);
+        pipeline1.OnPartitionsRevoked += (_, args) => worker1Revocations.Enqueue(args.Partitions);
+
+        await pipeline1.StartPipelineAsync().ConfigureAwait(false);
+
+        await KafkaPipelineTestHelpers.WaitForConditionAsync(
+            () => pipeline1.GetRuntimeContext().OwnedPartitions.Count == 2,
+            cluster.ConsumeTimeout).ConfigureAwait(false);
+
+        await pipeline2.StartPipelineAsync().ConfigureAwait(false);
+
+        await KafkaPipelineTestHelpers.WaitForConditionAsync(
+            () =>
+                pipeline1.GetRuntimeContext().OwnedPartitions.Count == 1 &&
+                pipeline2.GetRuntimeContext().OwnedPartitions.Count == 1,
+            cluster.ConsumeTimeout).ConfigureAwait(false);
+
+        Assert.NotEmpty(worker1Revocations);
+
+        await cluster.ProduceToPartitionAsync(
+            sourceTopic,
+            partition: 0,
+            new[] { KafkaPipelineTestHelpers.CreateMessage("p0", "value-0") }).ConfigureAwait(false);
+        await cluster.ProduceToPartitionAsync(
+            sourceTopic,
+            partition: 1,
+            new[] { KafkaPipelineTestHelpers.CreateMessage("p1", "value-1") }).ConfigureAwait(false);
+
+        await KafkaPipelineTestHelpers.WaitForConditionAsync(
+            () => worker1Completions.Count + worker2Completions.Count == 2,
+            cluster.ConsumeTimeout).ConfigureAwait(false);
+
+        var firstWave = worker1Completions.Concat(worker2Completions).ToArray();
+        Assert.Equal(2, firstWave.Length);
+        Assert.Equal(new int?[] { 0, 1 }, firstWave.Select(args => args.Distribution!.PartitionId).OrderBy(value => value).ToArray());
+        Assert.Equal(2, firstWave.Select(args => args.Distribution!.WorkerId).Distinct().Count());
+
+        await pipeline2.CompleteAsync().ConfigureAwait(false);
+        await pipeline2.Completion.ConfigureAwait(false);
+
+        await KafkaPipelineTestHelpers.WaitForConditionAsync(
+            () => pipeline1.GetRuntimeContext().OwnedPartitions.Count == 2,
+            cluster.ConsumeTimeout).ConfigureAwait(false);
+
+        await cluster.ProduceToPartitionAsync(
+            sourceTopic,
+            partition: 0,
+            new[] { KafkaPipelineTestHelpers.CreateMessage("p0-second", "value-2") }).ConfigureAwait(false);
+        await cluster.ProduceToPartitionAsync(
+            sourceTopic,
+            partition: 1,
+            new[] { KafkaPipelineTestHelpers.CreateMessage("p1-second", "value-3") }).ConfigureAwait(false);
+
+        await KafkaPipelineTestHelpers.WaitForConditionAsync(
+            () => worker1Completions.Count(args => args.Record.Key is "p0-second" or "p1-second") == 2,
+            cluster.ConsumeTimeout).ConfigureAwait(false);
+
+        var secondWave = worker1Completions
+            .Where(args => args.Record.Key is "p0-second" or "p1-second")
+            .ToArray();
+
+        Assert.Equal(2, secondWave.Length);
+        Assert.All(secondWave, args => Assert.Equal("worker-1", args.Distribution!.WorkerId));
+        Assert.Equal(new int?[] { 0, 1 }, secondWave.Select(args => args.Distribution!.PartitionId).OrderBy(value => value).ToArray());
+        Assert.Single(worker2Completions);
+
+        await pipeline1.CompleteAsync().ConfigureAwait(false);
+        await pipeline1.Completion.ConfigureAwait(false);
+
+        Assert.Equal(PipelineExecutionStatus.Completed, pipeline1.GetStatus().Status);
+        Assert.Equal(PipelineExecutionStatus.Completed, pipeline2.GetStatus().Status);
+    }
+}

--- a/src/tests/Pipelinez.Kafka.Tests/Infrastructure/KafkaTestCluster.cs
+++ b/src/tests/Pipelinez.Kafka.Tests/Infrastructure/KafkaTestCluster.cs
@@ -92,6 +92,19 @@ public sealed class KafkaTestCluster : IAsyncLifetime, IAsyncDisposable
         producer.Flush(TimeSpan.FromSeconds(10));
     }
 
+    public async Task ProduceToPartitionAsync(string topicName, int partition, IEnumerable<Message<string, string>> messages)
+    {
+        using var producer = new ProducerBuilder<string, string>(CreateProducerConfig()).Build();
+        var topicPartition = new TopicPartition(topicName, new Partition(partition));
+
+        foreach (var message in messages)
+        {
+            await producer.ProduceAsync(topicPartition, message).ConfigureAwait(false);
+        }
+
+        producer.Flush(TimeSpan.FromSeconds(10));
+    }
+
     public async Task<IReadOnlyList<ConsumeResult<string, string>>> ConsumeAsync(
         string topicName,
         int expectedCount,

--- a/src/tests/Pipelinez.Tests/Core/DistributedTests/Models/ManualDistributedSource.cs
+++ b/src/tests/Pipelinez.Tests/Core/DistributedTests/Models/ManualDistributedSource.cs
@@ -1,0 +1,83 @@
+using Pipelinez.Core.Distributed;
+using Pipelinez.Core.Record.Metadata;
+using Pipelinez.Core.Source;
+using Pipelinez.Tests.Core.SourceDestTests.Models;
+
+namespace Pipelinez.Tests.Core.DistributedTests.Models;
+
+public sealed class ManualDistributedSource : PipelineSourceBase<TestPipelineRecord>, IDistributedPipelineSource<TestPipelineRecord>
+{
+    private readonly object _leaseLock = new();
+    private IReadOnlyList<PipelinePartitionLease> _ownedPartitions = Array.Empty<PipelinePartitionLease>();
+
+    public bool SupportsDistributedExecution => true;
+
+    public string TransportName => "TestTransport";
+
+    public IReadOnlyList<PipelinePartitionLease> GetOwnedPartitions()
+    {
+        lock (_leaseLock)
+        {
+            return _ownedPartitions.ToArray();
+        }
+    }
+
+    public Task PublishDistributedAsync(TestPipelineRecord record, PipelinePartitionLease lease, long offset)
+    {
+        var metadata = new MetadataCollection();
+        metadata.Set(DistributedMetadataKeys.TransportName, TransportName);
+        metadata.Set(DistributedMetadataKeys.LeaseId, lease.LeaseId);
+        metadata.Set(DistributedMetadataKeys.PartitionKey, lease.PartitionKey);
+        metadata.Set(DistributedMetadataKeys.PartitionId, Convert.ToString(lease.PartitionId) ?? string.Empty);
+        metadata.Set(DistributedMetadataKeys.Offset, Convert.ToString(offset));
+        return PublishAsync(record, metadata);
+    }
+
+    public void AssignPartitions(params PipelinePartitionLease[] leases)
+    {
+        lock (_leaseLock)
+        {
+            _ownedPartitions = _ownedPartitions
+                .Concat(leases)
+                .GroupBy(lease => lease.LeaseId, StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.Last())
+                .ToArray();
+        }
+
+        ParentPipeline.ReportAssignedPartitions(leases);
+    }
+
+    public void RevokePartitions(params PipelinePartitionLease[] leases)
+    {
+        lock (_leaseLock)
+        {
+            var revokedIds = leases
+                .Select(lease => lease.LeaseId)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            _ownedPartitions = _ownedPartitions
+                .Where(lease => !revokedIds.Contains(lease.LeaseId))
+                .ToArray();
+        }
+
+        ParentPipeline.ReportRevokedPartitions(leases);
+    }
+
+    protected override async Task MainLoop(CancellationTokenSource cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await Task.Delay(50, cancellationToken.Token).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    protected override void Initialize()
+    {
+    }
+}

--- a/src/tests/Pipelinez.Tests/Core/DistributedTests/PipelineDistributedExecutionTests.cs
+++ b/src/tests/Pipelinez.Tests/Core/DistributedTests/PipelineDistributedExecutionTests.cs
@@ -1,0 +1,173 @@
+using System.Collections.Concurrent;
+using Pipelinez.Core;
+using Pipelinez.Core.Distributed;
+using Pipelinez.Core.Eventing;
+using Pipelinez.Core.Status;
+using Pipelinez.Tests.Core.DistributedTests.Models;
+using Pipelinez.Tests.Core.ErrorHandlingTests.Models;
+using Pipelinez.Tests.Core.SourceDestTests.Models;
+
+namespace Pipelinez.Tests.Core.DistributedTests;
+
+public class PipelineDistributedExecutionTests
+{
+    [Fact]
+    public void Pipeline_Build_Fails_When_Distributed_Mode_Is_Used_With_A_NonDistributed_Source()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            Pipeline<TestPipelineRecord>.New("distributed-invalid-source")
+                .UseHostOptions(new PipelineHostOptions
+                {
+                    ExecutionMode = PipelineExecutionMode.Distributed
+                })
+                .WithInMemorySource("config")
+                .WithInMemoryDestination("config")
+                .Build());
+
+        Assert.Contains("does not support distributed ownership", exception.Message);
+    }
+
+    [Fact]
+    public async Task Pipeline_Distributed_Runtime_Context_Status_And_Events_Are_Populated()
+    {
+        var source = new ManualDistributedSource();
+        var workerStarted = new ConcurrentQueue<PipelineRuntimeContext>();
+        var assignedEvents = new ConcurrentQueue<IReadOnlyList<PipelinePartitionLease>>();
+        var revokedEvents = new ConcurrentQueue<IReadOnlyList<PipelinePartitionLease>>();
+        var workerStopping = new ConcurrentQueue<PipelineRuntimeContext>();
+
+        var pipeline = Pipeline<TestPipelineRecord>.New("distributed-runtime")
+            .UseHostOptions(new PipelineHostOptions
+            {
+                ExecutionMode = PipelineExecutionMode.Distributed,
+                InstanceId = "instance-a",
+                WorkerId = "worker-a"
+            })
+            .WithSource(source)
+            .WithInMemoryDestination("config")
+            .Build();
+
+        pipeline.OnWorkerStarted += (_, args) => workerStarted.Enqueue(args.RuntimeContext);
+        pipeline.OnPartitionsAssigned += (_, args) => assignedEvents.Enqueue(args.Partitions);
+        pipeline.OnPartitionsRevoked += (_, args) => revokedEvents.Enqueue(args.Partitions);
+        pipeline.OnWorkerStopping += (_, args) => workerStopping.Enqueue(args.RuntimeContext);
+
+        await pipeline.StartPipelineAsync();
+
+        var runtimeContext = pipeline.GetRuntimeContext();
+        var partition0 = new PipelinePartitionLease("lease-0", "TestTransport", "partition-0", runtimeContext.InstanceId, runtimeContext.WorkerId, 0);
+        var partition1 = new PipelinePartitionLease("lease-1", "TestTransport", "partition-1", runtimeContext.InstanceId, runtimeContext.WorkerId, 1);
+
+        source.AssignPartitions(partition0, partition1);
+        source.RevokePartitions(partition1);
+
+        var activeContext = pipeline.GetRuntimeContext();
+        Assert.Single(activeContext.OwnedPartitions);
+        Assert.Equal("lease-0", activeContext.OwnedPartitions[0].LeaseId);
+
+        var activeDistributedStatus = pipeline.GetStatus().DistributedStatus;
+        Assert.NotNull(activeDistributedStatus);
+        Assert.Equal(PipelineExecutionMode.Distributed, activeDistributedStatus!.ExecutionMode);
+        Assert.Equal("worker-a", activeDistributedStatus.WorkerId);
+        Assert.Single(activeDistributedStatus.OwnedPartitions);
+        Assert.Equal("lease-0", activeDistributedStatus.OwnedPartitions[0].LeaseId);
+
+        await pipeline.CompleteAsync();
+        await pipeline.Completion;
+
+        Assert.Single(workerStarted);
+        Assert.Single(workerStopping);
+        Assert.Single(assignedEvents);
+        Assert.Single(revokedEvents);
+
+        var startedContext = Assert.Single(workerStarted);
+        Assert.Equal(PipelineExecutionMode.Distributed, startedContext.ExecutionMode);
+        Assert.Equal("instance-a", startedContext.InstanceId);
+        Assert.Equal("worker-a", startedContext.WorkerId);
+        Assert.Equal(PipelineExecutionStatus.Completed, pipeline.GetStatus().Status);
+    }
+
+    [Fact]
+    public async Task Pipeline_Distributed_Record_Completed_Event_Includes_Distribution_Context()
+    {
+        var source = new ManualDistributedSource();
+        PipelineRecordCompletedEventHandlerArgs<TestPipelineRecord>? completedArgs = null;
+
+        var pipeline = Pipeline<TestPipelineRecord>.New("distributed-record-completed")
+            .UseHostOptions(new PipelineHostOptions
+            {
+                ExecutionMode = PipelineExecutionMode.Distributed,
+                InstanceId = "instance-b",
+                WorkerId = "worker-b"
+            })
+            .WithSource(source)
+            .WithInMemoryDestination("config")
+            .Build();
+
+        pipeline.OnPipelineRecordCompleted += (_, args) => completedArgs = args;
+
+        await pipeline.StartPipelineAsync();
+
+        var context = pipeline.GetRuntimeContext();
+        var lease = new PipelinePartitionLease("lease-10", "TestTransport", "partition-10", context.InstanceId, context.WorkerId, 10);
+        source.AssignPartitions(lease);
+
+        await source.PublishDistributedAsync(new TestPipelineRecord { Data = "good" }, lease, offset: 42);
+        await pipeline.CompleteAsync();
+        await pipeline.Completion;
+
+        Assert.NotNull(completedArgs);
+        Assert.NotNull(completedArgs!.Distribution);
+        Assert.Equal("worker-b", completedArgs.Distribution!.WorkerId);
+        Assert.Equal("instance-b", completedArgs.Distribution.InstanceId);
+        Assert.Equal("TestTransport", completedArgs.Distribution.TransportName);
+        Assert.Equal("lease-10", completedArgs.Distribution.LeaseId);
+        Assert.Equal("partition-10", completedArgs.Distribution.PartitionKey);
+        Assert.Equal(10, completedArgs.Distribution.PartitionId);
+        Assert.Equal(42, completedArgs.Distribution.Offset);
+    }
+
+    [Fact]
+    public async Task Pipeline_Distributed_Record_Faulted_Event_Includes_Distribution_Context()
+    {
+        var source = new ManualDistributedSource();
+        PipelineRecordFaultedEventArgs<TestPipelineRecord>? faultedArgs = null;
+
+        var pipeline = Pipeline<TestPipelineRecord>.New("distributed-record-faulted")
+            .UseHostOptions(new PipelineHostOptions
+            {
+                ExecutionMode = PipelineExecutionMode.Distributed,
+                InstanceId = "instance-c",
+                WorkerId = "worker-c"
+            })
+            .WithSource(source)
+            .AddSegment(new ConditionalFaultingSegment(), "config")
+            .WithInMemoryDestination("config")
+            .Build();
+
+        pipeline.OnPipelineRecordFaulted += (_, args) => faultedArgs = args;
+
+        await pipeline.StartPipelineAsync();
+
+        var context = pipeline.GetRuntimeContext();
+        var lease = new PipelinePartitionLease("lease-20", "TestTransport", "partition-20", context.InstanceId, context.WorkerId, 20);
+        source.AssignPartitions(lease);
+
+        await source.PublishDistributedAsync(
+            new TestPipelineRecord { Data = ConditionalFaultingSegment.FaultingValue },
+            lease,
+            offset: 84);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await pipeline.Completion);
+
+        Assert.NotNull(faultedArgs);
+        Assert.NotNull(faultedArgs!.Distribution);
+        Assert.Equal("worker-c", faultedArgs.Distribution!.WorkerId);
+        Assert.Equal("instance-c", faultedArgs.Distribution.InstanceId);
+        Assert.Equal("TestTransport", faultedArgs.Distribution.TransportName);
+        Assert.Equal("lease-20", faultedArgs.Distribution.LeaseId);
+        Assert.Equal("partition-20", faultedArgs.Distribution.PartitionKey);
+        Assert.Equal(20, faultedArgs.Distribution.PartitionId);
+        Assert.Equal(84, faultedArgs.Distribution.Offset);
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements the distributed execution plan from `todo/09-distributed-stream-processing.md` and makes distributed stream processing a first-class runtime model in Pipelinez, with Kafka as the first supported distributed transport.

## What Changed

### Core distributed runtime
- Added explicit execution modes with `SingleProcess` and `Distributed`
- Added `PipelineHostOptions` so callers can opt into distributed mode and provide `InstanceId` / `WorkerId`
- Added `PipelineRuntimeContext` to expose pipeline identity and currently owned work
- Added `PipelineDistributedStatus` to surface distributed runtime information through `GetStatus()`
- Added `PipelinePartitionLease` as the transport-agnostic ownership model
- Added `PipelineRecordDistributionContext` so record-level events can include worker, partition, and offset information

### Pipeline API and validation
- Added `UseHostOptions(...)` to `PipelineBuilder<T>`
- Added `GetRuntimeContext()` to `IPipeline<T>` / `Pipeline<T>`
- Added build-time validation so distributed mode can only be used with distributed-capable sources
- Added `IDistributedPipelineSource<T>` to define the distributed source contract

### Eventing and observability
- Added worker lifecycle events:
  - `OnWorkerStarted`
  - `OnPartitionsAssigned`
  - `OnPartitionsRevoked`
  - `OnWorkerStopping`
- Extended `OnPipelineRecordCompleted` and `OnPipelineRecordFaulted` to include distribution context
- Added distributed startup/status behavior so worker identity and ownership are visible programmatically and in logs

### Kafka distributed support
- Updated Kafka source and consumer infrastructure to support:
  - partition assignment tracking
  - partition revocation tracking
  - lease ownership reporting back into the core runtime
  - record-level Kafka distribution metadata
- Improved Kafka shutdown/rebalance behavior so partitions are relinquished cleanly
- Corrected Kafka offset behavior so committed offsets are resumed normally, while `StartOffsetFromBeginning` controls reset behavior only for new groups

## GitHub Actions
- Added `PR.yaml` to validate pull requests on creation and updates
- Added `CI.yaml` to validate pushes to `main` after merge
- Both workflows restore, build, and run the full `src/Pipelinez.sln` test suite on .NET 8
- Added concurrency controls so outdated runs are cancelled when newer commits are pushed

## Testing

### Core tests
Added unit/runtime coverage for:
- distributed-mode validation against non-distributed sources
- runtime context population
- distributed status population
- worker lifecycle event propagation
- partition assignment/revocation propagation
- record-completed distribution context
- record-faulted distribution context

### Kafka integration tests
Added Docker-backed integration coverage for:
- distributed worker startup and ownership
- multi-worker partition rebalance
- reassignment after worker shutdown
- record-level worker/partition/offset context
- distributed status updates during runtime
- continued offset correctness across distributed execution

## Documentation
- Updated `docs/Overview.md` to describe the distributed runtime model, Kafka ownership behavior, and new observability surface
- Updated `README.md` to introduce distributed execution and the new public APIs at a high level

## Result
Pipelinez now has an explicit distributed execution model with:
- opt-in distributed hosting
- transport-agnostic ownership abstractions
- worker and partition observability
- Kafka as the first fully supported distributed source
- end-to-end automated coverage for multi-worker behavior