### PR TITLE
Adding Flow control

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Pipelinez is a small .NET 8 framework for building record-processing pipelines w
 - async startup and completion
 - fault tracking and configurable error policies
 - configurable retry policies for segments and destinations
+- explicit flow control and saturation observability
 - optional distributed execution for transport-backed sources
 - explicit performance tuning and runtime performance snapshots
 - transport extensions such as Kafka
@@ -196,6 +197,57 @@ Console.WriteLine(snapshot.RecordsPerSecond);
 
 Increasing parallelism or disabling ordering can improve throughput, but it can also change observable processing order. Those settings should be treated as explicit tradeoffs rather than passive defaults.
 
+## Flow Control
+
+Pipelinez now exposes explicit publish-time flow-control behavior in addition to component `BoundedCapacity` tuning.
+
+Flow control can be configured through:
+
+- `UseFlowControlOptions(...)`
+- `PublishAsync(record, PipelinePublishOptions)`
+
+Supported overflow behaviors include:
+
+- `PipelineOverflowPolicy.Wait`
+- `PipelineOverflowPolicy.Reject`
+- `PipelineOverflowPolicy.Cancel`
+
+Example shape:
+
+```csharp
+using Pipelinez.Core.FlowControl;
+
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .UsePerformanceOptions(new PipelinePerformanceOptions
+    {
+        SourceExecution = new PipelineExecutionOptions { BoundedCapacity = 100 },
+        DestinationExecution = new PipelineExecutionOptions { BoundedCapacity = 100 }
+    })
+    .UseFlowControlOptions(new PipelineFlowControlOptions
+    {
+        OverflowPolicy = PipelineOverflowPolicy.Wait,
+        PublishTimeout = TimeSpan.FromSeconds(5),
+        SaturationWarningThreshold = 0.8
+    })
+    .WithInMemorySource(new object())
+    .WithInMemoryDestination("config")
+    .Build();
+
+var publishResult = await pipeline.PublishAsync(
+    new MyRecord(),
+    new PipelinePublishOptions
+    {
+        OverflowPolicyOverride = PipelineOverflowPolicy.Reject
+    });
+
+if (!publishResult.Accepted)
+{
+    Console.WriteLine($"Publish was not accepted: {publishResult.Reason}");
+}
+```
+
+The runtime now also surfaces flow pressure through `GetStatus().FlowControlStatus`, `OnSaturationChanged`, `OnPublishRejected`, and publish wait/rejection counters in `GetPerformanceSnapshot()`.
+
 ## Retry Policies
 
 Pipelinez supports explicit retry policies for transient failures in segments and destinations.
@@ -261,6 +313,8 @@ Available actions:
 Public events include:
 
 - `OnPipelineRecordRetrying`
+- `OnSaturationChanged`
+- `OnPublishRejected`
 - `OnPipelineRecordCompleted`
 - `OnPipelineRecordFaulted`
 - `OnPipelineFaulted`
@@ -327,6 +381,7 @@ Current implemented capabilities include:
 - segment execution history
 - configurable error policies
 - configurable retry policies with retry events and retry history
+- configurable flow-control policies with saturation status and publish result handling
 - async destination execution
 - distributed runtime mode and worker/partition observability
 - performance tuning options, batching support, and runtime performance snapshots

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -52,6 +52,7 @@ The core builder currently supports:
 - `WithDestination(...)`
 - `WithInMemoryDestination(...)`
 - `UseHostOptions(...)`
+- `UseFlowControlOptions(...)`
 - `UsePerformanceOptions(...)`
 - `UseRetryOptions(...)`
 - `UseLogger(...)`
@@ -94,6 +95,7 @@ Sources derive from `PipelineSourceBase<T>`, which owns a `BufferBlock<PipelineC
 Responsibilities:
 
 - publish records manually through `PublishAsync`
+- publish records with explicit flow-control behavior through `PublishAsync(..., PipelinePublishOptions)`
 - optionally produce records from an external system inside `MainLoop(...)`
 - link to the next pipeline component
 - observe completed containers through `OnPipelineContainerComplete(...)`
@@ -147,6 +149,7 @@ The runtime lifecycle is:
 Important current semantics:
 
 - `StartPipelineAsync(...)` returns `Task`
+- `PublishAsync(record, PipelinePublishOptions)` returns `PipelinePublishResult`
 - starting twice throws
 - publishing before start throws
 - completing before start throws
@@ -193,6 +196,10 @@ Segment defaults remain conservative, but callers can now opt into higher-throug
 - total retry count
 - successful retry recovery count
 - retry exhaustion count
+- total publish wait count
+- average publish wait duration
+- total publish rejection count
+- peak buffered count
 - calculated records-per-second
 - average end-to-end latency
 - per-component performance snapshots
@@ -220,6 +227,58 @@ When batching is enabled:
 - batch failures are converted into per-record fault handling so the existing error-policy model remains in control
 
 This is intended for throughput-oriented destinations and should be used carefully because batching improves throughput at the cost of per-record latency.
+
+## Flow Control Model
+
+Pipelinez now has an explicit flow-control model layered on top of component bounded capacities.
+
+### Flow Control Configuration
+
+Flow behavior is configured through `UseFlowControlOptions(...)`.
+
+`PipelineFlowControlOptions` controls:
+
+- `OverflowPolicy`
+- `PublishTimeout`
+- `EmitSaturationEvents`
+- `SaturationWarningThreshold`
+
+Per-call overrides can then be supplied through `PublishAsync(record, PipelinePublishOptions)`.
+
+Supported overflow behaviors are:
+
+- `Wait`
+- `Reject`
+- `Cancel`
+
+### Publish Semantics
+
+Manual publishing now has two shapes:
+
+- `PublishAsync(T record)`
+- `PublishAsync(T record, PipelinePublishOptions options)`
+
+The overload with options returns `PipelinePublishResult`, which tells the caller whether the record was accepted and, if not, whether it was rejected, timed out, or canceled.
+
+The convenience overload still exists for callers that want exception-based behavior.
+
+### Flow Status And Events
+
+`PipelineStatus` now carries `FlowControlStatus`, which exposes:
+
+- current overflow policy
+- pipeline saturation state
+- saturation ratio
+- total buffered count
+- total bounded capacity
+- per-component queue depth and saturation
+
+The public event surface now also includes:
+
+- `OnSaturationChanged`
+- `OnPublishRejected`
+
+This makes pressure visible as operating state instead of only as a side effect of blocked tasks.
 
 ## Distributed Execution Model
 
@@ -365,6 +424,10 @@ The pipeline exposes:
 
 - `OnPipelineRecordRetrying`
   raised when a record is scheduled for another attempt after a retryable failure
+- `OnSaturationChanged`
+  raised when the pipeline crosses or clears the configured saturation warning threshold or full saturation state
+- `OnPublishRejected`
+  raised when a publish request is not accepted because it timed out, was canceled, or was rejected by overflow policy
 - `OnPipelineRecordCompleted`
   raised after a record successfully completes the entire pipeline
 - `OnPipelineRecordFaulted`
@@ -422,8 +485,10 @@ Reported execution status is derived from task state and runtime fault state:
 
 For distributed sources, this status reflects live ownership while the worker is active. For Kafka specifically, owned partitions are cleared on shutdown when the consumer leaves the group and revocation is observed.
 
+`PipelineStatus` now also carries `FlowControlStatus`, which exposes queue pressure and bounded-capacity saturation across the source, segments, and destination.
+
 Logging is managed through the internal `LoggingManager`, which wraps an `ILoggerFactory`. If the caller never supplies a logger factory, the runtime falls back to a null logger factory.
-The runtime now also exposes additive performance metrics through `GetPerformanceSnapshot()` rather than relying only on logs for throughput diagnostics, including retry counts and retry recovery/exhaustion totals.
+The runtime now also exposes additive performance metrics through `GetPerformanceSnapshot()` rather than relying only on logs for throughput diagnostics, including retry counts, retry recovery/exhaustion totals, publish wait totals, publish rejection totals, and peak buffered depth.
 
 ## Kafka Integration
 
@@ -520,6 +585,7 @@ The solution now includes two test layers.
 - async destination behavior
 - fault tracking and pipeline fault events
 - error-handler policies
+- flow-control wait, reject, cancel, status, and saturation event behavior
 - retry policy behavior, retry events, retry exhaustion, and retry-aware error handling
 - logger integration
 - builder-surface expectations
@@ -538,6 +604,7 @@ The solution now includes two test layers.
 - destination fault handling
 - record-fault and pipeline-fault event behavior
 - transient segment failures that recover under retry
+- downstream pressure slowing Kafka-backed ingress safely without faulting the pipeline
 - offset commit and replay behavior across pipeline runs
 - distributed worker startup, rebalance, and shutdown behavior across multiple pipeline instances
 - record-level worker and partition context on successful and faulted records
@@ -560,6 +627,7 @@ The major architectural work called out in the earlier planning docs has been im
 - explicit distributed execution mode with worker identity, partition ownership, and rebalance events
 - explicit performance tuning controls, built-in performance snapshots, destination batching, and a benchmark project
 - explicit retry policies with retry history, retry events, and retry-aware performance counters
+- explicit flow-control policies with publish results, saturation status, and pressure metrics
 
 The remaining work is mostly future evolution work rather than foundational cleanup. Likely areas include broader transport coverage, schema-registry integration tests, and further runtime ergonomics.
 
@@ -571,15 +639,17 @@ The simplest way to think about Pipelinez is:
 2. choose where records come from
 3. chain one or more `PipelineSegment<T>` transforms
 4. choose where processed records end up
-5. optionally configure retry behavior through `UseRetryOptions(...)`
-6. optionally configure fault policy through `WithErrorHandler(...)`
-7. observe retry, success, or failure through the public pipeline events
+5. optionally configure flow control through `UseFlowControlOptions(...)`
+6. optionally configure retry behavior through `UseRetryOptions(...)`
+7. optionally configure fault policy through `WithErrorHandler(...)`
+8. observe pressure, retry, success, or failure through the public pipeline events
 
 Under the hood, Pipelinez is a thin framework over TPL Dataflow that standardizes:
 
 - record wrapping
 - metadata flow
 - fault capture
+- flow control
 - retry execution
 - completion semantics
 - logging

--- a/src/Pipelinez/Core/Destination/PipelineDestination.cs
+++ b/src/Pipelinez/Core/Destination/PipelineDestination.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Pipelinez.Core.ErrorHandling;
 using Pipelinez.Core.Eventing;
 using Pipelinez.Core.FaultHandling;
+using Pipelinez.Core.FlowControl;
 using Pipelinez.Core.Logging;
 using Pipelinez.Core.Performance;
 using Pipelinez.Core.Record;
@@ -13,7 +14,7 @@ using Pipelinez.Core.Retry;
 
 namespace Pipelinez.Core.Destination;
 
-public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelineExecutionConfigurable, IPipelinePerformanceAware, IPipelineBatchingAware, IPipelineRetryConfigurable<T>
+public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelineExecutionConfigurable, IPipelinePerformanceAware, IPipelineBatchingAware, IPipelineRetryConfigurable<T>, IPipelineFlowStatusProvider
     where T : PipelineRecord
 {
     private BufferBlock<PipelineContainer<T>>? _messageBuffer;
@@ -118,6 +119,7 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
             try
             {
                 sourceRecord = await MessageBuffer.ReceiveAsync(cancellationToken.Token).ConfigureAwait(false);
+                ParentPipeline.ObserveFlowControlState();
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -155,6 +157,7 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
                 try
                 {
                     nextContainer = await MessageBuffer.ReceiveAsync(cancellationToken.Token).ConfigureAwait(false);
+                    ParentPipeline.ObserveFlowControlState();
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
@@ -339,6 +342,8 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
                     new PipelineContainerCompletedEventHandlerArgs<PipelineContainer<T>>(container));
             }
 
+            ParentPipeline.ObserveFlowControlState();
+
             return true;
         }
         catch (Exception e)
@@ -363,6 +368,8 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
                     return false;
                 }
             }
+
+            ParentPipeline.ObserveFlowControlState();
 
             return true;
         }
@@ -408,6 +415,18 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
             BoundedCapacity = _executionOptions.BoundedCapacity,
             EnsureOrdered = _executionOptions.EnsureOrdered
         });
+
+    int IPipelineFlowStatusProvider.GetApproximateQueueDepth()
+    {
+        return MessageBuffer.Count;
+    }
+
+    int? IPipelineFlowStatusProvider.GetBoundedCapacity()
+    {
+        return _executionOptions.BoundedCapacity == DataflowBlockOptions.Unbounded
+            ? null
+            : _executionOptions.BoundedCapacity;
+    }
 
     private void EnsureExecutionOptionsCanBeChanged()
     {

--- a/src/Pipelinez/Core/Eventing/Eventing.cs
+++ b/src/Pipelinez/Core/Eventing/Eventing.cs
@@ -52,6 +52,14 @@ public delegate void PipelineRecordRetryingEventHandler<T>(
     object sender,
     PipelineRecordRetryingEventArgs<T> args) where T : PipelineRecord;
 
+public delegate void PipelineSaturationChangedEventHandler(
+    object sender,
+    PipelineSaturationChangedEventArgs args);
+
+public delegate void PipelinePublishRejectedEventHandler<T>(
+    object sender,
+    PipelinePublishRejectedEventArgs<T> args) where T : PipelineRecord;
+
 public sealed class PipelineRecordFaultedEventArgs<T> where T : PipelineRecord
 {
     public PipelineRecordFaultedEventArgs(
@@ -114,6 +122,44 @@ public sealed class PipelineRecordRetryingEventArgs<T> where T : PipelineRecord
     public PipelineComponentKind ComponentKind => Fault.ComponentKind;
 
     public Exception Exception => Fault.Exception;
+}
+
+public sealed class PipelineSaturationChangedEventArgs
+{
+    public PipelineSaturationChangedEventArgs(
+        double saturationRatio,
+        bool isSaturated,
+        DateTimeOffset observedAtUtc)
+    {
+        SaturationRatio = saturationRatio;
+        IsSaturated = isSaturated;
+        ObservedAtUtc = observedAtUtc;
+    }
+
+    public double SaturationRatio { get; }
+
+    public bool IsSaturated { get; }
+
+    public DateTimeOffset ObservedAtUtc { get; }
+}
+
+public sealed class PipelinePublishRejectedEventArgs<T> where T : PipelineRecord
+{
+    public PipelinePublishRejectedEventArgs(
+        T record,
+        FlowControl.PipelinePublishResultReason reason,
+        DateTimeOffset observedAtUtc)
+    {
+        Record = Guard.Against.Null(record, nameof(record));
+        Reason = reason;
+        ObservedAtUtc = observedAtUtc;
+    }
+
+    public T Record { get; }
+
+    public FlowControl.PipelinePublishResultReason Reason { get; }
+
+    public DateTimeOffset ObservedAtUtc { get; }
 }
 
 public delegate void PipelineFaultedEventHandler(object sender, PipelineFaultedEventArgs args);

--- a/src/Pipelinez/Core/FlowControl/IPipelineFlowStatusProvider.cs
+++ b/src/Pipelinez/Core/FlowControl/IPipelineFlowStatusProvider.cs
@@ -1,0 +1,8 @@
+namespace Pipelinez.Core.FlowControl;
+
+internal interface IPipelineFlowStatusProvider
+{
+    int GetApproximateQueueDepth();
+
+    int? GetBoundedCapacity();
+}

--- a/src/Pipelinez/Core/FlowControl/PipelineComponentFlowStatus.cs
+++ b/src/Pipelinez/Core/FlowControl/PipelineComponentFlowStatus.cs
@@ -1,0 +1,26 @@
+namespace Pipelinez.Core.FlowControl;
+
+public sealed class PipelineComponentFlowStatus
+{
+    public PipelineComponentFlowStatus(
+        string name,
+        int approximateQueueDepth,
+        int? boundedCapacity)
+    {
+        Name = name;
+        ApproximateQueueDepth = approximateQueueDepth;
+        BoundedCapacity = boundedCapacity;
+    }
+
+    public string Name { get; }
+
+    public int ApproximateQueueDepth { get; }
+
+    public int? BoundedCapacity { get; }
+
+    public bool IsSaturated => BoundedCapacity.HasValue && ApproximateQueueDepth >= BoundedCapacity.Value;
+
+    public double SaturationRatio => BoundedCapacity.HasValue && BoundedCapacity.Value > 0
+        ? Math.Min(1d, (double)ApproximateQueueDepth / BoundedCapacity.Value)
+        : 0d;
+}

--- a/src/Pipelinez/Core/FlowControl/PipelineFlowControlOptions.cs
+++ b/src/Pipelinez/Core/FlowControl/PipelineFlowControlOptions.cs
@@ -1,0 +1,33 @@
+using Ardalis.GuardClauses;
+
+namespace Pipelinez.Core.FlowControl;
+
+public sealed class PipelineFlowControlOptions
+{
+    public PipelineOverflowPolicy OverflowPolicy { get; init; } = PipelineOverflowPolicy.Wait;
+
+    public TimeSpan? PublishTimeout { get; init; }
+
+    public bool EmitSaturationEvents { get; init; } = true;
+
+    public double SaturationWarningThreshold { get; init; } = 0.80d;
+
+    public PipelineFlowControlOptions Validate()
+    {
+        if (PublishTimeout.HasValue && PublishTimeout.Value <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(PublishTimeout),
+                PublishTimeout,
+                "Publish timeout must be greater than zero when provided.");
+        }
+
+        Guard.Against.OutOfRange(
+            SaturationWarningThreshold,
+            nameof(SaturationWarningThreshold),
+            0d,
+            1d);
+
+        return this;
+    }
+}

--- a/src/Pipelinez/Core/FlowControl/PipelineFlowControlStatus.cs
+++ b/src/Pipelinez/Core/FlowControl/PipelineFlowControlStatus.cs
@@ -1,0 +1,32 @@
+namespace Pipelinez.Core.FlowControl;
+
+public sealed class PipelineFlowControlStatus
+{
+    public PipelineFlowControlStatus(
+        PipelineOverflowPolicy overflowPolicy,
+        bool isSaturated,
+        double saturationRatio,
+        int totalBufferedCount,
+        int? totalCapacity,
+        IReadOnlyList<PipelineComponentFlowStatus> components)
+    {
+        OverflowPolicy = overflowPolicy;
+        IsSaturated = isSaturated;
+        SaturationRatio = saturationRatio;
+        TotalBufferedCount = totalBufferedCount;
+        TotalCapacity = totalCapacity;
+        Components = components;
+    }
+
+    public PipelineOverflowPolicy OverflowPolicy { get; }
+
+    public bool IsSaturated { get; }
+
+    public double SaturationRatio { get; }
+
+    public int TotalBufferedCount { get; }
+
+    public int? TotalCapacity { get; }
+
+    public IReadOnlyList<PipelineComponentFlowStatus> Components { get; }
+}

--- a/src/Pipelinez/Core/FlowControl/PipelineFlowController.cs
+++ b/src/Pipelinez/Core/FlowControl/PipelineFlowController.cs
@@ -1,0 +1,82 @@
+using System.Diagnostics;
+using System.Threading.Tasks.Dataflow;
+using Pipelinez.Core.Record;
+
+namespace Pipelinez.Core.FlowControl;
+
+internal static class PipelineFlowController
+{
+    public static async Task<PipelinePublishResult> PublishAsync<T>(
+        BufferBlock<PipelineContainer<T>> target,
+        PipelineContainer<T> container,
+        PipelineFlowControlOptions flowControlOptions,
+        PipelinePublishOptions publishOptions,
+        CancellationToken runtimeCancellationToken)
+        where T : PipelineRecord
+    {
+        if (target.Post(container))
+        {
+            return PipelinePublishResult.AcceptedResult(TimeSpan.Zero);
+        }
+
+        var overflowPolicy = publishOptions.OverflowPolicyOverride ?? flowControlOptions.OverflowPolicy;
+        var timeout = publishOptions.Timeout ?? flowControlOptions.PublishTimeout;
+
+        if (overflowPolicy == PipelineOverflowPolicy.Reject)
+        {
+            return PipelinePublishResult.Rejected(PipelinePublishResultReason.RejectedByOverflowPolicy, TimeSpan.Zero);
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        using var timeoutCancellation = timeout.HasValue
+            ? new CancellationTokenSource(timeout.Value)
+            : null;
+        using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            GetTokens(runtimeCancellationToken, publishOptions, overflowPolicy, timeoutCancellation));
+
+        try
+        {
+            var accepted = await target.SendAsync(container, linkedCancellation.Token).ConfigureAwait(false);
+            stopwatch.Stop();
+
+            return accepted
+                ? PipelinePublishResult.AcceptedResult(stopwatch.Elapsed)
+                : PipelinePublishResult.Rejected(PipelinePublishResultReason.RejectedByOverflowPolicy, stopwatch.Elapsed);
+        }
+        catch (OperationCanceledException)
+        {
+            stopwatch.Stop();
+
+            if (timeoutCancellation is { IsCancellationRequested: true })
+            {
+                return PipelinePublishResult.Rejected(PipelinePublishResultReason.TimedOut, stopwatch.Elapsed);
+            }
+
+            return PipelinePublishResult.Rejected(PipelinePublishResultReason.Canceled, stopwatch.Elapsed);
+        }
+    }
+
+    private static CancellationToken[] GetTokens(
+        CancellationToken runtimeCancellationToken,
+        PipelinePublishOptions publishOptions,
+        PipelineOverflowPolicy overflowPolicy,
+        CancellationTokenSource? timeoutCancellation)
+    {
+        var tokens = new List<CancellationToken>(3)
+        {
+            runtimeCancellationToken
+        };
+
+        if (overflowPolicy == PipelineOverflowPolicy.Cancel && publishOptions.CancellationToken.CanBeCanceled)
+        {
+            tokens.Add(publishOptions.CancellationToken);
+        }
+
+        if (timeoutCancellation is not null)
+        {
+            tokens.Add(timeoutCancellation.Token);
+        }
+
+        return tokens.ToArray();
+    }
+}

--- a/src/Pipelinez/Core/FlowControl/PipelineOverflowPolicy.cs
+++ b/src/Pipelinez/Core/FlowControl/PipelineOverflowPolicy.cs
@@ -1,0 +1,8 @@
+namespace Pipelinez.Core.FlowControl;
+
+public enum PipelineOverflowPolicy
+{
+    Wait,
+    Reject,
+    Cancel
+}

--- a/src/Pipelinez/Core/FlowControl/PipelinePublishOptions.cs
+++ b/src/Pipelinez/Core/FlowControl/PipelinePublishOptions.cs
@@ -1,0 +1,23 @@
+namespace Pipelinez.Core.FlowControl;
+
+public sealed class PipelinePublishOptions
+{
+    public TimeSpan? Timeout { get; init; }
+
+    public CancellationToken CancellationToken { get; init; } = CancellationToken.None;
+
+    public PipelineOverflowPolicy? OverflowPolicyOverride { get; init; }
+
+    public PipelinePublishOptions Validate()
+    {
+        if (Timeout.HasValue && Timeout.Value <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(Timeout),
+                Timeout,
+                "Publish timeout must be greater than zero when provided.");
+        }
+
+        return this;
+    }
+}

--- a/src/Pipelinez/Core/FlowControl/PipelinePublishResult.cs
+++ b/src/Pipelinez/Core/FlowControl/PipelinePublishResult.cs
@@ -1,0 +1,58 @@
+using System.Runtime.ExceptionServices;
+
+namespace Pipelinez.Core.FlowControl;
+
+public sealed class PipelinePublishResult
+{
+    private PipelinePublishResult(
+        bool accepted,
+        PipelinePublishResultReason reason,
+        TimeSpan waitDuration)
+    {
+        Accepted = accepted;
+        Reason = reason;
+        WaitDuration = waitDuration;
+    }
+
+    public bool Accepted { get; }
+
+    public PipelinePublishResultReason Reason { get; }
+
+    public TimeSpan WaitDuration { get; }
+
+    public static PipelinePublishResult AcceptedResult(TimeSpan waitDuration)
+    {
+        return new PipelinePublishResult(true, PipelinePublishResultReason.Accepted, waitDuration);
+    }
+
+    public static PipelinePublishResult Rejected(PipelinePublishResultReason reason, TimeSpan waitDuration)
+    {
+        if (reason == PipelinePublishResultReason.Accepted)
+        {
+            throw new ArgumentOutOfRangeException(nameof(reason), reason, "Rejected results cannot use Accepted reason.");
+        }
+
+        return new PipelinePublishResult(false, reason, waitDuration);
+    }
+
+    public void ThrowIfNotAccepted()
+    {
+        if (Accepted)
+        {
+            return;
+        }
+
+        switch (Reason)
+        {
+            case PipelinePublishResultReason.RejectedByOverflowPolicy:
+                throw new InvalidOperationException("The record could not be published because the pipeline is saturated and rejected the publish request.");
+            case PipelinePublishResultReason.TimedOut:
+                throw new TimeoutException("The record could not be published before the configured flow-control timeout elapsed.");
+            case PipelinePublishResultReason.Canceled:
+                ExceptionDispatchInfo.Capture(new OperationCanceledException("The record publish operation was canceled before capacity became available.")).Throw();
+                break;
+            default:
+                throw new InvalidOperationException($"Unknown publish result reason '{Reason}'.");
+        }
+    }
+}

--- a/src/Pipelinez/Core/FlowControl/PipelinePublishResultReason.cs
+++ b/src/Pipelinez/Core/FlowControl/PipelinePublishResultReason.cs
@@ -1,0 +1,9 @@
+namespace Pipelinez.Core.FlowControl;
+
+public enum PipelinePublishResultReason
+{
+    Accepted,
+    RejectedByOverflowPolicy,
+    TimedOut,
+    Canceled
+}

--- a/src/Pipelinez/Core/IPipeline.cs
+++ b/src/Pipelinez/Core/IPipeline.cs
@@ -1,5 +1,6 @@
 using Pipelinez.Core.Distributed;
 using Pipelinez.Core.Eventing;
+using Pipelinez.Core.FlowControl;
 using Pipelinez.Core.Performance;
 using Pipelinez.Core.Record;
 using Pipelinez.Core.Status;
@@ -20,6 +21,11 @@ public interface IPipeline<T> where T : PipelineRecord
     /// </summary>
     /// <returns></returns>
     Task PublishAsync(T record);
+
+    /// <summary>
+    /// Publishes a record into the pipeline with explicit flow-control behavior.
+    /// </summary>
+    Task<PipelinePublishResult> PublishAsync(T record, PipelinePublishOptions options);
 
     /// <summary>
     /// Completes and shuts down the pipeline.
@@ -52,6 +58,16 @@ public interface IPipeline<T> where T : PipelineRecord
     /// Event that is raised when a record is scheduled for retry after a transient failure.
     /// </summary>
     event PipelineRecordRetryingEventHandler<T> OnPipelineRecordRetrying;
+
+    /// <summary>
+    /// Event that is raised when pipeline saturation state changes.
+    /// </summary>
+    event PipelineSaturationChangedEventHandler OnSaturationChanged;
+
+    /// <summary>
+    /// Event that is raised when a publish request is rejected.
+    /// </summary>
+    event PipelinePublishRejectedEventHandler<T> OnPublishRejected;
 
     /// <summary>
     /// Event that is raised when the pipeline transitions into a faulted state.

--- a/src/Pipelinez/Core/Performance/IPipelinePerformanceCollector.cs
+++ b/src/Pipelinez/Core/Performance/IPipelinePerformanceCollector.cs
@@ -16,5 +16,11 @@ internal interface IPipelinePerformanceCollector
 
     void RecordRetryExhausted();
 
+    void RecordPublishWait(TimeSpan waitDuration);
+
+    void RecordPublishRejected();
+
+    void ObserveBufferedCount(int totalBufferedCount);
+
     PipelinePerformanceSnapshot CreateSnapshot();
 }

--- a/src/Pipelinez/Core/Performance/PipelinePerformanceCollector.cs
+++ b/src/Pipelinez/Core/Performance/PipelinePerformanceCollector.cs
@@ -22,6 +22,10 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
     private long _retryCount;
     private long _retryRecoveries;
     private long _retryExhaustions;
+    private long _publishWaitCount;
+    private long _publishRejectedCount;
+    private long _totalPublishWaitDurationTicks;
+    private int _peakBufferedCount;
     private long _totalEndToEndLatencyTicks;
 
     public PipelinePerformanceCollector(PipelineMetricsOptions metricsOptions)
@@ -134,6 +138,49 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
         }
     }
 
+    public void RecordPublishWait(TimeSpan waitDuration)
+    {
+        if (!_metricsOptions.EnableRuntimeMetrics || waitDuration <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        lock (_syncLock)
+        {
+            _publishWaitCount++;
+            _totalPublishWaitDurationTicks += waitDuration.Ticks;
+        }
+    }
+
+    public void RecordPublishRejected()
+    {
+        if (!_metricsOptions.EnableRuntimeMetrics)
+        {
+            return;
+        }
+
+        lock (_syncLock)
+        {
+            _publishRejectedCount++;
+        }
+    }
+
+    public void ObserveBufferedCount(int totalBufferedCount)
+    {
+        if (!_metricsOptions.EnableRuntimeMetrics)
+        {
+            return;
+        }
+
+        lock (_syncLock)
+        {
+            if (totalBufferedCount > _peakBufferedCount)
+            {
+                _peakBufferedCount = totalBufferedCount;
+            }
+        }
+    }
+
     public PipelinePerformanceSnapshot CreateSnapshot()
     {
         lock (_syncLock)
@@ -163,6 +210,9 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
             var averageLatency = totalFinished == 0
                 ? TimeSpan.Zero
                 : TimeSpan.FromTicks(_totalEndToEndLatencyTicks / totalFinished);
+            var averagePublishWait = _publishWaitCount == 0
+                ? TimeSpan.Zero
+                : TimeSpan.FromTicks(_totalPublishWaitDurationTicks / _publishWaitCount);
 
             return new PipelinePerformanceSnapshot(
                 _startedAtUtc,
@@ -173,6 +223,10 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
                 _retryCount,
                 _retryRecoveries,
                 _retryExhaustions,
+                _publishWaitCount,
+                averagePublishWait,
+                _publishRejectedCount,
+                _peakBufferedCount,
                 totalFinished / elapsedSeconds,
                 averageLatency,
                 componentSnapshots);

--- a/src/Pipelinez/Core/Performance/PipelinePerformanceSnapshot.cs
+++ b/src/Pipelinez/Core/Performance/PipelinePerformanceSnapshot.cs
@@ -11,6 +11,10 @@ public sealed class PipelinePerformanceSnapshot
         long totalRetryCount,
         long successfulRetryRecoveries,
         long retryExhaustions,
+        long totalPublishWaitCount,
+        TimeSpan averagePublishWaitDuration,
+        long totalPublishRejectedCount,
+        int peakBufferedCount,
         double recordsPerSecond,
         TimeSpan averageEndToEndLatency,
         IReadOnlyList<PipelineComponentPerformanceSnapshot> components)
@@ -23,6 +27,10 @@ public sealed class PipelinePerformanceSnapshot
         TotalRetryCount = totalRetryCount;
         SuccessfulRetryRecoveries = successfulRetryRecoveries;
         RetryExhaustions = retryExhaustions;
+        TotalPublishWaitCount = totalPublishWaitCount;
+        AveragePublishWaitDuration = averagePublishWaitDuration;
+        TotalPublishRejectedCount = totalPublishRejectedCount;
+        PeakBufferedCount = peakBufferedCount;
         RecordsPerSecond = recordsPerSecond;
         AverageEndToEndLatency = averageEndToEndLatency;
         Components = components;
@@ -43,6 +51,14 @@ public sealed class PipelinePerformanceSnapshot
     public long SuccessfulRetryRecoveries { get; }
 
     public long RetryExhaustions { get; }
+
+    public long TotalPublishWaitCount { get; }
+
+    public TimeSpan AveragePublishWaitDuration { get; }
+
+    public long TotalPublishRejectedCount { get; }
+
+    public int PeakBufferedCount { get; }
 
     public double RecordsPerSecond { get; }
 

--- a/src/Pipelinez/Core/Pipeline.cs
+++ b/src/Pipelinez/Core/Pipeline.cs
@@ -7,6 +7,7 @@ using Pipelinez.Core.Destination;
 using Pipelinez.Core.ErrorHandling;
 using Pipelinez.Core.Eventing;
 using Pipelinez.Core.FaultHandling;
+using Pipelinez.Core.FlowControl;
 using Pipelinez.Core.Logging;
 using Pipelinez.Core.Performance;
 using Pipelinez.Core.Record;
@@ -52,12 +53,14 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     private readonly IPipelineDestination<TPipelineRecord> _destination;
     private readonly PipelineErrorHandler<TPipelineRecord>? _errorHandler;
     private readonly PipelineHostOptions _hostOptions;
+    private readonly PipelineFlowControlOptions _flowControlOptions;
     private readonly IPipelinePerformanceCollector _performanceCollector;
     private readonly bool _emitRetryEvents;
     private readonly string _instanceId;
     private readonly string _workerId;
     private readonly object _stateLock = new();
     private readonly object _distributionLock = new();
+    private readonly object _flowControlLock = new();
     private readonly TaskCompletionSource _completionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private CancellationTokenSource? _runtimeCancellationTokenSource;
@@ -67,6 +70,8 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     private IReadOnlyList<PipelinePartitionLease> _ownedPartitions = Array.Empty<PipelinePartitionLease>();
     private bool _workerStartedRaised;
     private bool _workerStoppingRaised;
+    private bool? _lastObservedSaturationWarningState;
+    private bool? _lastObservedSaturationState;
     
     #endregion
     
@@ -100,6 +105,8 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     /// Occurs when a record is about to be retried after a transient failure.
     /// </summary>
     public event PipelineRecordRetryingEventHandler<TPipelineRecord>? OnPipelineRecordRetrying;
+    public event PipelineSaturationChangedEventHandler? OnSaturationChanged;
+    public event PipelinePublishRejectedEventHandler<TPipelineRecord>? OnPublishRejected;
 
     /// <summary>
     /// Occurs when the pipeline transitions into a faulted state.
@@ -147,6 +154,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
             new PipelineRecordCompletedEventHandlerArgs<TPipelineRecord>(
                 evt.Container.Record,
                 BuildDistributionContext(evt.Container.Metadata)));
+        ObserveFlowControlState();
     }
 
     internal async Task<PipelineErrorAction> HandleFaultedContainerAsync(PipelineContainer<TPipelineRecord> container)
@@ -180,6 +188,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
                     "Skipping faulted record in pipeline {PipelineName}. Component: {ComponentName}",
                     _name,
                     container.Fault.ComponentName);
+                ObserveFlowControlState();
                 return PipelineErrorAction.SkipRecord;
             case PipelineErrorAction.StopPipeline:
                 FaultPipeline(container.Fault);
@@ -203,6 +212,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         IList<IPipelineSegment<TPipelineRecord>> segments,
         PipelineErrorHandler<TPipelineRecord>? errorHandler = null,
         PipelineHostOptions? hostOptions = null,
+        PipelineFlowControlOptions? flowControlOptions = null,
         IPipelinePerformanceCollector? performanceCollector = null,
         bool emitRetryEvents = true)
     {
@@ -218,6 +228,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         this._segments = segments;
         this._errorHandler = errorHandler;
         _hostOptions = hostOptions ?? new PipelineHostOptions();
+        _flowControlOptions = (flowControlOptions ?? new PipelineFlowControlOptions()).Validate();
         _performanceCollector = performanceCollector ?? new PipelinePerformanceCollector(new PipelineMetricsOptions());
         _emitRetryEvents = emitRetryEvents;
         _instanceId = string.IsNullOrWhiteSpace(_hostOptions.InstanceId)
@@ -321,10 +332,18 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
 
     public async Task PublishAsync(TPipelineRecord record)
     {
+        var publishResult = await PublishAsync(record, new PipelinePublishOptions()).ConfigureAwait(false);
+        publishResult.ThrowIfNotAccepted();
+    }
+
+    public async Task<PipelinePublishResult> PublishAsync(
+        TPipelineRecord record,
+        PipelinePublishOptions options)
+    {
         Guard.Against.Null(record, nameof(record));
         EnsurePipelineStartedForPublish();
 
-        await _source.PublishAsync(record).ConfigureAwait(false);
+        return await _source.PublishAsync(record, Guard.Against.Null(options, nameof(options)).Validate()).ConfigureAwait(false);
     }
 
     public async Task CompleteAsync()
@@ -393,14 +412,27 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
 
     public PipelineStatus GetStatus()
     {
+        var flowControlStatus = GetFlowControlStatus();
+        PipelineComponentFlowStatus? GetFlow(string name) =>
+            flowControlStatus.Components.FirstOrDefault(component => component.Name == name);
         var components = new List<PipelineComponentStatus>();
-        components.Add(new PipelineComponentStatus(_source.GetType().Name, _source.Completion.Status.ToPipelineExecutionStatus()));
-        components.AddRange(_segments.Select(s => new PipelineComponentStatus(s.GetType().Name, s.Completion.Status.ToPipelineExecutionStatus())));
-        components.Add(new PipelineComponentStatus(_destination.GetType().Name, _destination.Completion.Status.ToPipelineExecutionStatus()));
+        components.Add(new PipelineComponentStatus(
+            _source.GetType().Name,
+            _source.Completion.Status.ToPipelineExecutionStatus(),
+            GetFlow(_source.GetType().Name)));
+        components.AddRange(_segments.Select(segment => new PipelineComponentStatus(
+            segment.GetType().Name,
+            segment.Completion.Status.ToPipelineExecutionStatus(),
+            GetFlow(segment.GetType().Name))));
+        components.Add(new PipelineComponentStatus(
+            _destination.GetType().Name,
+            _destination.Completion.Status.ToPipelineExecutionStatus(),
+            GetFlow(_destination.GetType().Name)));
         return new PipelineStatus(
             components,
             _state == PipelineRuntimeState.Faulted ? PipelineExecutionStatus.Faulted : null,
-            GetDistributedStatus());
+            GetDistributedStatus(),
+            flowControlStatus);
     }
 
     public PipelineRuntimeContext GetRuntimeContext()
@@ -421,9 +453,80 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         return _performanceCollector.CreateSnapshot();
     }
 
+    internal PipelineFlowControlOptions GetFlowControlOptions()
+    {
+        return _flowControlOptions;
+    }
+
     internal CancellationToken GetRuntimeCancellationToken()
     {
         return _runtimeCancellationTokenSource?.Token ?? CancellationToken.None;
+    }
+
+    internal void NotifyPublishAccepted(TimeSpan waitDuration)
+    {
+        _performanceCollector.RecordPublishWait(waitDuration);
+        ObserveFlowControlState();
+    }
+
+    internal void NotifyPublishRejected(TPipelineRecord record, PipelinePublishResult publishResult)
+    {
+        Guard.Against.Null(record, nameof(record));
+        Guard.Against.Null(publishResult, nameof(publishResult));
+
+        if (publishResult.WaitDuration > TimeSpan.Zero)
+        {
+            _performanceCollector.RecordPublishWait(publishResult.WaitDuration);
+        }
+
+        _performanceCollector.RecordPublishRejected();
+        OnPublishRejected?.Invoke(
+            this,
+            new PipelinePublishRejectedEventArgs<TPipelineRecord>(
+                record,
+                publishResult.Reason,
+                DateTimeOffset.UtcNow));
+        ObserveFlowControlState();
+    }
+
+    internal void ObserveFlowControlState()
+    {
+        var flowControlStatus = GetFlowControlStatus();
+        if (flowControlStatus is null)
+        {
+            return;
+        }
+
+        _performanceCollector.ObserveBufferedCount(flowControlStatus.TotalBufferedCount);
+
+        if (!_flowControlOptions.EmitSaturationEvents)
+        {
+            return;
+        }
+
+        var warningThresholdExceeded = flowControlStatus.SaturationRatio >= _flowControlOptions.SaturationWarningThreshold;
+        var shouldRaiseEvent = false;
+
+        lock (_flowControlLock)
+        {
+            if (_lastObservedSaturationWarningState != warningThresholdExceeded ||
+                _lastObservedSaturationState != flowControlStatus.IsSaturated)
+            {
+                _lastObservedSaturationWarningState = warningThresholdExceeded;
+                _lastObservedSaturationState = flowControlStatus.IsSaturated;
+                shouldRaiseEvent = true;
+            }
+        }
+
+        if (shouldRaiseEvent)
+        {
+            OnSaturationChanged?.Invoke(
+                this,
+                new PipelineSaturationChangedEventArgs(
+                    flowControlStatus.SaturationRatio,
+                    flowControlStatus.IsSaturated,
+                    DateTimeOffset.UtcNow));
+        }
     }
 
     internal Task NotifyRecordRetryingAsync(
@@ -692,6 +795,59 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
                 _workerId,
                 _ownedPartitions);
         }
+    }
+
+    private PipelineFlowControlStatus GetFlowControlStatus()
+    {
+        var componentFlows = new List<PipelineComponentFlowStatus>();
+
+        if (_source is IPipelineFlowStatusProvider sourceFlowProvider)
+        {
+            componentFlows.Add(new PipelineComponentFlowStatus(
+                _source.GetType().Name,
+                sourceFlowProvider.GetApproximateQueueDepth(),
+                sourceFlowProvider.GetBoundedCapacity()));
+        }
+
+        foreach (var segment in _segments)
+        {
+            if (segment is IPipelineFlowStatusProvider segmentFlowProvider)
+            {
+                componentFlows.Add(new PipelineComponentFlowStatus(
+                    segment.GetType().Name,
+                    segmentFlowProvider.GetApproximateQueueDepth(),
+                    segmentFlowProvider.GetBoundedCapacity()));
+            }
+        }
+
+        if (_destination is IPipelineFlowStatusProvider destinationFlowProvider)
+        {
+            componentFlows.Add(new PipelineComponentFlowStatus(
+                _destination.GetType().Name,
+                destinationFlowProvider.GetApproximateQueueDepth(),
+                destinationFlowProvider.GetBoundedCapacity()));
+        }
+
+        var totalBufferedCount = componentFlows.Sum(component => component.ApproximateQueueDepth);
+        var boundedComponents = componentFlows
+            .Where(component => component.BoundedCapacity.HasValue)
+            .ToArray();
+        int? totalCapacity = boundedComponents.Length == 0
+            ? null
+            : boundedComponents.Sum(component => component.BoundedCapacity!.Value);
+        var boundedBufferedCount = boundedComponents.Sum(component => component.ApproximateQueueDepth);
+        var saturationRatio = totalCapacity.HasValue && totalCapacity.Value > 0
+            ? Math.Min(1d, (double)boundedBufferedCount / totalCapacity.Value)
+            : 0d;
+        var isSaturated = componentFlows.Any(component => component.IsSaturated);
+
+        return new PipelineFlowControlStatus(
+            _flowControlOptions.OverflowPolicy,
+            isSaturated,
+            saturationRatio,
+            totalBufferedCount,
+            totalCapacity,
+            componentFlows);
     }
 
     private PipelineRecordDistributionContext BuildDistributionContext(Pipelinez.Core.Record.Metadata.MetadataCollection metadata)

--- a/src/Pipelinez/Core/PipelineBuilder.cs
+++ b/src/Pipelinez/Core/PipelineBuilder.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Pipelinez.Core.Distributed;
 using Pipelinez.Core.Destination;
 using Pipelinez.Core.ErrorHandling;
+using Pipelinez.Core.FlowControl;
 using Pipelinez.Core.Logging;
 using Pipelinez.Core.Performance;
 using Pipelinez.Core.Record;
@@ -32,6 +33,7 @@ public class PipelineBuilder<T>(string pipelineName)
     private PipelineRetryPolicy<T>? _destinationRetryPolicy;
     private PipelineErrorHandler<T>? _errorHandler;
     private PipelineHostOptions _hostOptions = new();
+    private PipelineFlowControlOptions _flowControlOptions = new();
     private PipelinePerformanceOptions _performanceOptions = new();
     private PipelineRetryOptions<T> _retryOptions = new();
 
@@ -174,6 +176,16 @@ public class PipelineBuilder<T>(string pipelineName)
 
     #endregion
 
+    #region Flow Control
+
+    public PipelineBuilder<T> UseFlowControlOptions(PipelineFlowControlOptions options)
+    {
+        _flowControlOptions = Guard.Against.Null(options, nameof(options)).Validate();
+        return this;
+    }
+
+    #endregion
+
     #region Performance
 
     public PipelineBuilder<T> UsePerformanceOptions(PipelinePerformanceOptions options)
@@ -276,6 +288,7 @@ public class PipelineBuilder<T>(string pipelineName)
             _segments.Select(registration => registration.Segment).ToList(),
             _errorHandler,
             _hostOptions,
+            _flowControlOptions,
             performanceCollector,
             _retryOptions.EmitRetryEvents);
         pipeline.LinkPipeline();

--- a/src/Pipelinez/Core/Segment/PipelineSegment.cs
+++ b/src/Pipelinez/Core/Segment/PipelineSegment.cs
@@ -4,6 +4,7 @@ using Ardalis.GuardClauses;
 using Microsoft.Extensions.Logging;
 using Pipelinez.Core.FaultHandling;
 using Pipelinez.Core.Flow;
+using Pipelinez.Core.FlowControl;
 using Pipelinez.Core.Logging;
 using Pipelinez.Core.Performance;
 using Pipelinez.Core.Record;
@@ -11,7 +12,7 @@ using Pipelinez.Core.Retry;
 
 namespace Pipelinez.Core.Segment;
 
-public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecutionConfigurable, IPipelinePerformanceAware, IPipelineRetryConfigurable<T> where T : PipelineRecord
+public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecutionConfigurable, IPipelinePerformanceAware, IPipelineRetryConfigurable<T>, IPipelineFlowStatusProvider where T : PipelineRecord
 {
     private TransformBlock<PipelineContainer<T>, PipelineContainer<T>>? _transformBlock;
     private Pipeline<T>? _parentPipeline;
@@ -96,6 +97,7 @@ public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecuti
         try
         {
             Logger.LogTrace("Executing Segment");
+            ParentPipeline.ObserveFlowControlState();
 
             var finalResult = await PipelineRetryExecutor.ExecuteAsync(
                     arg,
@@ -152,6 +154,7 @@ public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecuti
                 succeeded,
                 failureMessage));
             _performanceCollector?.RecordComponentExecution(_componentName, stopwatch.Elapsed, succeeded);
+            ParentPipeline.ObserveFlowControlState();
         }
 
         return arg;
@@ -232,4 +235,16 @@ public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecuti
 
     private Pipeline<T> ParentPipeline =>
         _parentPipeline ?? throw new InvalidOperationException("Pipeline segment has not been initialized.");
+
+    int IPipelineFlowStatusProvider.GetApproximateQueueDepth()
+    {
+        return TransformBlock.InputCount + TransformBlock.OutputCount;
+    }
+
+    int? IPipelineFlowStatusProvider.GetBoundedCapacity()
+    {
+        return _executionOptions.BoundedCapacity == DataflowBlockOptions.Unbounded
+            ? null
+            : _executionOptions.BoundedCapacity;
+    }
 }

--- a/src/Pipelinez/Core/Source/IPipelineSource.cs
+++ b/src/Pipelinez/Core/Source/IPipelineSource.cs
@@ -1,5 +1,6 @@
 using Pipelinez.Core.Eventing;
 using Pipelinez.Core.Flow;
+using Pipelinez.Core.FlowControl;
 using Pipelinez.Core.Record;
 using Pipelinez.Core.Record.Metadata;
 
@@ -11,7 +12,11 @@ public interface IPipelineSource<T> : IFlowSource<PipelineContainer<T>> where T 
     
     Task PublishAsync(T record);
 
+    Task<PipelinePublishResult> PublishAsync(T record, PipelinePublishOptions options);
+
     Task PublishAsync(T record, MetadataCollection metadata);
+
+    Task<PipelinePublishResult> PublishAsync(T record, MetadataCollection metadata, PipelinePublishOptions options);
 
     void Complete();
     Task Completion { get; }

--- a/src/Pipelinez/Core/Source/PipelineSource.cs
+++ b/src/Pipelinez/Core/Source/PipelineSource.cs
@@ -3,6 +3,7 @@ using Ardalis.GuardClauses;
 using Microsoft.Extensions.Logging;
 using Pipelinez.Core.Eventing;
 using Pipelinez.Core.Flow;
+using Pipelinez.Core.FlowControl;
 using Pipelinez.Core.Logging;
 using Pipelinez.Core.Performance;
 using Pipelinez.Core.Record;
@@ -10,7 +11,7 @@ using Pipelinez.Core.Record.Metadata;
 
 namespace Pipelinez.Core.Source;
 
-public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecutionConfigurable, IPipelinePerformanceAware where T : PipelineRecord
+public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecutionConfigurable, IPipelinePerformanceAware, IPipelineFlowStatusProvider where T : PipelineRecord
 {
     private BufferBlock<PipelineContainer<T>>? _messageBuffer;
     private Pipeline<T>? _parentPipeline;
@@ -54,18 +55,44 @@ public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecu
 
     public async Task PublishAsync(T record)
     {
-        var container = new PipelineContainer<T>(record);
+        var publishResult = await PublishAsync(record, new PipelinePublishOptions()).ConfigureAwait(false);
+        HandleUnacceptedPublishResult(publishResult);
+    }
 
-        await MessageBuffer.SendAsync(container).ConfigureAwait(false);
-        _performanceCollector?.RecordPublished(_componentName);
+    public Task<PipelinePublishResult> PublishAsync(T record, PipelinePublishOptions options)
+    {
+        return PublishAsync(record, new MetadataCollection(), options);
     }
 
     public async Task PublishAsync(T record, MetadataCollection metadata)
     {
-        var container = new PipelineContainer<T>(record, metadata);
+        var publishResult = await PublishAsync(record, metadata, new PipelinePublishOptions()).ConfigureAwait(false);
+        HandleUnacceptedPublishResult(publishResult);
+    }
 
-        await MessageBuffer.SendAsync(container).ConfigureAwait(false);
-        _performanceCollector?.RecordPublished(_componentName);
+    public async Task<PipelinePublishResult> PublishAsync(T record, MetadataCollection metadata, PipelinePublishOptions options)
+    {
+        var container = new PipelineContainer<T>(
+            Guard.Against.Null(record, nameof(record)),
+            Guard.Against.Null(metadata, nameof(metadata)));
+        var validatedOptions = Guard.Against.Null(options, nameof(options)).Validate();
+        var publishResult = await PipelineFlowController.PublishAsync(
+                MessageBuffer,
+                container,
+                ParentPipeline.GetFlowControlOptions(),
+                validatedOptions,
+                ParentPipeline.GetRuntimeCancellationToken())
+            .ConfigureAwait(false);
+
+        if (publishResult.Accepted)
+        {
+            _performanceCollector?.RecordPublished(_componentName);
+            ParentPipeline.NotifyPublishAccepted(publishResult.WaitDuration);
+            return publishResult;
+        }
+
+        ParentPipeline.NotifyPublishRejected(record, publishResult);
+        return publishResult;
     }
 
     public void Complete()
@@ -144,6 +171,18 @@ public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecu
             EnsureOrdered = _executionOptions.EnsureOrdered
         });
 
+    int IPipelineFlowStatusProvider.GetApproximateQueueDepth()
+    {
+        return MessageBuffer.Count;
+    }
+
+    int? IPipelineFlowStatusProvider.GetBoundedCapacity()
+    {
+        return _executionOptions.BoundedCapacity == DataflowBlockOptions.Unbounded
+            ? null
+            : _executionOptions.BoundedCapacity;
+    }
+
     private void EnsureExecutionOptionsCanBeChanged()
     {
         if (_messageBuffer is not null)
@@ -151,5 +190,21 @@ public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecu
             throw new InvalidOperationException(
                 $"Execution options for source '{GetType().Name}' must be configured before the source is linked or used.");
         }
+    }
+
+    private void HandleUnacceptedPublishResult(PipelinePublishResult publishResult)
+    {
+        if (publishResult.Accepted)
+        {
+            return;
+        }
+
+        if (publishResult.Reason == PipelinePublishResultReason.Canceled &&
+            ParentPipeline.GetRuntimeCancellationToken().IsCancellationRequested)
+        {
+            return;
+        }
+
+        publishResult.ThrowIfNotAccepted();
     }
 }

--- a/src/Pipelinez/Core/Status/PipelineComponentStatus.cs
+++ b/src/Pipelinez/Core/Status/PipelineComponentStatus.cs
@@ -1,13 +1,20 @@
+using Pipelinez.Core.FlowControl;
+
 namespace Pipelinez.Core.Status;
 
 public class PipelineComponentStatus
 {
-    public PipelineComponentStatus(string name, PipelineExecutionStatus status)
+    public PipelineComponentStatus(
+        string name,
+        PipelineExecutionStatus status,
+        PipelineComponentFlowStatus? flow = null)
     {
         Name = name;
         Status = status;
+        Flow = flow;
     }
 
     public string Name { get; }
     public PipelineExecutionStatus Status { get; }
+    public PipelineComponentFlowStatus? Flow { get; }
 }

--- a/src/Pipelinez/Core/Status/PipelineStatus.cs
+++ b/src/Pipelinez/Core/Status/PipelineStatus.cs
@@ -1,4 +1,5 @@
 using Pipelinez.Core.Distributed;
+using Pipelinez.Core.FlowControl;
 
 namespace Pipelinez.Core.Status;
 
@@ -7,17 +8,20 @@ public class PipelineStatus
     public PipelineStatus(
         IList<PipelineComponentStatus> components,
         PipelineExecutionStatus? runtimeStatus = null,
-        PipelineDistributedStatus? distributedStatus = null)
+        PipelineDistributedStatus? distributedStatus = null,
+        PipelineFlowControlStatus? flowControlStatus = null)
     {
         Components = components;
         RuntimeStatus = runtimeStatus;
         DistributedStatus = distributedStatus;
+        FlowControlStatus = flowControlStatus;
     }
     
     public PipelineExecutionStatus Status => GetStatus();
     public IList<PipelineComponentStatus> Components { get; }
     public PipelineExecutionStatus? RuntimeStatus { get; }
     public PipelineDistributedStatus? DistributedStatus { get; }
+    public PipelineFlowControlStatus? FlowControlStatus { get; }
     
     private PipelineExecutionStatus GetStatus()
     {

--- a/src/tests/Pipelinez.Kafka.Tests/EndToEnd/KafkaPipelineFlowControlTests.cs
+++ b/src/tests/Pipelinez.Kafka.Tests/EndToEnd/KafkaPipelineFlowControlTests.cs
@@ -1,0 +1,93 @@
+using Confluent.Kafka;
+using Pipelinez.Core;
+using Pipelinez.Core.FlowControl;
+using Pipelinez.Core.Performance;
+using Pipelinez.Core.Status;
+using Pipelinez.Kafka;
+using Pipelinez.Kafka.Tests.Infrastructure;
+using Pipelinez.Kafka.Tests.Models;
+using Xunit;
+
+namespace Pipelinez.Kafka.Tests.EndToEnd;
+
+[Collection(KafkaIntegrationCollection.Name)]
+public sealed class KafkaPipelineFlowControlTests(KafkaTestCluster cluster)
+{
+    [Fact]
+    public async Task KafkaPipeline_DownstreamPressure_Slows_Ingress_Without_Faulting()
+    {
+        var scenarioName = nameof(KafkaPipeline_DownstreamPressure_Slows_Ingress_Without_Faulting);
+        var sourceTopic = await cluster.CreateTopicAsync($"{scenarioName}-source").ConfigureAwait(false);
+        var consumerGroup = KafkaTopicNameFactory.CreateConsumerGroupName("pipelinez", scenarioName);
+        var destination = new BlockingCountingDestination();
+
+        var pipeline = Pipeline<TestKafkaRecord>.New(scenarioName)
+            .UsePerformanceOptions(new PipelinePerformanceOptions
+            {
+                SourceExecution = new PipelineExecutionOptions
+                {
+                    BoundedCapacity = 1,
+                    DegreeOfParallelism = 1,
+                    EnsureOrdered = true
+                },
+                DestinationExecution = new PipelineExecutionOptions
+                {
+                    BoundedCapacity = 1,
+                    DegreeOfParallelism = 1,
+                    EnsureOrdered = true
+                }
+            })
+            .UseFlowControlOptions(new PipelineFlowControlOptions
+            {
+                OverflowPolicy = PipelineOverflowPolicy.Wait,
+                SaturationWarningThreshold = 0.5d
+            })
+            .WithKafkaSource(
+                cluster.CreateSourceOptions(sourceTopic, consumerGroup),
+                (string key, string value) => new TestKafkaRecord
+                {
+                    Key = key,
+                    Value = value
+                })
+            .WithDestination(destination)
+            .Build();
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+
+        await cluster.ProduceAsync(
+            sourceTopic,
+            new[]
+            {
+                KafkaPipelineTestHelpers.CreateMessage("key-1", "value-1"),
+                KafkaPipelineTestHelpers.CreateMessage("key-2", "value-2"),
+                KafkaPipelineTestHelpers.CreateMessage("key-3", "value-3"),
+                KafkaPipelineTestHelpers.CreateMessage("key-4", "value-4")
+            }).ConfigureAwait(false);
+
+        await destination.FirstExecutionStarted.Task.WaitAsync(cluster.ConsumeTimeout).ConfigureAwait(false);
+        await KafkaPipelineTestHelpers.WaitForConditionAsync(
+            () => pipeline.GetStatus().FlowControlStatus is { TotalBufferedCount: >= 2 },
+            cluster.ConsumeTimeout).ConfigureAwait(false);
+
+        var activeStatus = pipeline.GetStatus();
+        Assert.NotNull(activeStatus.FlowControlStatus);
+        Assert.NotEqual(PipelineExecutionStatus.Faulted, activeStatus.Status);
+        Assert.True(activeStatus.FlowControlStatus!.SaturationRatio > 0);
+        Assert.True(activeStatus.FlowControlStatus.TotalBufferedCount >= 2);
+
+        destination.ReleaseFirstExecution();
+
+        await KafkaPipelineTestHelpers.WaitForConditionAsync(
+            () => destination.ProcessedKeys.Count == 4,
+            cluster.ConsumeTimeout).ConfigureAwait(false);
+
+        await pipeline.CompleteAsync().ConfigureAwait(false);
+        await pipeline.Completion.ConfigureAwait(false);
+
+        var snapshot = pipeline.GetPerformanceSnapshot();
+        Assert.True(snapshot.TotalPublishWaitCount > 0);
+        Assert.Equal(0, snapshot.TotalPublishRejectedCount);
+        Assert.True(snapshot.PeakBufferedCount > 0);
+        Assert.Equal(PipelineExecutionStatus.Completed, pipeline.GetStatus().Status);
+    }
+}

--- a/src/tests/Pipelinez.Kafka.Tests/Models/BlockingCountingDestination.cs
+++ b/src/tests/Pipelinez.Kafka.Tests/Models/BlockingCountingDestination.cs
@@ -1,0 +1,37 @@
+using System.Collections.Concurrent;
+using Pipelinez.Core.Destination;
+
+namespace Pipelinez.Kafka.Tests.Models;
+
+public sealed class BlockingCountingDestination : PipelineDestination<TestKafkaRecord>
+{
+    private readonly TaskCompletionSource _allowFirstExecution =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _executionCount;
+
+    public TaskCompletionSource FirstExecutionStarted { get; } =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public ConcurrentQueue<string> ProcessedKeys { get; } = new();
+
+    protected override async Task ExecuteAsync(TestKafkaRecord record, CancellationToken cancellationToken)
+    {
+        var executionNumber = Interlocked.Increment(ref _executionCount);
+        if (executionNumber == 1)
+        {
+            FirstExecutionStarted.TrySetResult();
+            await _allowFirstExecution.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        ProcessedKeys.Enqueue(record.Key);
+    }
+
+    public void ReleaseFirstExecution()
+    {
+        _allowFirstExecution.TrySetResult();
+    }
+
+    protected override void Initialize()
+    {
+    }
+}

--- a/src/tests/Pipelinez.Tests/Core/FlowControlTests/PipelineFlowControlTests.cs
+++ b/src/tests/Pipelinez.Tests/Core/FlowControlTests/PipelineFlowControlTests.cs
@@ -1,0 +1,217 @@
+using Pipelinez.Core;
+using Pipelinez.Core.Eventing;
+using Pipelinez.Core.FlowControl;
+using Pipelinez.Core.Performance;
+using Pipelinez.Core.Status;
+using Pipelinez.Tests.Core.DestinationTests.Models;
+using Pipelinez.Tests.Core.SourceDestTests.Models;
+
+namespace Pipelinez.Tests.Core.FlowControlTests;
+
+public sealed class PipelineFlowControlTests
+{
+    [Fact]
+    public async Task Pipeline_Publish_With_RejectPolicy_Returns_Rejected_Result_When_Saturated()
+    {
+        var (pipeline, destination) = CreatePipeline(
+            "flow-reject",
+            new PipelineFlowControlOptions
+            {
+                OverflowPolicy = PipelineOverflowPolicy.Wait
+            });
+
+        var rejectedEvents = new List<PipelinePublishRejectedEventArgs<TestPipelineRecord>>();
+        pipeline.OnPublishRejected += (_, args) => rejectedEvents.Add(args);
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+        await SaturatePipelineAsync(pipeline, destination).ConfigureAwait(false);
+
+        var result = await pipeline.PublishAsync(
+                new TestPipelineRecord { Data = "rejected" },
+                new PipelinePublishOptions
+                {
+                    OverflowPolicyOverride = PipelineOverflowPolicy.Reject
+                })
+            .ConfigureAwait(false);
+
+        await DrainPipelineAsync(pipeline, destination).ConfigureAwait(false);
+
+        Assert.False(result.Accepted);
+        Assert.Equal(PipelinePublishResultReason.RejectedByOverflowPolicy, result.Reason);
+        Assert.Single(rejectedEvents);
+        Assert.Equal("rejected", rejectedEvents[0].Record.Data);
+        Assert.Equal(PipelineExecutionStatus.Completed, pipeline.GetStatus().Status);
+        Assert.Equal(1, pipeline.GetPerformanceSnapshot().TotalPublishRejectedCount);
+    }
+
+    [Fact]
+    public async Task Pipeline_Publish_With_Timeout_Returns_TimedOut_Result_When_Saturated()
+    {
+        var (pipeline, destination) = CreatePipeline(
+            "flow-timeout",
+            new PipelineFlowControlOptions
+            {
+                OverflowPolicy = PipelineOverflowPolicy.Wait,
+                PublishTimeout = TimeSpan.FromMilliseconds(200)
+            });
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+        await SaturatePipelineAsync(pipeline, destination).ConfigureAwait(false);
+
+        var startedAt = DateTimeOffset.UtcNow;
+        var result = await pipeline.PublishAsync(
+                new TestPipelineRecord { Data = "timeout" },
+                new PipelinePublishOptions())
+            .ConfigureAwait(false);
+        var elapsed = DateTimeOffset.UtcNow - startedAt;
+
+        await DrainPipelineAsync(pipeline, destination).ConfigureAwait(false);
+
+        Assert.False(result.Accepted);
+        Assert.Equal(PipelinePublishResultReason.TimedOut, result.Reason);
+        Assert.True(elapsed >= TimeSpan.FromMilliseconds(150));
+
+        var snapshot = pipeline.GetPerformanceSnapshot();
+        Assert.True(snapshot.TotalPublishWaitCount >= 1);
+        Assert.True(snapshot.AveragePublishWaitDuration > TimeSpan.Zero);
+        Assert.True(snapshot.TotalPublishRejectedCount >= 1);
+    }
+
+    [Fact]
+    public async Task Pipeline_Publish_With_CancelPolicy_Returns_Canceled_Result_When_Saturated()
+    {
+        var (pipeline, destination) = CreatePipeline(
+            "flow-cancel",
+            new PipelineFlowControlOptions
+            {
+                OverflowPolicy = PipelineOverflowPolicy.Wait
+            });
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+        await SaturatePipelineAsync(pipeline, destination).ConfigureAwait(false);
+
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(150));
+        var result = await pipeline.PublishAsync(
+                new TestPipelineRecord { Data = "canceled" },
+                new PipelinePublishOptions
+                {
+                    OverflowPolicyOverride = PipelineOverflowPolicy.Cancel,
+                    CancellationToken = cancellation.Token
+                })
+            .ConfigureAwait(false);
+
+        await DrainPipelineAsync(pipeline, destination).ConfigureAwait(false);
+
+        Assert.False(result.Accepted);
+        Assert.Equal(PipelinePublishResultReason.Canceled, result.Reason);
+    }
+
+    [Fact]
+    public async Task Pipeline_Status_Events_And_PerformanceSnapshot_Report_FlowControl_State()
+    {
+        var (pipeline, destination) = CreatePipeline(
+            "flow-status",
+            new PipelineFlowControlOptions
+            {
+                OverflowPolicy = PipelineOverflowPolicy.Wait,
+                SaturationWarningThreshold = 0.5d
+            });
+
+        var saturationEvents = new List<PipelineSaturationChangedEventArgs>();
+        pipeline.OnSaturationChanged += (_, args) => saturationEvents.Add(args);
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+        await SaturatePipelineAsync(pipeline, destination).ConfigureAwait(false);
+
+        var rejectedResult = await pipeline.PublishAsync(
+                new TestPipelineRecord { Data = "rejected" },
+                new PipelinePublishOptions
+                {
+                    OverflowPolicyOverride = PipelineOverflowPolicy.Reject
+                })
+            .ConfigureAwait(false);
+
+        var saturatedStatus = pipeline.GetStatus();
+
+        Assert.NotNull(saturatedStatus.FlowControlStatus);
+        Assert.True(saturatedStatus.FlowControlStatus!.IsSaturated);
+        Assert.True(saturatedStatus.FlowControlStatus.TotalBufferedCount >= 2);
+        Assert.All(saturatedStatus.Components, component => Assert.NotNull(component.Flow));
+        Assert.Contains(saturatedStatus.FlowControlStatus.Components, component => component.IsSaturated);
+        Assert.False(rejectedResult.Accepted);
+
+        await DrainPipelineAsync(pipeline, destination).ConfigureAwait(false);
+
+        var completedStatus = pipeline.GetStatus();
+        var snapshot = pipeline.GetPerformanceSnapshot();
+
+        Assert.NotNull(completedStatus.FlowControlStatus);
+        Assert.False(completedStatus.FlowControlStatus!.IsSaturated);
+        Assert.Equal(0, completedStatus.FlowControlStatus.TotalBufferedCount);
+        Assert.True(snapshot.PeakBufferedCount >= 2);
+        Assert.Equal(1, snapshot.TotalPublishRejectedCount);
+        Assert.Contains(saturationEvents, args => args.IsSaturated);
+    }
+
+    private static async Task SaturatePipelineAsync(
+        IPipeline<TestPipelineRecord> pipeline,
+        BlockingAsyncDestination destination)
+    {
+        await pipeline.PublishAsync(
+                new TestPipelineRecord { Data = "record-1" },
+                new PipelinePublishOptions())
+            .ConfigureAwait(false);
+        await destination.ExecutionStarted.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+        var second = await pipeline.PublishAsync(
+                new TestPipelineRecord { Data = "record-2" },
+                new PipelinePublishOptions())
+            .ConfigureAwait(false);
+        var third = await pipeline.PublishAsync(
+                new TestPipelineRecord { Data = "record-3" },
+                new PipelinePublishOptions())
+            .ConfigureAwait(false);
+
+        Assert.True(second.Accepted);
+        Assert.True(third.Accepted);
+    }
+
+    private static async Task DrainPipelineAsync(
+        IPipeline<TestPipelineRecord> pipeline,
+        BlockingAsyncDestination destination)
+    {
+        destination.ReleaseExecution();
+        await pipeline.CompleteAsync().ConfigureAwait(false);
+        await pipeline.Completion.ConfigureAwait(false);
+    }
+
+    private static (IPipeline<TestPipelineRecord> Pipeline, BlockingAsyncDestination Destination) CreatePipeline(
+        string pipelineName,
+        PipelineFlowControlOptions flowControlOptions)
+    {
+        var destination = new BlockingAsyncDestination();
+
+        var pipeline = Pipeline<TestPipelineRecord>.New(pipelineName)
+            .UsePerformanceOptions(new PipelinePerformanceOptions
+            {
+                SourceExecution = new PipelineExecutionOptions
+                {
+                    BoundedCapacity = 1,
+                    DegreeOfParallelism = 1,
+                    EnsureOrdered = true
+                },
+                DestinationExecution = new PipelineExecutionOptions
+                {
+                    BoundedCapacity = 1,
+                    DegreeOfParallelism = 1,
+                    EnsureOrdered = true
+                }
+            })
+            .UseFlowControlOptions(flowControlOptions)
+            .WithInMemorySource(new object())
+            .WithDestination(destination)
+            .Build();
+
+        return (pipeline, destination);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds first-class flow control and backpressure support to Pipelinez so publish behavior under saturation is explicit, configurable, and observable.

## What Changed

### Flow-control configuration
- Added `PipelineFlowControlOptions`
- Added `UseFlowControlOptions(...)` to the pipeline builder
- Added `PipelineOverflowPolicy` with:
  - `Wait`
  - `Reject`
  - `Cancel`
- Added configurable publish timeout and saturation warning threshold

### Publish API
- Added `PublishAsync(record, PipelinePublishOptions)`
- Added `PipelinePublishOptions` for per-call timeout, cancellation, and overflow overrides
- Added `PipelinePublishResult` and `PipelinePublishResultReason`
- Kept the existing `PublishAsync(record)` convenience path for exception-based callers

### Runtime flow-control behavior
- Centralized publish mediation through a shared flow-control path instead of raw `SendAsync(...)`
- Added explicit handling for:
  - waiting for capacity
  - immediate rejection when full
  - cooperative cancellation while waiting
  - timeout while waiting
- Preserved existing bounded-capacity behavior as the underlying mechanism, but elevated it into an intentional public runtime contract

### Saturation status and observability
- Added `FlowControlStatus` to pipeline status
- Added per-component flow state through `PipelineComponentStatus.Flow`
- Added `PipelineComponentFlowStatus`
- Added runtime events:
  - `OnSaturationChanged`
  - `OnPublishRejected`
- Added queue depth and saturation reporting for sources, segments, and destinations

### Performance metrics
- Extended performance snapshots with:
  - total publish wait count
  - average publish wait duration
  - total publish rejection count
  - peak buffered count
- Wired flow-pressure observations into the runtime performance collector

### Kafka behavior under pressure
- Added integration coverage proving downstream pressure slows Kafka-backed ingestion safely
- Verified that saturation does not fault the pipeline by itself
- Verified that pressure remains observable while the pipeline stays healthy

## Testing
Added coverage for:
- reject behavior when the pipeline is saturated
- timeout behavior while waiting for capacity
- cancellation behavior while waiting for capacity
- flow-control status visibility
- saturation event emission
- performance snapshot pressure metrics
- Kafka-backed downstream pressure and safe ingress slowdown

## Result
Pipelinez now treats backpressure as a first-class runtime capability rather than an internal implementation detail, giving consumers clear publish semantics, operational visibility, and safer behavior under sustained load.