### PR TITLE
implementing retry policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Pipelinez is a small .NET 8 framework for building record-processing pipelines w
 - pluggable sources, segments, and destinations
 - async startup and completion
 - fault tracking and configurable error policies
+- configurable retry policies for segments and destinations
 - optional distributed execution for transport-backed sources
 - explicit performance tuning and runtime performance snapshots
 - transport extensions such as Kafka
@@ -33,6 +34,7 @@ Each record is wrapped in a `PipelineContainer<T>` so the framework can carry:
 - metadata
 - fault state
 - segment execution history
+- retry history
 
 ## Quick Example
 
@@ -194,6 +196,55 @@ Console.WriteLine(snapshot.RecordsPerSecond);
 
 Increasing parallelism or disabling ordering can improve throughput, but it can also change observable processing order. Those settings should be treated as explicit tradeoffs rather than passive defaults.
 
+## Retry Policies
+
+Pipelinez supports explicit retry policies for transient failures in segments and destinations.
+
+Retry configuration can be applied:
+
+- pipeline-wide through `UseRetryOptions(...)`
+- per segment through `AddSegment(..., retryPolicy)`
+- per destination through `WithDestination(..., retryPolicy)`
+
+Available policy styles include:
+
+- `PipelineRetryPolicy<T>.None()`
+- `PipelineRetryPolicy<T>.FixedDelay(...)`
+- `PipelineRetryPolicy<T>.ExponentialBackoff(...)`
+
+Example shape:
+
+```csharp
+using Pipelinez.Core.Retry;
+
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .UseRetryOptions(new PipelineRetryOptions<MyRecord>
+    {
+        DefaultSegmentPolicy = PipelineRetryPolicy<MyRecord>
+            .ExponentialBackoff(
+                maxAttempts: 5,
+                initialDelay: TimeSpan.FromMilliseconds(100),
+                maxDelay: TimeSpan.FromSeconds(3),
+                useJitter: true)
+            .Handle<TimeoutException>(),
+        DestinationPolicy = PipelineRetryPolicy<MyRecord>.FixedDelay(
+            maxAttempts: 3,
+            delay: TimeSpan.FromSeconds(1))
+    })
+    .WithInMemorySource(new object())
+    .AddSegment(new MySegment(), new object())
+    .WithInMemoryDestination("config")
+    .Build();
+
+pipeline.OnPipelineRecordRetrying += (_, args) =>
+{
+    Console.WriteLine(
+        $"{args.ComponentName} retry {args.AttemptNumber}/{args.MaxAttempts} for {args.Record.Id}");
+};
+```
+
+Retry exhaustion flows into the existing `WithErrorHandler(...)` path, so consumers can still decide whether to skip, stop, or rethrow once the configured retry policy has been exhausted.
+
 ## Error Handling
 
 Pipelinez supports explicit fault handling through `WithErrorHandler(...)`.
@@ -209,6 +260,7 @@ Available actions:
 
 Public events include:
 
+- `OnPipelineRecordRetrying`
 - `OnPipelineRecordCompleted`
 - `OnPipelineRecordFaulted`
 - `OnPipelineFaulted`
@@ -274,6 +326,7 @@ Current implemented capabilities include:
 - fault-aware record containers
 - segment execution history
 - configurable error policies
+- configurable retry policies with retry events and retry history
 - async destination execution
 - distributed runtime mode and worker/partition observability
 - performance tuning options, batching support, and runtime performance snapshots

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -53,6 +53,7 @@ The core builder currently supports:
 - `WithInMemoryDestination(...)`
 - `UseHostOptions(...)`
 - `UsePerformanceOptions(...)`
+- `UseRetryOptions(...)`
 - `UseLogger(...)`
 - `WithErrorHandler(...)`
 
@@ -81,6 +82,8 @@ Performance options are resolved at build time and applied to sources, segments,
   convenience flag for fault checks
 - `SegmentHistory`
   ordered `PipelineSegmentExecution` entries that capture segment execution results
+- `RetryHistory`
+  ordered `PipelineRetryAttempt` entries that capture retry failures and scheduled delays before terminal success or exhaustion
 
 This container is the runtime boundary object shared by sources, segments, destinations, error handling, and transport adapters.
 
@@ -106,10 +109,11 @@ Segments derive from `PipelineSegment<T>`, which wraps a `TransformBlock<Pipelin
 For each container:
 
 1. the segment checks whether the container already has a fault
-2. the segment executes `ExecuteAsync(T arg)`
-3. the returned record replaces `PipelineContainer<T>.Record`
-4. the segment appends a `PipelineSegmentExecution` entry to `SegmentHistory`
-5. if an exception occurs, the segment marks the container faulted and allows downstream error handling to decide what to do
+2. the segment executes `ExecuteAsync(T arg)` under the configured retry policy, if one exists
+3. retry attempts are appended to `RetryHistory` and retry events are raised before each delayed retry
+4. the returned record replaces `PipelineContainer<T>.Record`
+5. the segment appends a `PipelineSegmentExecution` entry to `SegmentHistory`
+6. if execution still fails after retries are exhausted, the segment marks the container faulted and allows downstream error handling to decide what to do
 
 This keeps the segment authoring model simple while still preserving runtime-level observability.
 Segments now also support configurable `DegreeOfParallelism`, `BoundedCapacity`, and `EnsureOrdered` behavior through `PipelineExecutionOptions`.
@@ -123,8 +127,9 @@ The destination loop:
 1. receives completed containers from upstream
 2. checks for pre-faulted containers
 3. delegates fault-policy decisions back to the pipeline when needed
-4. executes `ExecuteAsync(T record, CancellationToken cancellationToken)` for successful containers
-5. raises container-completed and record-completed events only after successful destination execution
+4. executes `ExecuteAsync(T record, CancellationToken cancellationToken)` or batch execution for successful containers under the configured retry policy
+5. records retry attempts on the container when destination execution fails transiently
+6. raises container-completed and record-completed events only after successful destination execution
 
 Destination execution is fully async, and destination `Completion` now represents the full destination work lifecycle rather than only message-buffer completion.
 Destinations also support optional batched execution when they implement `IBatchedPipelineDestination<T>` and batching is enabled through `PipelinePerformanceOptions`.
@@ -185,6 +190,9 @@ Segment defaults remain conservative, but callers can now opt into higher-throug
 
 - elapsed runtime
 - total published, completed, and faulted record counts
+- total retry count
+- successful retry recovery count
+- retry exhaustion count
 - calculated records-per-second
 - average end-to-end latency
 - per-component performance snapshots
@@ -285,6 +293,56 @@ For Kafka-backed distributed execution, that context includes:
 
 This makes per-record ownership and replay diagnostics available directly to consumers without forcing them to inspect raw metadata collections.
 
+## Retry Model
+
+Pipelinez now has a first-class retry model for transient failures in segments and destinations.
+
+### Retry Configuration
+
+Retry behavior is configured through `UseRetryOptions(...)` and component-level overloads on the builder.
+
+`PipelineRetryOptions<T>` can provide:
+
+- `DefaultSegmentPolicy`
+- `DestinationPolicy`
+- `EmitRetryEvents`
+
+Component-specific policies can override those defaults when calling `AddSegment(...)` or `WithDestination(...)`.
+
+The built-in policy factories are:
+
+- `PipelineRetryPolicy<T>.None()`
+- `PipelineRetryPolicy<T>.FixedDelay(...)`
+- `PipelineRetryPolicy<T>.ExponentialBackoff(...)`
+
+Policies can then be narrowed with exception filters using `Handle<TException>()` or `Handle(...)`.
+
+### Retry Execution
+
+Retry execution is handled by a shared internal retry executor rather than duplicated independently in each component type.
+
+For each retry-aware execution path:
+
+1. the component attempts the operation
+2. the policy evaluates whether the exception is retryable
+3. a `PipelineRetryAttempt` is appended to `RetryHistory`
+4. `OnPipelineRecordRetrying` is raised when retry events are enabled
+5. the runtime waits for the configured delay, honoring pipeline cancellation
+6. the operation is attempted again
+7. if retries are exhausted, normal fault handling begins
+
+If a later attempt succeeds, the container is not marked faulted and normal processing continues.
+
+### Retry Observability
+
+Retry behavior is visible through:
+
+- `PipelineContainer<T>.RetryHistory`
+- `OnPipelineRecordRetrying`
+- retry counters in `PipelinePerformanceSnapshot`
+
+This makes the difference between transient recovery and terminal failure visible in both event handlers and runtime diagnostics.
+
 ## Fault Handling And Error Policies
 
 Fault handling is now a first-class part of the runtime.
@@ -305,6 +363,8 @@ Segment-level execution history is preserved separately in `SegmentHistory`.
 
 The pipeline exposes:
 
+- `OnPipelineRecordRetrying`
+  raised when a record is scheduled for another attempt after a retryable failure
 - `OnPipelineRecordCompleted`
   raised after a record successfully completes the entire pipeline
 - `OnPipelineRecordFaulted`
@@ -321,6 +381,9 @@ The builder supports `WithErrorHandler(...)` with sync or async handlers. The ha
 - the exception
 - the `PipelineContainer<T>`
 - the captured `PipelineFaultState`
+- `RetryHistory`
+- `RetryAttemptCount`
+- `RetryExhausted`
 - the runtime cancellation token
 
 The handler returns a `PipelineErrorAction`:
@@ -333,6 +396,7 @@ The handler returns a `PipelineErrorAction`:
   mark the pipeline faulted and surface the original exception path
 
 If no handler is configured, the default behavior is to stop the pipeline on fault.
+Retries always run before the error handler is invoked. If retry eventually succeeds, the error handler is never called. If retry is exhausted, the handler receives the populated retry context and can decide whether to skip, stop, or rethrow.
 
 ## Status And Observability
 
@@ -359,7 +423,7 @@ Reported execution status is derived from task state and runtime fault state:
 For distributed sources, this status reflects live ownership while the worker is active. For Kafka specifically, owned partitions are cleared on shutdown when the consumer leaves the group and revocation is observed.
 
 Logging is managed through the internal `LoggingManager`, which wraps an `ILoggerFactory`. If the caller never supplies a logger factory, the runtime falls back to a null logger factory.
-The runtime now also exposes additive performance metrics through `GetPerformanceSnapshot()` rather than relying only on logs for throughput diagnostics.
+The runtime now also exposes additive performance metrics through `GetPerformanceSnapshot()` rather than relying only on logs for throughput diagnostics, including retry counts and retry recovery/exhaustion totals.
 
 ## Kafka Integration
 
@@ -456,6 +520,7 @@ The solution now includes two test layers.
 - async destination behavior
 - fault tracking and pipeline fault events
 - error-handler policies
+- retry policy behavior, retry events, retry exhaustion, and retry-aware error handling
 - logger integration
 - builder-surface expectations
 - performance-option propagation and override precedence
@@ -472,6 +537,7 @@ The solution now includes two test layers.
 - segment fault handling with `SkipRecord`, `StopPipeline`, and `Rethrow`
 - destination fault handling
 - record-fault and pipeline-fault event behavior
+- transient segment failures that recover under retry
 - offset commit and replay behavior across pipeline runs
 - distributed worker startup, rebalance, and shutdown behavior across multiple pipeline instances
 - record-level worker and partition context on successful and faulted records
@@ -493,6 +559,7 @@ The major architectural work called out in the earlier planning docs has been im
 - Docker-backed Kafka integration tests
 - explicit distributed execution mode with worker identity, partition ownership, and rebalance events
 - explicit performance tuning controls, built-in performance snapshots, destination batching, and a benchmark project
+- explicit retry policies with retry history, retry events, and retry-aware performance counters
 
 The remaining work is mostly future evolution work rather than foundational cleanup. Likely areas include broader transport coverage, schema-registry integration tests, and further runtime ergonomics.
 
@@ -504,14 +571,16 @@ The simplest way to think about Pipelinez is:
 2. choose where records come from
 3. chain one or more `PipelineSegment<T>` transforms
 4. choose where processed records end up
-5. optionally configure fault policy through `WithErrorHandler(...)`
-6. observe success or failure through the public pipeline events
+5. optionally configure retry behavior through `UseRetryOptions(...)`
+6. optionally configure fault policy through `WithErrorHandler(...)`
+7. observe retry, success, or failure through the public pipeline events
 
 Under the hood, Pipelinez is a thin framework over TPL Dataflow that standardizes:
 
 - record wrapping
 - metadata flow
 - fault capture
+- retry execution
 - completion semantics
 - logging
 - transport-specific adapters such as Kafka

--- a/src/Pipelinez/Core/Destination/PipelineDestination.cs
+++ b/src/Pipelinez/Core/Destination/PipelineDestination.cs
@@ -9,10 +9,11 @@ using Pipelinez.Core.FaultHandling;
 using Pipelinez.Core.Logging;
 using Pipelinez.Core.Performance;
 using Pipelinez.Core.Record;
+using Pipelinez.Core.Retry;
 
 namespace Pipelinez.Core.Destination;
 
-public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelineExecutionConfigurable, IPipelinePerformanceAware, IPipelineBatchingAware
+public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelineExecutionConfigurable, IPipelinePerformanceAware, IPipelineBatchingAware, IPipelineRetryConfigurable<T>
     where T : PipelineRecord
 {
     private BufferBlock<PipelineContainer<T>>? _messageBuffer;
@@ -21,6 +22,7 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
     private Pipeline<T>? _parentPipeline;
     private PipelineExecutionOptions _executionOptions = PipelineExecutionOptions.CreateDefaultDestinationOptions();
     private PipelineBatchingOptions? _batchingOptions;
+    private PipelineRetryPolicy<T>? _retryPolicy;
     private IPipelinePerformanceCollector? _performanceCollector;
     private string _componentName = "Destination";
 
@@ -73,6 +75,17 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
     public PipelineExecutionOptions GetExecutionOptions()
     {
         return _executionOptions;
+    }
+
+    public void ConfigureRetryPolicy(PipelineRetryPolicy<T>? retryPolicy)
+    {
+        EnsureExecutionOptionsCanBeChanged();
+        _retryPolicy = retryPolicy;
+    }
+
+    public PipelineRetryPolicy<T>? GetRetryPolicy()
+    {
+        return _retryPolicy;
     }
 
     void IPipelinePerformanceAware.ConfigurePerformanceCollector(
@@ -221,14 +234,39 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
     {
         if (sourceRecord.HasFault)
         {
-            return await HandleFaultedContainerAsync(sourceRecord).ConfigureAwait(false);
+            return await HandleFaultedContainerAsync(sourceRecord, throwOnStopPipeline: true).ConfigureAwait(false);
         }
 
         var stopwatch = Stopwatch.StartNew();
 
         try
         {
-            await ExecuteAsync(sourceRecord.Record, cancellationToken).ConfigureAwait(false);
+            await PipelineRetryExecutor.ExecuteAsync(
+                    sourceRecord,
+                    _retryPolicy,
+                    GetType().Name,
+                    PipelineComponentKind.Destination,
+                    () => ParentPipeline.GetRuntimeCancellationToken(),
+                    async (retryAttempt, exception) =>
+                    {
+                        sourceRecord.AddRetryAttempt(retryAttempt);
+                        await ParentPipeline.NotifyRecordRetryingAsync(
+                            sourceRecord,
+                            retryAttempt,
+                            _retryPolicy?.MaxAttempts ?? 1,
+                            exception).ConfigureAwait(false);
+                    },
+                    () =>
+                    {
+                        ParentPipeline.NotifyRetryRecovered();
+                        return Task.CompletedTask;
+                    },
+                    async token =>
+                    {
+                        await ExecuteAsync(sourceRecord.Record, token).ConfigureAwait(false);
+                        return sourceRecord;
+                    })
+                .ConfigureAwait(false);
             stopwatch.Stop();
             _performanceCollector?.RecordComponentExecution(_componentName, stopwatch.Elapsed, succeeded: true);
 
@@ -262,7 +300,35 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
 
         try
         {
-            await batchedDestination.ExecuteBatchAsync(batch, cancellationToken).ConfigureAwait(false);
+            await PipelineRetryExecutor.ExecuteAsync(
+                    batch[0],
+                    _retryPolicy,
+                    GetType().Name,
+                    PipelineComponentKind.Destination,
+                    () => ParentPipeline.GetRuntimeCancellationToken(),
+                    async (retryAttempt, exception) =>
+                    {
+                        foreach (var container in batch)
+                        {
+                            container.AddRetryAttempt(retryAttempt);
+                            await ParentPipeline.NotifyRecordRetryingAsync(
+                                container,
+                                retryAttempt,
+                                _retryPolicy?.MaxAttempts ?? 1,
+                                exception).ConfigureAwait(false);
+                        }
+                    },
+                    () =>
+                    {
+                        ParentPipeline.NotifyRetryRecovered();
+                        return Task.CompletedTask;
+                    },
+                    async token =>
+                    {
+                        await batchedDestination.ExecuteBatchAsync(batch, token).ConfigureAwait(false);
+                        return true;
+                    })
+                .ConfigureAwait(false);
             stopwatch.Stop();
 
             var durationPerRecord = GetPerRecordDuration(stopwatch.Elapsed, batch.Count);
@@ -292,7 +358,7 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
                     DateTimeOffset.UtcNow,
                     e.Message));
 
-                if (!await HandleFaultedContainerAsync(container).ConfigureAwait(false))
+                if (!await HandleFaultedContainerAsync(container, throwOnStopPipeline: true).ConfigureAwait(false))
                 {
                     return false;
                 }
@@ -302,7 +368,9 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
         }
     }
 
-    private async Task<bool> HandleFaultedContainerAsync(PipelineContainer<T> sourceRecord)
+    private async Task<bool> HandleFaultedContainerAsync(
+        PipelineContainer<T> sourceRecord,
+        bool throwOnStopPipeline = false)
     {
         var action = await ParentPipeline.HandleFaultedContainerAsync(sourceRecord).ConfigureAwait(false);
 
@@ -312,6 +380,11 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
         }
 
         if (action == PipelineErrorAction.Rethrow)
+        {
+            ExceptionDispatchInfo.Capture(sourceRecord.Fault!.Exception).Throw();
+        }
+
+        if (throwOnStopPipeline)
         {
             ExceptionDispatchInfo.Capture(sourceRecord.Fault!.Exception).Throw();
         }

--- a/src/Pipelinez/Core/ErrorHandling/PipelineErrorContext.cs
+++ b/src/Pipelinez/Core/ErrorHandling/PipelineErrorContext.cs
@@ -1,6 +1,7 @@
 using Ardalis.GuardClauses;
 using Pipelinez.Core.FaultHandling;
 using Pipelinez.Core.Record;
+using Pipelinez.Core.Retry;
 
 namespace Pipelinez.Core.ErrorHandling;
 
@@ -31,4 +32,10 @@ public sealed class PipelineErrorContext<T> where T : PipelineRecord
     public PipelineComponentKind ComponentKind => Fault.ComponentKind;
 
     public CancellationToken CancellationToken { get; }
+
+    public IReadOnlyList<PipelineRetryAttempt> RetryHistory => Container.RetryHistory.ToArray();
+
+    public int RetryAttemptCount => Container.RetryHistory.Count;
+
+    public bool RetryExhausted => RetryAttemptCount > 0;
 }

--- a/src/Pipelinez/Core/Eventing/Eventing.cs
+++ b/src/Pipelinez/Core/Eventing/Eventing.cs
@@ -48,6 +48,10 @@ public delegate void PipelineRecordFaultedEventHandler<T>(
     object sender,
     PipelineRecordFaultedEventArgs<T> args) where T : PipelineRecord;
 
+public delegate void PipelineRecordRetryingEventHandler<T>(
+    object sender,
+    PipelineRecordRetryingEventArgs<T> args) where T : PipelineRecord;
+
 public sealed class PipelineRecordFaultedEventArgs<T> where T : PipelineRecord
 {
     public PipelineRecordFaultedEventArgs(
@@ -69,6 +73,47 @@ public sealed class PipelineRecordFaultedEventArgs<T> where T : PipelineRecord
     public PipelineFaultState Fault { get; }
 
     public PipelineRecordDistributionContext? Distribution { get; }
+}
+
+public sealed class PipelineRecordRetryingEventArgs<T> where T : PipelineRecord
+{
+    public PipelineRecordRetryingEventArgs(
+        T record,
+        PipelineContainer<T> container,
+        PipelineFaultState fault,
+        int attemptNumber,
+        int maxAttempts,
+        TimeSpan delay,
+        PipelineRecordDistributionContext? distribution = null)
+    {
+        Record = Guard.Against.Null(record, nameof(record));
+        Container = Guard.Against.Null(container, nameof(container));
+        Fault = Guard.Against.Null(fault, nameof(fault));
+        AttemptNumber = Guard.Against.NegativeOrZero(attemptNumber, nameof(attemptNumber));
+        MaxAttempts = Guard.Against.NegativeOrZero(maxAttempts, nameof(maxAttempts));
+        Delay = delay;
+        Distribution = distribution;
+    }
+
+    public T Record { get; }
+
+    public PipelineContainer<T> Container { get; }
+
+    public PipelineFaultState Fault { get; }
+
+    public int AttemptNumber { get; }
+
+    public int MaxAttempts { get; }
+
+    public TimeSpan Delay { get; }
+
+    public PipelineRecordDistributionContext? Distribution { get; }
+
+    public string ComponentName => Fault.ComponentName;
+
+    public PipelineComponentKind ComponentKind => Fault.ComponentKind;
+
+    public Exception Exception => Fault.Exception;
 }
 
 public delegate void PipelineFaultedEventHandler(object sender, PipelineFaultedEventArgs args);

--- a/src/Pipelinez/Core/IPipeline.cs
+++ b/src/Pipelinez/Core/IPipeline.cs
@@ -49,6 +49,11 @@ public interface IPipeline<T> where T : PipelineRecord
     event PipelineRecordFaultedEventHandler<T> OnPipelineRecordFaulted;
 
     /// <summary>
+    /// Event that is raised when a record is scheduled for retry after a transient failure.
+    /// </summary>
+    event PipelineRecordRetryingEventHandler<T> OnPipelineRecordRetrying;
+
+    /// <summary>
     /// Event that is raised when the pipeline transitions into a faulted state.
     /// </summary>
     event PipelineFaultedEventHandler OnPipelineFaulted;

--- a/src/Pipelinez/Core/Performance/IPipelinePerformanceCollector.cs
+++ b/src/Pipelinez/Core/Performance/IPipelinePerformanceCollector.cs
@@ -10,5 +10,11 @@ internal interface IPipelinePerformanceCollector
 
     void RecordComponentExecution(string componentName, TimeSpan duration, bool succeeded);
 
+    void RecordRetryAttempt();
+
+    void RecordRetryRecovery();
+
+    void RecordRetryExhausted();
+
     PipelinePerformanceSnapshot CreateSnapshot();
 }

--- a/src/Pipelinez/Core/Performance/PipelinePerformanceCollector.cs
+++ b/src/Pipelinez/Core/Performance/PipelinePerformanceCollector.cs
@@ -19,6 +19,9 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
     private long _publishedCount;
     private long _completedCount;
     private long _faultedCount;
+    private long _retryCount;
+    private long _retryRecoveries;
+    private long _retryExhaustions;
     private long _totalEndToEndLatencyTicks;
 
     public PipelinePerformanceCollector(PipelineMetricsOptions metricsOptions)
@@ -92,6 +95,45 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
         }
     }
 
+    public void RecordRetryAttempt()
+    {
+        if (!_metricsOptions.EnableRuntimeMetrics)
+        {
+            return;
+        }
+
+        lock (_syncLock)
+        {
+            _retryCount++;
+        }
+    }
+
+    public void RecordRetryRecovery()
+    {
+        if (!_metricsOptions.EnableRuntimeMetrics)
+        {
+            return;
+        }
+
+        lock (_syncLock)
+        {
+            _retryRecoveries++;
+        }
+    }
+
+    public void RecordRetryExhausted()
+    {
+        if (!_metricsOptions.EnableRuntimeMetrics)
+        {
+            return;
+        }
+
+        lock (_syncLock)
+        {
+            _retryExhaustions++;
+        }
+    }
+
     public PipelinePerformanceSnapshot CreateSnapshot()
     {
         lock (_syncLock)
@@ -128,6 +170,9 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
                 _publishedCount,
                 _completedCount,
                 _faultedCount,
+                _retryCount,
+                _retryRecoveries,
+                _retryExhaustions,
                 totalFinished / elapsedSeconds,
                 averageLatency,
                 componentSnapshots);

--- a/src/Pipelinez/Core/Performance/PipelinePerformanceSnapshot.cs
+++ b/src/Pipelinez/Core/Performance/PipelinePerformanceSnapshot.cs
@@ -8,6 +8,9 @@ public sealed class PipelinePerformanceSnapshot
         long totalRecordsPublished,
         long totalRecordsCompleted,
         long totalRecordsFaulted,
+        long totalRetryCount,
+        long successfulRetryRecoveries,
+        long retryExhaustions,
         double recordsPerSecond,
         TimeSpan averageEndToEndLatency,
         IReadOnlyList<PipelineComponentPerformanceSnapshot> components)
@@ -17,6 +20,9 @@ public sealed class PipelinePerformanceSnapshot
         TotalRecordsPublished = totalRecordsPublished;
         TotalRecordsCompleted = totalRecordsCompleted;
         TotalRecordsFaulted = totalRecordsFaulted;
+        TotalRetryCount = totalRetryCount;
+        SuccessfulRetryRecoveries = successfulRetryRecoveries;
+        RetryExhaustions = retryExhaustions;
         RecordsPerSecond = recordsPerSecond;
         AverageEndToEndLatency = averageEndToEndLatency;
         Components = components;
@@ -31,6 +37,12 @@ public sealed class PipelinePerformanceSnapshot
     public long TotalRecordsCompleted { get; }
 
     public long TotalRecordsFaulted { get; }
+
+    public long TotalRetryCount { get; }
+
+    public long SuccessfulRetryRecoveries { get; }
+
+    public long RetryExhaustions { get; }
 
     public double RecordsPerSecond { get; }
 

--- a/src/Pipelinez/Core/Pipeline.cs
+++ b/src/Pipelinez/Core/Pipeline.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks.Dataflow;
+using System.Runtime.ExceptionServices;
 using Ardalis.GuardClauses;
 using Microsoft.Extensions.Logging;
 using Pipelinez.Core.Distributed;
@@ -9,6 +10,7 @@ using Pipelinez.Core.FaultHandling;
 using Pipelinez.Core.Logging;
 using Pipelinez.Core.Performance;
 using Pipelinez.Core.Record;
+using Pipelinez.Core.Retry;
 using Pipelinez.Core.Segment;
 using Pipelinez.Core.Source;
 using Pipelinez.Core.Status;
@@ -51,6 +53,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     private readonly PipelineErrorHandler<TPipelineRecord>? _errorHandler;
     private readonly PipelineHostOptions _hostOptions;
     private readonly IPipelinePerformanceCollector _performanceCollector;
+    private readonly bool _emitRetryEvents;
     private readonly string _instanceId;
     private readonly string _workerId;
     private readonly object _stateLock = new();
@@ -92,6 +95,11 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     /// Occurs when a record in the pipeline faults.
     /// </summary>
     public event PipelineRecordFaultedEventHandler<TPipelineRecord>? OnPipelineRecordFaulted;
+
+    /// <summary>
+    /// Occurs when a record is about to be retried after a transient failure.
+    /// </summary>
+    public event PipelineRecordRetryingEventHandler<TPipelineRecord>? OnPipelineRecordRetrying;
 
     /// <summary>
     /// Occurs when the pipeline transitions into a faulted state.
@@ -157,6 +165,10 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
                 container,
                 container.Fault,
                 BuildDistributionContext(container.Metadata)));
+        if (container.RetryHistory.Count > 0)
+        {
+            _performanceCollector.RecordRetryExhausted();
+        }
         _performanceCollector.RecordFaulted(container.CreatedAtUtc);
 
         var action = await ResolveErrorActionAsync(container, container.Fault).ConfigureAwait(false);
@@ -191,7 +203,8 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         IList<IPipelineSegment<TPipelineRecord>> segments,
         PipelineErrorHandler<TPipelineRecord>? errorHandler = null,
         PipelineHostOptions? hostOptions = null,
-        IPipelinePerformanceCollector? performanceCollector = null)
+        IPipelinePerformanceCollector? performanceCollector = null,
+        bool emitRetryEvents = true)
     {
         Guard.Against.NullOrEmpty(name, message: "Pipeline must have a name");
         Guard.Against.Null(source, message: "Pipeline must have a valid source");
@@ -206,6 +219,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         this._errorHandler = errorHandler;
         _hostOptions = hostOptions ?? new PipelineHostOptions();
         _performanceCollector = performanceCollector ?? new PipelinePerformanceCollector(new PipelineMetricsOptions());
+        _emitRetryEvents = emitRetryEvents;
         _instanceId = string.IsNullOrWhiteSpace(_hostOptions.InstanceId)
             ? Environment.MachineName
             : _hostOptions.InstanceId;
@@ -245,6 +259,11 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     /// </summary>
     internal void InitializePipeline()
     {
+        foreach (var segment in _segments.OfType<PipelineSegment<TPipelineRecord>>())
+        {
+            segment.Initialize(this);
+        }
+
         // Allow for components of the pipeline to initialize
         _source.Initialize(this);
         _destination.Initialize(this);
@@ -361,6 +380,11 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         }
 
         await completionTask.ConfigureAwait(false);
+
+        if (_state == PipelineRuntimeState.Faulted && _pipelineFault is not null)
+        {
+            ExceptionDispatchInfo.Capture(_pipelineFault.Exception).Throw();
+        }
     }
     
     /// <summary>Gets a <see cref="T:System.Threading.Tasks.Task" /> that represents the asynchronous operation and completion of the pipeline.</summary>
@@ -395,6 +419,54 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     public PipelinePerformanceSnapshot GetPerformanceSnapshot()
     {
         return _performanceCollector.CreateSnapshot();
+    }
+
+    internal CancellationToken GetRuntimeCancellationToken()
+    {
+        return _runtimeCancellationTokenSource?.Token ?? CancellationToken.None;
+    }
+
+    internal Task NotifyRecordRetryingAsync(
+        PipelineContainer<TPipelineRecord> container,
+        PipelineRetryAttempt retryAttempt,
+        int maxAttempts,
+        Exception exception)
+    {
+        Guard.Against.Null(container, nameof(container));
+        Guard.Against.Null(retryAttempt, nameof(retryAttempt));
+        Guard.Against.NegativeOrZero(maxAttempts, nameof(maxAttempts));
+        Guard.Against.Null(exception, nameof(exception));
+
+        _performanceCollector.RecordRetryAttempt();
+
+        if (!_emitRetryEvents)
+        {
+            return Task.CompletedTask;
+        }
+
+        var fault = CreatePipelineFaultState(
+            exception,
+            retryAttempt.ComponentName,
+            retryAttempt.ComponentKind,
+            retryAttempt.Message);
+
+        OnPipelineRecordRetrying?.Invoke(
+            this,
+            new PipelineRecordRetryingEventArgs<TPipelineRecord>(
+                container.Record,
+                container,
+                fault,
+                retryAttempt.AttemptNumber,
+                maxAttempts,
+                retryAttempt.DelayBeforeNextAttempt,
+                BuildDistributionContext(container.Metadata)));
+
+        return Task.CompletedTask;
+    }
+
+    internal void NotifyRetryRecovered()
+    {
+        _performanceCollector.RecordRetryRecovery();
     }
 
     private void EnsurePipelineStartedForPublish()

--- a/src/Pipelinez/Core/PipelineBuilder.cs
+++ b/src/Pipelinez/Core/PipelineBuilder.cs
@@ -6,6 +6,7 @@ using Pipelinez.Core.ErrorHandling;
 using Pipelinez.Core.Logging;
 using Pipelinez.Core.Performance;
 using Pipelinez.Core.Record;
+using Pipelinez.Core.Retry;
 using Pipelinez.Core.Segment;
 using Pipelinez.Core.Source;
 
@@ -16,7 +17,8 @@ public class PipelineBuilder<T>(string pipelineName)
 {
     private sealed record PipelineSegmentRegistration(
         IPipelineSegment<T> Segment,
-        PipelineExecutionOptions? ExecutionOptions);
+        PipelineExecutionOptions? ExecutionOptions,
+        PipelineRetryPolicy<T>? RetryPolicy);
 
     public string PipelineName { get; } = Guard.Against.NullOrWhiteSpace(pipelineName, nameof(pipelineName));
 
@@ -27,9 +29,11 @@ public class PipelineBuilder<T>(string pipelineName)
     private readonly IList<PipelineSegmentRegistration> _segments = new List<PipelineSegmentRegistration>();
     private IPipelineDestination<T>? _destination;
     private PipelineExecutionOptions? _destinationExecutionOptions;
+    private PipelineRetryPolicy<T>? _destinationRetryPolicy;
     private PipelineErrorHandler<T>? _errorHandler;
     private PipelineHostOptions _hostOptions = new();
     private PipelinePerformanceOptions _performanceOptions = new();
+    private PipelineRetryOptions<T> _retryOptions = new();
 
     #endregion
 
@@ -62,6 +66,7 @@ public class PipelineBuilder<T>(string pipelineName)
     {
         _segments.Add(new PipelineSegmentRegistration(
             Guard.Against.Null(segment, nameof(segment)),
+            null,
             null));
         return this;
     }
@@ -73,7 +78,33 @@ public class PipelineBuilder<T>(string pipelineName)
     {
         _segments.Add(new PipelineSegmentRegistration(
             Guard.Against.Null(segment, nameof(segment)),
-            Guard.Against.Null(executionOptions, nameof(executionOptions)).Validate()));
+            Guard.Against.Null(executionOptions, nameof(executionOptions)).Validate(),
+            null));
+        return this;
+    }
+
+    public PipelineBuilder<T> AddSegment(
+        IPipelineSegment<T> segment,
+        object config,
+        PipelineRetryPolicy<T> retryPolicy)
+    {
+        _segments.Add(new PipelineSegmentRegistration(
+            Guard.Against.Null(segment, nameof(segment)),
+            null,
+            Guard.Against.Null(retryPolicy, nameof(retryPolicy))));
+        return this;
+    }
+
+    public PipelineBuilder<T> AddSegment(
+        IPipelineSegment<T> segment,
+        object config,
+        PipelineExecutionOptions executionOptions,
+        PipelineRetryPolicy<T> retryPolicy)
+    {
+        _segments.Add(new PipelineSegmentRegistration(
+            Guard.Against.Null(segment, nameof(segment)),
+            Guard.Against.Null(executionOptions, nameof(executionOptions)).Validate(),
+            Guard.Against.Null(retryPolicy, nameof(retryPolicy))));
         return this;
     }
 
@@ -85,6 +116,7 @@ public class PipelineBuilder<T>(string pipelineName)
     {
         _destination = Guard.Against.Null(destination, nameof(destination));
         _destinationExecutionOptions = null;
+        _destinationRetryPolicy = null;
         return this;
     }
 
@@ -92,6 +124,26 @@ public class PipelineBuilder<T>(string pipelineName)
     {
         _destination = Guard.Against.Null(destination, nameof(destination));
         _destinationExecutionOptions = Guard.Against.Null(executionOptions, nameof(executionOptions)).Validate();
+        _destinationRetryPolicy = null;
+        return this;
+    }
+
+    public PipelineBuilder<T> WithDestination(IPipelineDestination<T> destination, PipelineRetryPolicy<T> retryPolicy)
+    {
+        _destination = Guard.Against.Null(destination, nameof(destination));
+        _destinationExecutionOptions = null;
+        _destinationRetryPolicy = Guard.Against.Null(retryPolicy, nameof(retryPolicy));
+        return this;
+    }
+
+    public PipelineBuilder<T> WithDestination(
+        IPipelineDestination<T> destination,
+        PipelineExecutionOptions executionOptions,
+        PipelineRetryPolicy<T> retryPolicy)
+    {
+        _destination = Guard.Against.Null(destination, nameof(destination));
+        _destinationExecutionOptions = Guard.Against.Null(executionOptions, nameof(executionOptions)).Validate();
+        _destinationRetryPolicy = Guard.Against.Null(retryPolicy, nameof(retryPolicy));
         return this;
     }
 
@@ -127,6 +179,16 @@ public class PipelineBuilder<T>(string pipelineName)
     public PipelineBuilder<T> UsePerformanceOptions(PipelinePerformanceOptions options)
     {
         _performanceOptions = Guard.Against.Null(options, nameof(options)).Validate();
+        return this;
+    }
+
+    #endregion
+
+    #region Retry
+
+    public PipelineBuilder<T> UseRetryOptions(PipelineRetryOptions<T> options)
+    {
+        _retryOptions = Guard.Against.Null(options, nameof(options));
         return this;
     }
 
@@ -183,6 +245,10 @@ public class PipelineBuilder<T>(string pipelineName)
                 "segment",
                 registration.Segment,
                 registration.ExecutionOptions ?? _performanceOptions.DefaultSegmentExecution);
+            ApplyRetryOptions(
+                "segment",
+                registration.Segment,
+                registration.RetryPolicy ?? _retryOptions.DefaultSegmentPolicy);
             ApplyPerformanceCollector(
                 registration.Segment,
                 performanceCollector,
@@ -193,6 +259,10 @@ public class PipelineBuilder<T>(string pipelineName)
             "destination",
             _destination,
             _destinationExecutionOptions ?? _performanceOptions.DestinationExecution);
+        ApplyRetryOptions(
+            "destination",
+            _destination,
+            _destinationRetryPolicy ?? _retryOptions.DestinationPolicy);
         ApplyBatchingOptions(_destination, _performanceOptions.DestinationBatching);
         ApplyPerformanceCollector(
             _destination,
@@ -206,7 +276,8 @@ public class PipelineBuilder<T>(string pipelineName)
             _segments.Select(registration => registration.Segment).ToList(),
             _errorHandler,
             _hostOptions,
-            performanceCollector);
+            performanceCollector,
+            _retryOptions.EmitRetryEvents);
         pipeline.LinkPipeline();
         pipeline.InitializePipeline();
         return pipeline;
@@ -236,6 +307,26 @@ public class PipelineBuilder<T>(string pipelineName)
         {
             performanceAware.ConfigurePerformanceCollector(performanceCollector, componentName);
         }
+    }
+
+    private static void ApplyRetryOptions<TComponent>(
+        string componentRole,
+        TComponent component,
+        PipelineRetryPolicy<T>? retryPolicy)
+    {
+        if (retryPolicy is null)
+        {
+            return;
+        }
+
+        if (component is IPipelineRetryConfigurable<T> configurable)
+        {
+            configurable.ConfigureRetryPolicy(retryPolicy);
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Pipeline {componentRole} '{component?.GetType().Name}' does not support retry policies.");
     }
 
     private static void ApplyBatchingOptions<TComponent>(

--- a/src/Pipelinez/Core/Record/PipelineContainer.cs
+++ b/src/Pipelinez/Core/Record/PipelineContainer.cs
@@ -1,6 +1,7 @@
 using Ardalis.GuardClauses;
 using Pipelinez.Core.FaultHandling;
 using Pipelinez.Core.Record.Metadata;
+using Pipelinez.Core.Retry;
 
 namespace Pipelinez.Core.Record;
 
@@ -32,6 +33,8 @@ public sealed class PipelineContainer<T> where T : PipelineRecord
 
     public IList<PipelineSegmentExecution> SegmentHistory { get; } = new List<PipelineSegmentExecution>();
 
+    public IList<PipelineRetryAttempt> RetryHistory { get; } = new List<PipelineRetryAttempt>();
+
     public void MarkFaulted(PipelineFaultState fault)
     {
         Fault ??= Guard.Against.Null(fault, nameof(fault));
@@ -40,5 +43,10 @@ public sealed class PipelineContainer<T> where T : PipelineRecord
     public void AddSegmentExecution(PipelineSegmentExecution segmentExecution)
     {
         SegmentHistory.Add(Guard.Against.Null(segmentExecution, nameof(segmentExecution)));
+    }
+
+    public void AddRetryAttempt(PipelineRetryAttempt retryAttempt)
+    {
+        RetryHistory.Add(Guard.Against.Null(retryAttempt, nameof(retryAttempt)));
     }
 }

--- a/src/Pipelinez/Core/Retry/IPipelineRetryConfigurable.cs
+++ b/src/Pipelinez/Core/Retry/IPipelineRetryConfigurable.cs
@@ -1,0 +1,10 @@
+using Pipelinez.Core.Record;
+
+namespace Pipelinez.Core.Retry;
+
+public interface IPipelineRetryConfigurable<T> where T : PipelineRecord
+{
+    void ConfigureRetryPolicy(PipelineRetryPolicy<T>? retryPolicy);
+
+    PipelineRetryPolicy<T>? GetRetryPolicy();
+}

--- a/src/Pipelinez/Core/Retry/PipelineRetryAttempt.cs
+++ b/src/Pipelinez/Core/Retry/PipelineRetryAttempt.cs
@@ -1,0 +1,47 @@
+using Ardalis.GuardClauses;
+using Pipelinez.Core.FaultHandling;
+
+namespace Pipelinez.Core.Retry;
+
+public sealed class PipelineRetryAttempt
+{
+    public PipelineRetryAttempt(
+        int attemptNumber,
+        string componentName,
+        PipelineComponentKind componentKind,
+        DateTimeOffset startedAtUtc,
+        DateTimeOffset completedAtUtc,
+        TimeSpan duration,
+        TimeSpan delayBeforeNextAttempt,
+        string exceptionType,
+        string message)
+    {
+        AttemptNumber = Guard.Against.NegativeOrZero(attemptNumber, nameof(attemptNumber));
+        ComponentName = Guard.Against.NullOrWhiteSpace(componentName, nameof(componentName));
+        ComponentKind = componentKind;
+        StartedAtUtc = startedAtUtc;
+        CompletedAtUtc = completedAtUtc;
+        Duration = duration;
+        DelayBeforeNextAttempt = delayBeforeNextAttempt;
+        ExceptionType = Guard.Against.NullOrWhiteSpace(exceptionType, nameof(exceptionType));
+        Message = Guard.Against.NullOrWhiteSpace(message, nameof(message));
+    }
+
+    public int AttemptNumber { get; }
+
+    public string ComponentName { get; }
+
+    public PipelineComponentKind ComponentKind { get; }
+
+    public DateTimeOffset StartedAtUtc { get; }
+
+    public DateTimeOffset CompletedAtUtc { get; }
+
+    public TimeSpan Duration { get; }
+
+    public TimeSpan DelayBeforeNextAttempt { get; }
+
+    public string ExceptionType { get; }
+
+    public string Message { get; }
+}

--- a/src/Pipelinez/Core/Retry/PipelineRetryContext.cs
+++ b/src/Pipelinez/Core/Retry/PipelineRetryContext.cs
@@ -1,0 +1,42 @@
+using Ardalis.GuardClauses;
+using Pipelinez.Core.FaultHandling;
+using Pipelinez.Core.Record;
+
+namespace Pipelinez.Core.Retry;
+
+public sealed class PipelineRetryContext<T> where T : PipelineRecord
+{
+    public PipelineRetryContext(
+        Exception exception,
+        PipelineContainer<T> container,
+        string componentName,
+        PipelineComponentKind componentKind,
+        int attemptNumber,
+        int maxAttempts,
+        CancellationToken cancellationToken)
+    {
+        Exception = Guard.Against.Null(exception, nameof(exception));
+        Container = Guard.Against.Null(container, nameof(container));
+        ComponentName = Guard.Against.NullOrWhiteSpace(componentName, nameof(componentName));
+        ComponentKind = componentKind;
+        AttemptNumber = Guard.Against.NegativeOrZero(attemptNumber, nameof(attemptNumber));
+        MaxAttempts = Guard.Against.NegativeOrZero(maxAttempts, nameof(maxAttempts));
+        CancellationToken = cancellationToken;
+    }
+
+    public Exception Exception { get; }
+
+    public PipelineContainer<T> Container { get; }
+
+    public T Record => Container.Record;
+
+    public string ComponentName { get; }
+
+    public PipelineComponentKind ComponentKind { get; }
+
+    public int AttemptNumber { get; }
+
+    public int MaxAttempts { get; }
+
+    public CancellationToken CancellationToken { get; }
+}

--- a/src/Pipelinez/Core/Retry/PipelineRetryExecutor.cs
+++ b/src/Pipelinez/Core/Retry/PipelineRetryExecutor.cs
@@ -1,0 +1,93 @@
+using System.Diagnostics;
+using Ardalis.GuardClauses;
+using Pipelinez.Core.FaultHandling;
+using Pipelinez.Core.Record;
+
+namespace Pipelinez.Core.Retry;
+
+internal static class PipelineRetryExecutor
+{
+    public static async Task<TResult> ExecuteAsync<T, TResult>(
+        PipelineContainer<T> container,
+        PipelineRetryPolicy<T>? retryPolicy,
+        string componentName,
+        PipelineComponentKind componentKind,
+        Func<CancellationToken> cancellationTokenProvider,
+        Func<PipelineRetryAttempt, Exception, Task> onRetryingAsync,
+        Func<Task> onRetryRecoveredAsync,
+        Func<CancellationToken, Task<TResult>> operation)
+        where T : PipelineRecord
+    {
+        Guard.Against.Null(container, nameof(container));
+        Guard.Against.NullOrWhiteSpace(componentName, nameof(componentName));
+        Guard.Against.Null(cancellationTokenProvider, nameof(cancellationTokenProvider));
+        Guard.Against.Null(onRetryingAsync, nameof(onRetryingAsync));
+        Guard.Against.Null(onRetryRecoveredAsync, nameof(onRetryRecoveredAsync));
+        Guard.Against.Null(operation, nameof(operation));
+
+        var effectivePolicy = retryPolicy ?? PipelineRetryPolicy<T>.None();
+
+        for (var attemptNumber = 1; ; attemptNumber++)
+        {
+            var cancellationToken = cancellationTokenProvider();
+            var startedAtUtc = DateTimeOffset.UtcNow;
+            var stopwatch = Stopwatch.StartNew();
+
+            try
+            {
+                var result = await operation(cancellationToken).ConfigureAwait(false);
+                stopwatch.Stop();
+
+                if (attemptNumber > 1)
+                {
+                    await onRetryRecoveredAsync().ConfigureAwait(false);
+                }
+
+                return result;
+            }
+            catch (Exception exception) when (!(exception is OperationCanceledException && cancellationToken.IsCancellationRequested))
+            {
+                stopwatch.Stop();
+
+                var retryContext = new PipelineRetryContext<T>(
+                    exception,
+                    container,
+                    componentName,
+                    componentKind,
+                    attemptNumber,
+                    effectivePolicy.MaxAttempts,
+                    cancellationToken);
+
+                if (!effectivePolicy.CanRetry(retryContext))
+                {
+                    throw;
+                }
+
+                var delay = effectivePolicy.DelayProvider(retryContext);
+                if (delay < TimeSpan.Zero)
+                {
+                    throw new InvalidOperationException(
+                        $"Retry delay for component '{componentName}' cannot be negative.");
+                }
+
+                var retryAttempt = new PipelineRetryAttempt(
+                    attemptNumber,
+                    componentName,
+                    componentKind,
+                    startedAtUtc,
+                    startedAtUtc.Add(stopwatch.Elapsed),
+                    stopwatch.Elapsed,
+                    delay,
+                    exception.GetType().Name,
+                    exception.Message);
+
+                await onRetryingAsync(retryAttempt, exception).ConfigureAwait(false);
+
+                if (delay > TimeSpan.Zero)
+                {
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}

--- a/src/Pipelinez/Core/Retry/PipelineRetryOptions.cs
+++ b/src/Pipelinez/Core/Retry/PipelineRetryOptions.cs
@@ -1,0 +1,12 @@
+using Pipelinez.Core.Record;
+
+namespace Pipelinez.Core.Retry;
+
+public sealed class PipelineRetryOptions<T> where T : PipelineRecord
+{
+    public PipelineRetryPolicy<T>? DefaultSegmentPolicy { get; init; }
+
+    public PipelineRetryPolicy<T>? DestinationPolicy { get; init; }
+
+    public bool EmitRetryEvents { get; init; } = true;
+}

--- a/src/Pipelinez/Core/Retry/PipelineRetryPolicy.cs
+++ b/src/Pipelinez/Core/Retry/PipelineRetryPolicy.cs
@@ -1,0 +1,124 @@
+using Ardalis.GuardClauses;
+using Pipelinez.Core.Record;
+
+namespace Pipelinez.Core.Retry;
+
+public sealed class PipelineRetryPolicy<T> where T : PipelineRecord
+{
+    private readonly IReadOnlyList<Func<PipelineRetryContext<T>, bool>> _filters;
+
+    private PipelineRetryPolicy(
+        int maxAttempts,
+        Func<PipelineRetryContext<T>, TimeSpan> delayProvider,
+        IReadOnlyList<Func<PipelineRetryContext<T>, bool>> filters)
+    {
+        MaxAttempts = Guard.Against.NegativeOrZero(maxAttempts, nameof(maxAttempts));
+        DelayProvider = Guard.Against.Null(delayProvider, nameof(delayProvider));
+        _filters = Guard.Against.Null(filters, nameof(filters));
+    }
+
+    public int MaxAttempts { get; }
+
+    public Func<PipelineRetryContext<T>, TimeSpan> DelayProvider { get; }
+
+    public static PipelineRetryPolicy<T> None()
+    {
+        return new PipelineRetryPolicy<T>(
+            1,
+            _ => TimeSpan.Zero,
+            Array.Empty<Func<PipelineRetryContext<T>, bool>>());
+    }
+
+    public static PipelineRetryPolicy<T> FixedDelay(int maxAttempts, TimeSpan delay)
+    {
+        if (delay < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(delay), delay, "Retry delay must be zero or greater.");
+        }
+
+        return new PipelineRetryPolicy<T>(
+            maxAttempts,
+            _ => delay,
+            Array.Empty<Func<PipelineRetryContext<T>, bool>>());
+    }
+
+    public static PipelineRetryPolicy<T> ExponentialBackoff(
+        int maxAttempts,
+        TimeSpan initialDelay,
+        TimeSpan maxDelay,
+        bool useJitter = false)
+    {
+        if (initialDelay < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(initialDelay),
+                initialDelay,
+                "Initial retry delay must be zero or greater.");
+        }
+
+        if (maxDelay < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxDelay),
+                maxDelay,
+                "Maximum retry delay must be zero or greater.");
+        }
+
+        if (maxDelay < initialDelay)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxDelay),
+                maxDelay,
+                "Maximum retry delay must be greater than or equal to the initial delay.");
+        }
+
+        return new PipelineRetryPolicy<T>(
+            maxAttempts,
+            context =>
+            {
+                var multiplier = Math.Pow(2, Math.Max(context.AttemptNumber - 1, 0));
+                var unboundedMilliseconds = initialDelay.TotalMilliseconds * multiplier;
+                var cappedMilliseconds = Math.Min(unboundedMilliseconds, maxDelay.TotalMilliseconds);
+
+                if (!useJitter)
+                {
+                    return TimeSpan.FromMilliseconds(cappedMilliseconds);
+                }
+
+                return TimeSpan.FromMilliseconds(Random.Shared.NextDouble() * cappedMilliseconds);
+            },
+            Array.Empty<Func<PipelineRetryContext<T>, bool>>());
+    }
+
+    public PipelineRetryPolicy<T> Handle<TException>() where TException : Exception
+    {
+        return Handle(context => context.Exception is TException);
+    }
+
+    public PipelineRetryPolicy<T> Handle(Func<PipelineRetryContext<T>, bool> predicate)
+    {
+        Guard.Against.Null(predicate, nameof(predicate));
+
+        return new PipelineRetryPolicy<T>(
+            MaxAttempts,
+            DelayProvider,
+            _filters.Concat(new[] { predicate }).ToArray());
+    }
+
+    internal bool CanRetry(PipelineRetryContext<T> context)
+    {
+        Guard.Against.Null(context, nameof(context));
+
+        if (context.AttemptNumber >= MaxAttempts)
+        {
+            return false;
+        }
+
+        if (_filters.Count == 0)
+        {
+            return true;
+        }
+
+        return _filters.Any(filter => filter(context));
+    }
+}

--- a/src/Pipelinez/Core/Segment/PipelineSegment.cs
+++ b/src/Pipelinez/Core/Segment/PipelineSegment.cs
@@ -7,13 +7,16 @@ using Pipelinez.Core.Flow;
 using Pipelinez.Core.Logging;
 using Pipelinez.Core.Performance;
 using Pipelinez.Core.Record;
+using Pipelinez.Core.Retry;
 
 namespace Pipelinez.Core.Segment;
 
-public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecutionConfigurable, IPipelinePerformanceAware where T : PipelineRecord
+public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecutionConfigurable, IPipelinePerformanceAware, IPipelineRetryConfigurable<T> where T : PipelineRecord
 {
     private TransformBlock<PipelineContainer<T>, PipelineContainer<T>>? _transformBlock;
+    private Pipeline<T>? _parentPipeline;
     private PipelineExecutionOptions _executionOptions = PipelineExecutionOptions.CreateDefaultSegmentOptions();
+    private PipelineRetryPolicy<T>? _retryPolicy;
     private IPipelinePerformanceCollector? _performanceCollector;
     private string _componentName = "Segment";
 
@@ -93,9 +96,29 @@ public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecuti
         try
         {
             Logger.LogTrace("Executing Segment");
-            
-            // Execute the worker method
-            var finalResult = await transformMethod(arg.Record).ConfigureAwait(false);
+
+            var finalResult = await PipelineRetryExecutor.ExecuteAsync(
+                    arg,
+                    _retryPolicy,
+                    segmentName,
+                    PipelineComponentKind.Segment,
+                    () => ParentPipeline.GetRuntimeCancellationToken(),
+                    async (retryAttempt, exception) =>
+                    {
+                        arg.AddRetryAttempt(retryAttempt);
+                        await ParentPipeline.NotifyRecordRetryingAsync(
+                            arg,
+                            retryAttempt,
+                            _retryPolicy?.MaxAttempts ?? 1,
+                            exception).ConfigureAwait(false);
+                    },
+                    () =>
+                    {
+                        ParentPipeline.NotifyRetryRecovered();
+                        return Task.CompletedTask;
+                    },
+                    _ => transformMethod(arg.Record))
+                .ConfigureAwait(false);
 
             if (finalResult is null)
             {
@@ -161,6 +184,17 @@ public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecuti
         return _executionOptions;
     }
 
+    public void ConfigureRetryPolicy(PipelineRetryPolicy<T>? retryPolicy)
+    {
+        EnsureExecutionOptionsCanBeChanged();
+        _retryPolicy = retryPolicy;
+    }
+
+    public PipelineRetryPolicy<T>? GetRetryPolicy()
+    {
+        return _retryPolicy;
+    }
+
     void IPipelinePerformanceAware.ConfigurePerformanceCollector(
         IPipelinePerformanceCollector performanceCollector,
         string componentName)
@@ -190,4 +224,12 @@ public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecuti
                 $"Execution options for segment '{GetType().Name}' must be configured before the segment is linked or used.");
         }
     }
+
+    internal void Initialize(Pipeline<T> parentPipeline)
+    {
+        _parentPipeline = Guard.Against.Null(parentPipeline, nameof(parentPipeline));
+    }
+
+    private Pipeline<T> ParentPipeline =>
+        _parentPipeline ?? throw new InvalidOperationException("Pipeline segment has not been initialized.");
 }

--- a/src/tests/Pipelinez.Kafka.Tests/EndToEnd/KafkaPipelineRetryTests.cs
+++ b/src/tests/Pipelinez.Kafka.Tests/EndToEnd/KafkaPipelineRetryTests.cs
@@ -1,0 +1,79 @@
+using Confluent.Kafka;
+using Pipelinez.Core;
+using Pipelinez.Core.Eventing;
+using Pipelinez.Core.Retry;
+using Pipelinez.Kafka;
+using Pipelinez.Kafka.Tests.Infrastructure;
+using Pipelinez.Kafka.Tests.Models;
+using Xunit;
+
+namespace Pipelinez.Kafka.Tests.EndToEnd;
+
+[Collection(KafkaIntegrationCollection.Name)]
+public sealed class KafkaPipelineRetryTests(KafkaTestCluster cluster)
+{
+    [Fact]
+    public async Task KafkaPipeline_Segment_Retry_Recovers_And_Produces_Output()
+    {
+        var scenarioName = nameof(KafkaPipeline_Segment_Retry_Recovers_And_Produces_Output);
+        var sourceTopic = await cluster.CreateTopicAsync($"{scenarioName}-source").ConfigureAwait(false);
+        var destinationTopic = await cluster.CreateTopicAsync($"{scenarioName}-destination").ConfigureAwait(false);
+        var consumerGroup = KafkaTopicNameFactory.CreateConsumerGroupName("pipelinez", scenarioName);
+        var retryEvents = new List<PipelineRecordRetryingEventArgs<TestKafkaRecord>>();
+
+        var pipeline = Pipeline<TestKafkaRecord>.New(scenarioName)
+            .UseRetryOptions(new PipelineRetryOptions<TestKafkaRecord>
+            {
+                DefaultSegmentPolicy = PipelineRetryPolicy<TestKafkaRecord>
+                    .FixedDelay(3, TimeSpan.Zero)
+                    .Handle<InvalidOperationException>()
+            })
+            .WithKafkaSource(
+                cluster.CreateSourceOptions(sourceTopic, consumerGroup),
+                (string key, string value) => new TestKafkaRecord
+                {
+                    Key = key,
+                    Value = value
+                })
+            .AddSegment(new FlakyKafkaSegment(), new object())
+            .WithKafkaDestination(
+                cluster.CreateDestinationOptions(destinationTopic),
+                (TestKafkaRecord record) => new Message<string, string>
+                {
+                    Key = record.Key,
+                    Value = record.Value
+                })
+            .Build();
+
+        pipeline.OnPipelineRecordRetrying += (_, args) => retryEvents.Add(args);
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+
+        await cluster.ProduceAsync(
+            sourceTopic,
+            new[]
+            {
+                KafkaPipelineTestHelpers.CreateMessage("retry-1", "value")
+            }).ConfigureAwait(false);
+
+        var outputMessages = await cluster
+            .ConsumeAsync(
+                destinationTopic,
+                expectedCount: 1,
+                consumerGroup: KafkaTopicNameFactory.CreateConsumerGroupName("probe", scenarioName))
+            .ConfigureAwait(false);
+
+        await pipeline.CompleteAsync().ConfigureAwait(false);
+        await pipeline.Completion.ConfigureAwait(false);
+
+        Assert.Single(retryEvents);
+        Assert.Single(outputMessages);
+        Assert.Equal("retry-1", outputMessages[0].Message.Key);
+        Assert.Equal("value|retried", outputMessages[0].Message.Value);
+
+        var snapshot = pipeline.GetPerformanceSnapshot();
+        Assert.Equal(1, snapshot.TotalRetryCount);
+        Assert.Equal(1, snapshot.SuccessfulRetryRecoveries);
+        Assert.Equal(0, snapshot.RetryExhaustions);
+    }
+}

--- a/src/tests/Pipelinez.Kafka.Tests/Models/FlakyKafkaSegment.cs
+++ b/src/tests/Pipelinez.Kafka.Tests/Models/FlakyKafkaSegment.cs
@@ -1,0 +1,22 @@
+using System.Collections.Concurrent;
+using Pipelinez.Core.Segment;
+
+namespace Pipelinez.Kafka.Tests.Models;
+
+public sealed class FlakyKafkaSegment : PipelineSegment<TestKafkaRecord>
+{
+    private readonly ConcurrentDictionary<string, int> _attempts = new(StringComparer.Ordinal);
+
+    public override Task<TestKafkaRecord> ExecuteAsync(TestKafkaRecord arg)
+    {
+        var attempts = _attempts.AddOrUpdate(arg.Key, 1, (_, current) => current + 1);
+
+        if (attempts == 1)
+        {
+            throw new InvalidOperationException("Kafka segment failed transiently.");
+        }
+
+        arg.Value = $"{arg.Value}|retried";
+        return Task.FromResult(arg);
+    }
+}

--- a/src/tests/Pipelinez.Tests/Core/RetryTests/Models/FlakyDestination.cs
+++ b/src/tests/Pipelinez.Tests/Core/RetryTests/Models/FlakyDestination.cs
@@ -1,0 +1,35 @@
+using Pipelinez.Core.Destination;
+using Pipelinez.Tests.Core.SourceDestTests.Models;
+
+namespace Pipelinez.Tests.Core.RetryTests.Models;
+
+public sealed class FlakyDestination : PipelineDestination<TestPipelineRecord>
+{
+    private int _remainingFailures;
+
+    public FlakyDestination(int failuresBeforeSuccess)
+    {
+        _remainingFailures = failuresBeforeSuccess;
+    }
+
+    public int Attempts { get; private set; }
+
+    public List<string> ReceivedRecords { get; } = new();
+
+    protected override Task ExecuteAsync(TestPipelineRecord record, CancellationToken cancellationToken)
+    {
+        Attempts++;
+
+        if (_remainingFailures-- > 0)
+        {
+            throw new RetryTestException("Destination failed transiently.");
+        }
+
+        ReceivedRecords.Add(record.Data);
+        return Task.CompletedTask;
+    }
+
+    protected override void Initialize()
+    {
+    }
+}

--- a/src/tests/Pipelinez.Tests/Core/RetryTests/Models/FlakySegment.cs
+++ b/src/tests/Pipelinez.Tests/Core/RetryTests/Models/FlakySegment.cs
@@ -1,0 +1,36 @@
+using Pipelinez.Core.Segment;
+using Pipelinez.Tests.Core.SourceDestTests.Models;
+
+namespace Pipelinez.Tests.Core.RetryTests.Models;
+
+public sealed class FlakySegment : PipelineSegment<TestPipelineRecord>
+{
+    private int _remainingFailures;
+    private readonly bool _throwNonRetryable;
+
+    public FlakySegment(int failuresBeforeSuccess, bool throwNonRetryable = false)
+    {
+        _remainingFailures = failuresBeforeSuccess;
+        _throwNonRetryable = throwNonRetryable;
+    }
+
+    public int Attempts { get; private set; }
+
+    public override Task<TestPipelineRecord> ExecuteAsync(TestPipelineRecord arg)
+    {
+        Attempts++;
+
+        if (_remainingFailures-- > 0)
+        {
+            if (_throwNonRetryable)
+            {
+                throw new NonRetryableTestException("Segment threw a non-retryable exception.");
+            }
+
+            throw new RetryTestException("Segment failed transiently.");
+        }
+
+        arg.Data = $"{arg.Data}|segment-ok";
+        return Task.FromResult(arg);
+    }
+}

--- a/src/tests/Pipelinez.Tests/Core/RetryTests/Models/NonRetryableTestException.cs
+++ b/src/tests/Pipelinez.Tests/Core/RetryTests/Models/NonRetryableTestException.cs
@@ -1,0 +1,8 @@
+namespace Pipelinez.Tests.Core.RetryTests.Models;
+
+public sealed class NonRetryableTestException : InvalidOperationException
+{
+    public NonRetryableTestException(string message) : base(message)
+    {
+    }
+}

--- a/src/tests/Pipelinez.Tests/Core/RetryTests/Models/RetryTestException.cs
+++ b/src/tests/Pipelinez.Tests/Core/RetryTests/Models/RetryTestException.cs
@@ -1,0 +1,8 @@
+namespace Pipelinez.Tests.Core.RetryTests.Models;
+
+public sealed class RetryTestException : InvalidOperationException
+{
+    public RetryTestException(string message) : base(message)
+    {
+    }
+}

--- a/src/tests/Pipelinez.Tests/Core/RetryTests/PipelineRetryPolicyTests.cs
+++ b/src/tests/Pipelinez.Tests/Core/RetryTests/PipelineRetryPolicyTests.cs
@@ -1,0 +1,164 @@
+using Pipelinez.Core;
+using Pipelinez.Core.ErrorHandling;
+using Pipelinez.Core.Eventing;
+using Pipelinez.Core.Retry;
+using Pipelinez.Core.Status;
+using Pipelinez.Tests.Core.RetryTests.Models;
+using Pipelinez.Tests.Core.SourceDestTests.Models;
+
+namespace Pipelinez.Tests.Core.RetryTests;
+
+public class PipelineRetryPolicyTests
+{
+    [Fact]
+    public async Task Pipeline_Segment_Retry_Recovers_And_Emits_Retry_Event()
+    {
+        var segment = new FlakySegment(failuresBeforeSuccess: 1);
+        var retryEvents = new List<PipelineRecordRetryingEventArgs<TestPipelineRecord>>();
+        var completedRecords = new List<TestPipelineRecord>();
+
+        var pipeline = Pipeline<TestPipelineRecord>.New("segment-retry-recovers")
+            .UseRetryOptions(new PipelineRetryOptions<TestPipelineRecord>
+            {
+                DefaultSegmentPolicy = PipelineRetryPolicy<TestPipelineRecord>
+                    .FixedDelay(3, TimeSpan.Zero)
+                    .Handle<RetryTestException>()
+            })
+            .WithInMemorySource(new object())
+            .AddSegment(segment, new object())
+            .WithInMemoryDestination("config")
+            .Build();
+
+        pipeline.OnPipelineRecordRetrying += (_, args) => retryEvents.Add(args);
+        pipeline.OnPipelineRecordCompleted += (_, args) => completedRecords.Add(args.Record);
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = "good" }).ConfigureAwait(false);
+        await pipeline.CompleteAsync().ConfigureAwait(false);
+        await pipeline.Completion.ConfigureAwait(false);
+
+        Assert.Single(retryEvents);
+        Assert.Single(completedRecords);
+        Assert.Equal("good|segment-ok", completedRecords[0].Data);
+        Assert.Equal(2, segment.Attempts);
+        Assert.Equal(1, retryEvents[0].AttemptNumber);
+        Assert.Equal(nameof(FlakySegment), retryEvents[0].ComponentName);
+
+        var snapshot = pipeline.GetPerformanceSnapshot();
+        Assert.Equal(1, snapshot.TotalRetryCount);
+        Assert.Equal(1, snapshot.SuccessfulRetryRecoveries);
+        Assert.Equal(0, snapshot.RetryExhaustions);
+        Assert.Equal(PipelineExecutionStatus.Completed, pipeline.GetStatus().Status);
+    }
+
+    [Fact]
+    public async Task Pipeline_Destination_Retry_Recovers_And_Completes()
+    {
+        var destination = new FlakyDestination(failuresBeforeSuccess: 2);
+
+        var pipeline = Pipeline<TestPipelineRecord>.New("destination-retry-recovers")
+            .UseRetryOptions(new PipelineRetryOptions<TestPipelineRecord>
+            {
+                DestinationPolicy = PipelineRetryPolicy<TestPipelineRecord>
+                    .FixedDelay(4, TimeSpan.Zero)
+                    .Handle<RetryTestException>()
+            })
+            .WithInMemorySource(new object())
+            .AddSegment(new FlakySegment(failuresBeforeSuccess: 0), new object())
+            .WithDestination(destination)
+            .Build();
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = "good" }).ConfigureAwait(false);
+        await pipeline.CompleteAsync().ConfigureAwait(false);
+        await pipeline.Completion.ConfigureAwait(false);
+
+        Assert.Equal(3, destination.Attempts);
+        Assert.Single(destination.ReceivedRecords);
+        Assert.Equal("good|segment-ok", destination.ReceivedRecords[0]);
+
+        var snapshot = pipeline.GetPerformanceSnapshot();
+        Assert.Equal(2, snapshot.TotalRetryCount);
+        Assert.Equal(1, snapshot.SuccessfulRetryRecoveries);
+        Assert.Equal(0, snapshot.RetryExhaustions);
+    }
+
+    [Fact]
+    public async Task Pipeline_Retry_Exhaustion_Flows_Into_Error_Handler_Context()
+    {
+        PipelineErrorContext<TestPipelineRecord>? capturedContext = null;
+        var retryEvents = new List<PipelineRecordRetryingEventArgs<TestPipelineRecord>>();
+
+        var pipeline = Pipeline<TestPipelineRecord>.New("retry-exhaustion")
+            .UseRetryOptions(new PipelineRetryOptions<TestPipelineRecord>
+            {
+                DefaultSegmentPolicy = PipelineRetryPolicy<TestPipelineRecord>
+                    .FixedDelay(2, TimeSpan.Zero)
+                    .Handle<RetryTestException>()
+            })
+            .WithInMemorySource(new object())
+            .AddSegment(new FlakySegment(failuresBeforeSuccess: 5), new object())
+            .WithInMemoryDestination("config")
+            .WithErrorHandler(context =>
+            {
+                capturedContext = context;
+                return PipelineErrorAction.SkipRecord;
+            })
+            .Build();
+
+        pipeline.OnPipelineRecordRetrying += (_, args) => retryEvents.Add(args);
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = "bad" }).ConfigureAwait(false);
+        await pipeline.CompleteAsync().ConfigureAwait(false);
+        await pipeline.Completion.ConfigureAwait(false);
+
+        Assert.Single(retryEvents);
+        Assert.NotNull(capturedContext);
+        Assert.True(capturedContext!.RetryExhausted);
+        Assert.Equal(1, capturedContext.RetryAttemptCount);
+        Assert.Single(capturedContext.RetryHistory);
+        Assert.True(capturedContext.Container.HasFault);
+
+        var snapshot = pipeline.GetPerformanceSnapshot();
+        Assert.Equal(1, snapshot.TotalRetryCount);
+        Assert.Equal(0, snapshot.SuccessfulRetryRecoveries);
+        Assert.Equal(1, snapshot.RetryExhaustions);
+    }
+
+    [Fact]
+    public async Task Pipeline_Retry_Filter_Does_Not_Retry_NonMatching_Exceptions()
+    {
+        PipelineErrorContext<TestPipelineRecord>? capturedContext = null;
+        var retryEvents = new List<PipelineRecordRetryingEventArgs<TestPipelineRecord>>();
+
+        var pipeline = Pipeline<TestPipelineRecord>.New("retry-filter")
+            .UseRetryOptions(new PipelineRetryOptions<TestPipelineRecord>
+            {
+                DefaultSegmentPolicy = PipelineRetryPolicy<TestPipelineRecord>
+                    .FixedDelay(4, TimeSpan.Zero)
+                    .Handle<RetryTestException>()
+            })
+            .WithInMemorySource(new object())
+            .AddSegment(new FlakySegment(failuresBeforeSuccess: 1, throwNonRetryable: true), new object())
+            .WithInMemoryDestination("config")
+            .WithErrorHandler(context =>
+            {
+                capturedContext = context;
+                return PipelineErrorAction.SkipRecord;
+            })
+            .Build();
+
+        pipeline.OnPipelineRecordRetrying += (_, args) => retryEvents.Add(args);
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = "bad" }).ConfigureAwait(false);
+        await pipeline.CompleteAsync().ConfigureAwait(false);
+        await pipeline.Completion.ConfigureAwait(false);
+
+        Assert.Empty(retryEvents);
+        Assert.NotNull(capturedContext);
+        Assert.False(capturedContext!.RetryExhausted);
+        Assert.Equal(0, capturedContext.RetryAttemptCount);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds first-class retry support to Pipelinez so transient failures in segments and destinations can be retried before entering terminal fault handling.

## What Changed

### Retry configuration
- Added pipeline-level retry configuration through `UseRetryOptions(...)`
- Added per-segment retry overrides on `AddSegment(...)`
- Added per-destination retry overrides on `WithDestination(...)`
- Added built-in retry policy factories for:
  - no retry
  - fixed delay retry
  - exponential backoff retry with optional jitter
- Added exception filtering through typed and predicate-based policy handlers

### Runtime retry execution
- Added a shared retry executor used by both segment and destination execution paths
- Retries now happen before a record is marked faulted
- Successful recovery keeps the record flowing normally without leaving fault state behind
- Retry delays honor pipeline cancellation and shutdown

### Retry observability
- Added `RetryHistory` to `PipelineContainer<T>`
- Added `OnPipelineRecordRetrying`
- Added retry-aware error context so handlers can inspect:
  - retry history
  - retry attempt count
  - whether retries were exhausted
- Added retry counters to runtime performance snapshots:
  - total retries
  - successful retry recoveries
  - retry exhaustions

### Fault-handling integration
- Retry exhaustion now flows into the existing error-handler path
- `WithErrorHandler(...)` remains the terminal decision point after retries are exhausted
- Existing `SkipRecord`, `StopPipeline`, and `Rethrow` behavior is preserved after retry completion

## Testing
Added coverage for:
- no-retry behavior
- fixed-delay retry success
- exponential-backoff retry success
- retry exhaustion
- exception-type retry filtering
- retry predicate filtering
- retry event emission
- retry-aware error handling
- transient retry recovery in Kafka-backed execution

## Result
Pipelinez now distinguishes cleanly between transient failures and terminal failures, while keeping retry behavior explicit, observable, and consistent across the runtime.