### PR TITLE
Adding dead letter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Pipelinez is a small .NET 8 framework for building record-processing pipelines w
 - async startup and completion
 - fault tracking and configurable error policies
 - configurable retry policies for segments and destinations
+- dead-letter destinations for preserving failed records
 - explicit flow control and saturation observability
 - optional distributed execution for transport-backed sources
 - explicit performance tuning and runtime performance snapshots
@@ -82,6 +83,7 @@ Kafka support lives in the separate `Pipelinez.Kafka` assembly and extends the c
 
 - `WithKafkaSource(...)`
 - `WithKafkaDestination(...)`
+- `WithKafkaDeadLetterDestination(...)`
 
 Example shape:
 
@@ -308,6 +310,47 @@ pipeline.OnPipelineRecordRetrying += (_, args) =>
 
 Retry exhaustion flows into the existing `WithErrorHandler(...)` path, so consumers can still decide whether to skip, stop, or rethrow once the configured retry policy has been exhausted.
 
+## Dead-Lettering
+
+Pipelinez supports first-class dead-letter handling for faulted records.
+
+Dead-letter configuration can be applied through:
+
+- `WithDeadLetterDestination(...)`
+- `UseDeadLetterOptions(...)`
+- `WithKafkaDeadLetterDestination(...)`
+
+When an error handler returns `PipelineErrorAction.DeadLetter`, the runtime:
+
+- preserves the failed record in a `PipelineDeadLetterRecord<T>`
+- includes fault state, metadata, segment history, retry history, and distribution context
+- writes that envelope to the configured dead-letter destination
+- continues processing later records if the dead-letter write succeeds
+
+Example shape:
+
+```csharp
+using Pipelinez.Core.DeadLettering;
+
+var deadLetters = new InMemoryDeadLetterDestination<MyRecord>();
+
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .WithInMemorySource(new object())
+    .AddSegment(new MySegment(), new object())
+    .WithInMemoryDestination("config")
+    .WithDeadLetterDestination(deadLetters)
+    .WithErrorHandler(_ => PipelineErrorAction.DeadLetter)
+    .Build();
+
+pipeline.OnPipelineRecordDeadLettered += (_, args) =>
+{
+    Console.WriteLine(
+        $"Dead-lettered {args.Record.Id} from {args.DeadLetterRecord.Fault.ComponentName}");
+};
+```
+
+Kafka-backed pipelines can route failures to a dead-letter topic through `WithKafkaDeadLetterDestination(...)`.
+
 ## Error Handling
 
 Pipelinez supports explicit fault handling through `WithErrorHandler(...)`.
@@ -316,6 +359,8 @@ Available actions:
 
 - `SkipRecord`
   continue processing later records
+- `DeadLetter`
+  preserve the failed record through the configured dead-letter destination and continue when that write succeeds
 - `StopPipeline`
   fault and stop the pipeline
 - `Rethrow`
@@ -328,6 +373,8 @@ Public events include:
 - `OnPublishRejected`
 - `OnPipelineRecordCompleted`
 - `OnPipelineRecordFaulted`
+- `OnPipelineRecordDeadLettered`
+- `OnPipelineDeadLetterWriteFailed`
 - `OnPipelineFaulted`
 - `OnWorkerStarted`
 - `OnPartitionsAssigned`
@@ -392,6 +439,7 @@ Current implemented capabilities include:
 - segment execution history
 - configurable error policies
 - configurable retry policies with retry events and retry history
+- dead-letter destinations, dead-letter events, and dead-letter performance counters
 - configurable flow-control policies with saturation status and publish result handling
 - async destination execution
 - distributed runtime mode and worker/partition observability

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -51,7 +51,9 @@ The core builder currently supports:
 - `AddSegment(...)`
 - `WithDestination(...)`
 - `WithInMemoryDestination(...)`
+- `WithDeadLetterDestination(...)`
 - `UseHostOptions(...)`
+- `UseDeadLetterOptions(...)`
 - `UseFlowControlOptions(...)`
 - `UsePerformanceOptions(...)`
 - `UseRetryOptions(...)`
@@ -62,6 +64,7 @@ Kafka integrates through extension methods in `Pipelinez.Kafka`, not through par
 
 - `WithKafkaSource(...)`
 - `WithKafkaDestination(...)`
+- `WithKafkaDeadLetterDestination(...)`
 
 `Build()` validates that a source and destination exist, creates a `Pipeline<T>`, links all blocks, and initializes the source and destination.
 If distributed execution is requested, `Build()` also validates that the configured source implements the distributed source contract.
@@ -196,6 +199,8 @@ Segment defaults remain conservative, but callers can now opt into higher-throug
 - total retry count
 - successful retry recovery count
 - retry exhaustion count
+- total dead-lettered count
+- total dead-letter failure count
 - total publish wait count
 - average publish wait duration
 - total publish rejection count
@@ -438,6 +443,10 @@ The pipeline exposes:
   raised after a record successfully completes the entire pipeline
 - `OnPipelineRecordFaulted`
   raised when a record faults and enters policy handling
+- `OnPipelineRecordDeadLettered`
+  raised when a faulted record is preserved through the configured dead-letter path
+- `OnPipelineDeadLetterWriteFailed`
+  raised when a dead-letter write attempt fails
 - `OnPipelineFaulted`
   raised when the pipeline transitions into a faulted runtime state
 
@@ -459,6 +468,8 @@ The handler returns a `PipelineErrorAction`:
 
 - `SkipRecord`
   skip the faulted record and continue processing
+- `DeadLetter`
+  preserve the faulted record through the configured dead-letter destination and continue if the dead-letter write succeeds
 - `StopPipeline`
   mark the pipeline faulted and stop processing
 - `Rethrow`
@@ -466,6 +477,30 @@ The handler returns a `PipelineErrorAction`:
 
 If no handler is configured, the default behavior is to stop the pipeline on fault.
 Retries always run before the error handler is invoked. If retry eventually succeeds, the error handler is never called. If retry is exhausted, the handler receives the populated retry context and can decide whether to skip, stop, or rethrow.
+
+### Dead-Letter Model
+
+Dead-lettering is now a first-class terminal record outcome.
+
+When a handler returns `DeadLetter`, the runtime:
+
+1. builds a `PipelineDeadLetterRecord<T>`
+2. copies the original record, fault state, metadata, segment history, retry history, and distribution context
+3. writes that envelope to the configured `IPipelineDeadLetterDestination<T>`
+4. treats the record as terminally handled without raising the normal completion event
+
+Dead-letter writes are available through:
+
+- `InMemoryDeadLetterDestination<T>` in core
+- `WithKafkaDeadLetterDestination(...)` in `Pipelinez.Kafka`
+
+Dead-letter write failures are explicit:
+
+- by default they fault the pipeline
+- they raise `OnPipelineDeadLetterWriteFailed`
+- they increment dead-letter failure counters in `PipelinePerformanceSnapshot`
+
+The dead-letter path does not require special removal from TPL Dataflow blocks. Faulted containers already leave the active block as part of normal execution and then reach the destination-side terminal fault handler, where the dead-letter decision is applied.
 
 ## Status And Observability
 
@@ -507,6 +542,7 @@ Kafka extends the builder through `KafkaPipelineBuilderExtensions`:
 
 - `WithKafkaSource(...)`
 - `WithKafkaDestination(...)`
+- `WithKafkaDeadLetterDestination(...)`
 
 Kafka source configuration can now also include `KafkaPartitionScalingOptions`, either by setting `KafkaSourceOptions.PartitionScaling` directly or by using the overload that accepts partition scaling explicitly.
 
@@ -572,6 +608,16 @@ The default is to preserve ordering within a partition while still allowing conc
 
 The destination only treats the record as complete after broker delivery has been awaited successfully.
 
+### Kafka Dead-Letter Destination
+
+`KafkaDeadLetterDestination<T, TRecordKey, TRecordValue>`:
+
+- reuses the existing Kafka producer infrastructure
+- maps `PipelineDeadLetterRecord<T>` into a Kafka `Message<TKey, TValue>`
+- copies pipeline headers into the dead-letter message
+- adds dead-letter fault headers for component, component kind, and fault timestamp
+- awaits broker acknowledgement before the runtime treats the dead-letter write as successful
+
 ### Configuration
 
 Kafka configuration types include:
@@ -632,6 +678,7 @@ The solution now includes two test layers.
 `src/tests/Pipelinez.Kafka.Tests` uses Docker and `Testcontainers.Kafka` to run broker-backed integration tests that validate:
 
 - source-topic to destination-topic flow
+- dead-letter topic publishing for faulted records
 - header propagation through Kafka and the pipeline runtime
 - segment fault handling with `SkipRecord`, `StopPipeline`, and `Rethrow`
 - destination fault handling
@@ -663,6 +710,7 @@ The major architectural work called out in the earlier planning docs has been im
 - explicit partition-aware Kafka scaling with partition execution state, drain events, and per-partition scheduling rules
 - explicit performance tuning controls, built-in performance snapshots, destination batching, and a benchmark project
 - explicit retry policies with retry history, retry events, and retry-aware performance counters
+- explicit dead-letter flows with in-memory and Kafka dead-letter destinations
 - explicit flow-control policies with publish results, saturation status, and pressure metrics
 
 The remaining work is mostly future evolution work rather than foundational cleanup. Likely areas include broader transport coverage, schema-registry integration tests, and further runtime ergonomics.

--- a/src/Pipelinez.Kafka/Kafka/Destination/KafkaDeadLetterDestination.cs
+++ b/src/Pipelinez.Kafka/Kafka/Destination/KafkaDeadLetterDestination.cs
@@ -1,0 +1,67 @@
+using Ardalis.GuardClauses;
+using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+using System.Text;
+using Pipelinez.Core.DeadLettering;
+using Pipelinez.Core.Logging;
+using Pipelinez.Core.Record;
+using Pipelinez.Kafka.Client;
+using Pipelinez.Kafka.Configuration;
+using Pipelinez.Kafka.Record;
+
+namespace Pipelinez.Kafka.Destination;
+
+public sealed class KafkaDeadLetterDestination<T, TRecordKey, TRecordValue>
+    : IPipelineDeadLetterDestination<T>
+    where T : PipelineRecord
+    where TRecordKey : class
+    where TRecordValue : class
+{
+    private readonly KafkaDestinationOptions _config;
+    private readonly Func<PipelineDeadLetterRecord<T>, Message<TRecordKey, TRecordValue>> _messageMapper;
+    private readonly ILogger<KafkaDeadLetterDestination<T, TRecordKey, TRecordValue>> _logger;
+    private IKafkaProducer<TRecordKey, TRecordValue>? _producer;
+
+    public KafkaDeadLetterDestination(
+        string pipelineName,
+        KafkaDestinationOptions config,
+        Func<PipelineDeadLetterRecord<T>, Message<TRecordKey, TRecordValue>> messageMapper)
+    {
+        _config = Guard.Against.Null(config, nameof(config));
+        _messageMapper = Guard.Against.Null(messageMapper, nameof(messageMapper));
+        _logger = LoggingManager.Instance.CreateLogger<KafkaDeadLetterDestination<T, TRecordKey, TRecordValue>>();
+        _producer = KafkaClientFactory.CreateProducer<TRecordKey, TRecordValue>(
+            Guard.Against.NullOrWhiteSpace(pipelineName, nameof(pipelineName)),
+            _config);
+    }
+
+    public async Task WriteAsync(
+        PipelineDeadLetterRecord<T> deadLetterRecord,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(deadLetterRecord);
+
+        var message = _messageMapper(deadLetterRecord);
+        message.Headers ??= new Headers();
+
+        foreach (var header in deadLetterRecord.Record.Headers)
+        {
+            message.Headers.Add(header.ToKafkaHeader());
+        }
+
+        message.Headers.Add("pipelinez-deadletter-component", Encoding.UTF8.GetBytes(deadLetterRecord.Fault.ComponentName));
+        message.Headers.Add("pipelinez-deadletter-kind", Encoding.UTF8.GetBytes(deadLetterRecord.Fault.ComponentKind.ToString()));
+        message.Headers.Add("pipelinez-deadletter-occurred-at", Encoding.UTF8.GetBytes(deadLetterRecord.Fault.OccurredAtUtc.ToString("O")));
+
+        await Producer
+            .ProduceAsync(_config.TopicName, message, cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogTrace(
+            "Dead-letter Kafka message produced to topic {TopicName}",
+            _config.TopicName);
+    }
+
+    private IKafkaProducer<TRecordKey, TRecordValue> Producer =>
+        _producer ?? throw new InvalidOperationException("Kafka dead-letter producer has not been initialized.");
+}

--- a/src/Pipelinez.Kafka/Kafka/KafkaPipelineBuilderExtensions.cs
+++ b/src/Pipelinez.Kafka/Kafka/KafkaPipelineBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Confluent.Kafka;
 using Pipelinez.Core;
+using Pipelinez.Core.DeadLettering;
 using Pipelinez.Core.Record;
 using Pipelinez.Kafka.Configuration;
 using Pipelinez.Kafka.Destination;
@@ -52,6 +53,24 @@ public static class KafkaPipelineBuilderExtensions
         ArgumentNullException.ThrowIfNull(recordMapper);
 
         return builder.WithDestination(new KafkaPipelineDestination<T, TRecordKey, TRecordValue>(
+            builder.PipelineName,
+            config,
+            recordMapper));
+    }
+
+    public static PipelineBuilder<T> WithKafkaDeadLetterDestination<T, TRecordKey, TRecordValue>(
+        this PipelineBuilder<T> builder,
+        KafkaDestinationOptions config,
+        Func<PipelineDeadLetterRecord<T>, Message<TRecordKey, TRecordValue>> recordMapper)
+        where TRecordKey : class
+        where TRecordValue : class
+        where T : PipelineRecord
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(recordMapper);
+
+        return builder.WithDeadLetterDestination(new KafkaDeadLetterDestination<T, TRecordKey, TRecordValue>(
             builder.PipelineName,
             config,
             recordMapper));

--- a/src/Pipelinez.Kafka/Kafka/Source/KafkaPipelineSource.cs
+++ b/src/Pipelinez.Kafka/Kafka/Source/KafkaPipelineSource.cs
@@ -168,7 +168,7 @@ public class KafkaPipelineSource<T, TRecordKey, TRecordValue> : PipelineSourceBa
 
         HandleTerminalRecord(
             topicPartitionOffset,
-            canAdvanceProgress: e.Action == PipelineErrorAction.SkipRecord);
+            canAdvanceProgress: e.Action is PipelineErrorAction.SkipRecord or PipelineErrorAction.DeadLetter);
     }
 
     private IKafkaConsumer<TRecordKey, TRecordValue> Consumer =>

--- a/src/Pipelinez/Core/DeadLettering/IPipelineDeadLetterDestination.cs
+++ b/src/Pipelinez/Core/DeadLettering/IPipelineDeadLetterDestination.cs
@@ -1,0 +1,8 @@
+using Pipelinez.Core.Record;
+
+namespace Pipelinez.Core.DeadLettering;
+
+public interface IPipelineDeadLetterDestination<T> where T : PipelineRecord
+{
+    Task WriteAsync(PipelineDeadLetterRecord<T> deadLetterRecord, CancellationToken cancellationToken);
+}

--- a/src/Pipelinez/Core/DeadLettering/InMemoryDeadLetterDestination.cs
+++ b/src/Pipelinez/Core/DeadLettering/InMemoryDeadLetterDestination.cs
@@ -1,0 +1,20 @@
+using System.Collections.Concurrent;
+using Pipelinez.Core.Record;
+
+namespace Pipelinez.Core.DeadLettering;
+
+public sealed class InMemoryDeadLetterDestination<T> : IPipelineDeadLetterDestination<T>
+    where T : PipelineRecord
+{
+    private readonly ConcurrentQueue<PipelineDeadLetterRecord<T>> _records = new();
+
+    public IReadOnlyList<PipelineDeadLetterRecord<T>> Records => _records.ToArray();
+
+    public Task WriteAsync(PipelineDeadLetterRecord<T> deadLetterRecord, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(deadLetterRecord);
+        cancellationToken.ThrowIfCancellationRequested();
+        _records.Enqueue(deadLetterRecord);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Pipelinez/Core/DeadLettering/PipelineDeadLetterOptions.cs
+++ b/src/Pipelinez/Core/DeadLettering/PipelineDeadLetterOptions.cs
@@ -1,0 +1,15 @@
+namespace Pipelinez.Core.DeadLettering;
+
+public sealed class PipelineDeadLetterOptions
+{
+    public bool EmitDeadLetterEvents { get; init; } = true;
+
+    public bool TreatDeadLetterFailureAsPipelineFault { get; init; } = true;
+
+    public bool CloneMetadata { get; init; } = true;
+
+    public PipelineDeadLetterOptions Validate()
+    {
+        return this;
+    }
+}

--- a/src/Pipelinez/Core/DeadLettering/PipelineDeadLetterRecord.cs
+++ b/src/Pipelinez/Core/DeadLettering/PipelineDeadLetterRecord.cs
@@ -1,0 +1,37 @@
+using Ardalis.GuardClauses;
+using Pipelinez.Core.Distributed;
+using Pipelinez.Core.FaultHandling;
+using Pipelinez.Core.Record;
+using Pipelinez.Core.Record.Metadata;
+using Pipelinez.Core.Retry;
+
+namespace Pipelinez.Core.DeadLettering;
+
+public sealed class PipelineDeadLetterRecord<T> where T : PipelineRecord
+{
+    public required T Record { get; init; }
+
+    public required PipelineFaultState Fault { get; init; }
+
+    public required MetadataCollection Metadata { get; init; }
+
+    public required IReadOnlyList<PipelineSegmentExecution> SegmentHistory { get; init; }
+
+    public required IReadOnlyList<PipelineRetryAttempt> RetryHistory { get; init; }
+
+    public required DateTimeOffset CreatedAtUtc { get; init; }
+
+    public required DateTimeOffset DeadLetteredAtUtc { get; init; }
+
+    public required PipelineRecordDistributionContext Distribution { get; init; }
+
+    public void Validate()
+    {
+        Guard.Against.Null(Record, nameof(Record));
+        Guard.Against.Null(Fault, nameof(Fault));
+        Guard.Against.Null(Metadata, nameof(Metadata));
+        Guard.Against.Null(SegmentHistory, nameof(SegmentHistory));
+        Guard.Against.Null(RetryHistory, nameof(RetryHistory));
+        Guard.Against.Null(Distribution, nameof(Distribution));
+    }
+}

--- a/src/Pipelinez/Core/Destination/PipelineDestination.cs
+++ b/src/Pipelinez/Core/Destination/PipelineDestination.cs
@@ -386,6 +386,11 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
             return true;
         }
 
+        if (action == PipelineErrorAction.DeadLetter)
+        {
+            return true;
+        }
+
         if (action == PipelineErrorAction.Rethrow)
         {
             ExceptionDispatchInfo.Capture(sourceRecord.Fault!.Exception).Throw();

--- a/src/Pipelinez/Core/ErrorHandling/PipelineErrorAction.cs
+++ b/src/Pipelinez/Core/ErrorHandling/PipelineErrorAction.cs
@@ -4,5 +4,6 @@ public enum PipelineErrorAction
 {
     StopPipeline,
     SkipRecord,
-    Rethrow
+    Rethrow,
+    DeadLetter
 }

--- a/src/Pipelinez/Core/Eventing/Eventing.cs
+++ b/src/Pipelinez/Core/Eventing/Eventing.cs
@@ -1,4 +1,5 @@
 using Ardalis.GuardClauses;
+using Pipelinez.Core.DeadLettering;
 using Pipelinez.Core.Distributed;
 using Pipelinez.Core.FaultHandling;
 using Pipelinez.Core.Record;
@@ -75,6 +76,14 @@ public delegate void PipelineSaturationChangedEventHandler(
 public delegate void PipelinePublishRejectedEventHandler<T>(
     object sender,
     PipelinePublishRejectedEventArgs<T> args) where T : PipelineRecord;
+
+public delegate void PipelineRecordDeadLetteredEventHandler<T>(
+    object sender,
+    PipelineRecordDeadLetteredEventArgs<T> args) where T : PipelineRecord;
+
+public delegate void PipelineDeadLetterWriteFailedEventHandler<T>(
+    object sender,
+    PipelineDeadLetterWriteFailedEventArgs<T> args) where T : PipelineRecord;
 
 public sealed class PipelineRecordFaultedEventArgs<T> where T : PipelineRecord
 {
@@ -176,6 +185,40 @@ public sealed class PipelinePublishRejectedEventArgs<T> where T : PipelineRecord
     public FlowControl.PipelinePublishResultReason Reason { get; }
 
     public DateTimeOffset ObservedAtUtc { get; }
+}
+
+public sealed class PipelineRecordDeadLetteredEventArgs<T> where T : PipelineRecord
+{
+    public PipelineRecordDeadLetteredEventArgs(
+        T record,
+        PipelineDeadLetterRecord<T> deadLetterRecord)
+    {
+        Record = Guard.Against.Null(record, nameof(record));
+        DeadLetterRecord = Guard.Against.Null(deadLetterRecord, nameof(deadLetterRecord));
+    }
+
+    public T Record { get; }
+
+    public PipelineDeadLetterRecord<T> DeadLetterRecord { get; }
+}
+
+public sealed class PipelineDeadLetterWriteFailedEventArgs<T> where T : PipelineRecord
+{
+    public PipelineDeadLetterWriteFailedEventArgs(
+        T record,
+        PipelineDeadLetterRecord<T> deadLetterRecord,
+        Exception exception)
+    {
+        Record = Guard.Against.Null(record, nameof(record));
+        DeadLetterRecord = Guard.Against.Null(deadLetterRecord, nameof(deadLetterRecord));
+        Exception = Guard.Against.Null(exception, nameof(exception));
+    }
+
+    public T Record { get; }
+
+    public PipelineDeadLetterRecord<T> DeadLetterRecord { get; }
+
+    public Exception Exception { get; }
 }
 
 public delegate void PipelineFaultedEventHandler(object sender, PipelineFaultedEventArgs args);

--- a/src/Pipelinez/Core/IPipeline.cs
+++ b/src/Pipelinez/Core/IPipeline.cs
@@ -1,4 +1,5 @@
 using Pipelinez.Core.Distributed;
+using Pipelinez.Core.DeadLettering;
 using Pipelinez.Core.Eventing;
 using Pipelinez.Core.FlowControl;
 using Pipelinez.Core.Performance;
@@ -58,6 +59,16 @@ public interface IPipeline<T> where T : PipelineRecord
     /// Event that is raised when a record is scheduled for retry after a transient failure.
     /// </summary>
     event PipelineRecordRetryingEventHandler<T> OnPipelineRecordRetrying;
+
+    /// <summary>
+    /// Event that is raised when a faulted record is preserved through the dead-letter path.
+    /// </summary>
+    event PipelineRecordDeadLetteredEventHandler<T> OnPipelineRecordDeadLettered;
+
+    /// <summary>
+    /// Event that is raised when a dead-letter write attempt fails.
+    /// </summary>
+    event PipelineDeadLetterWriteFailedEventHandler<T> OnPipelineDeadLetterWriteFailed;
 
     /// <summary>
     /// Event that is raised when pipeline saturation state changes.

--- a/src/Pipelinez/Core/Performance/IPipelinePerformanceCollector.cs
+++ b/src/Pipelinez/Core/Performance/IPipelinePerformanceCollector.cs
@@ -16,6 +16,10 @@ internal interface IPipelinePerformanceCollector
 
     void RecordRetryExhausted();
 
+    void RecordDeadLettered();
+
+    void RecordDeadLetterFailure();
+
     void RecordPublishWait(TimeSpan waitDuration);
 
     void RecordPublishRejected();

--- a/src/Pipelinez/Core/Performance/PipelinePerformanceCollector.cs
+++ b/src/Pipelinez/Core/Performance/PipelinePerformanceCollector.cs
@@ -22,6 +22,8 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
     private long _retryCount;
     private long _retryRecoveries;
     private long _retryExhaustions;
+    private long _deadLetterCount;
+    private long _deadLetterFailureCount;
     private long _publishWaitCount;
     private long _publishRejectedCount;
     private long _totalPublishWaitDurationTicks;
@@ -138,6 +140,32 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
         }
     }
 
+    public void RecordDeadLettered()
+    {
+        if (!_metricsOptions.EnableRuntimeMetrics)
+        {
+            return;
+        }
+
+        lock (_syncLock)
+        {
+            _deadLetterCount++;
+        }
+    }
+
+    public void RecordDeadLetterFailure()
+    {
+        if (!_metricsOptions.EnableRuntimeMetrics)
+        {
+            return;
+        }
+
+        lock (_syncLock)
+        {
+            _deadLetterFailureCount++;
+        }
+    }
+
     public void RecordPublishWait(TimeSpan waitDuration)
     {
         if (!_metricsOptions.EnableRuntimeMetrics || waitDuration <= TimeSpan.Zero)
@@ -223,6 +251,8 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
                 _retryCount,
                 _retryRecoveries,
                 _retryExhaustions,
+                _deadLetterCount,
+                _deadLetterFailureCount,
                 _publishWaitCount,
                 averagePublishWait,
                 _publishRejectedCount,

--- a/src/Pipelinez/Core/Performance/PipelinePerformanceSnapshot.cs
+++ b/src/Pipelinez/Core/Performance/PipelinePerformanceSnapshot.cs
@@ -11,6 +11,8 @@ public sealed class PipelinePerformanceSnapshot
         long totalRetryCount,
         long successfulRetryRecoveries,
         long retryExhaustions,
+        long totalDeadLetteredCount,
+        long totalDeadLetterFailureCount,
         long totalPublishWaitCount,
         TimeSpan averagePublishWaitDuration,
         long totalPublishRejectedCount,
@@ -27,6 +29,8 @@ public sealed class PipelinePerformanceSnapshot
         TotalRetryCount = totalRetryCount;
         SuccessfulRetryRecoveries = successfulRetryRecoveries;
         RetryExhaustions = retryExhaustions;
+        TotalDeadLetteredCount = totalDeadLetteredCount;
+        TotalDeadLetterFailureCount = totalDeadLetterFailureCount;
         TotalPublishWaitCount = totalPublishWaitCount;
         AveragePublishWaitDuration = averagePublishWaitDuration;
         TotalPublishRejectedCount = totalPublishRejectedCount;
@@ -51,6 +55,10 @@ public sealed class PipelinePerformanceSnapshot
     public long SuccessfulRetryRecoveries { get; }
 
     public long RetryExhaustions { get; }
+
+    public long TotalDeadLetteredCount { get; }
+
+    public long TotalDeadLetterFailureCount { get; }
 
     public long TotalPublishWaitCount { get; }
 

--- a/src/Pipelinez/Core/Pipeline.cs
+++ b/src/Pipelinez/Core/Pipeline.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks.Dataflow;
 using System.Runtime.ExceptionServices;
 using Ardalis.GuardClauses;
 using Microsoft.Extensions.Logging;
+using Pipelinez.Core.DeadLettering;
 using Pipelinez.Core.Distributed;
 using Pipelinez.Core.Destination;
 using Pipelinez.Core.ErrorHandling;
@@ -53,6 +54,8 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     private readonly IPipelineDestination<TPipelineRecord> _destination;
     private readonly PipelineErrorHandler<TPipelineRecord>? _errorHandler;
     private readonly PipelineHostOptions _hostOptions;
+    private readonly IPipelineDeadLetterDestination<TPipelineRecord>? _deadLetterDestination;
+    private readonly PipelineDeadLetterOptions _deadLetterOptions;
     private readonly PipelineFlowControlOptions _flowControlOptions;
     private readonly IPipelinePerformanceCollector _performanceCollector;
     private readonly bool _emitRetryEvents;
@@ -105,6 +108,8 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     /// Occurs when a record is about to be retried after a transient failure.
     /// </summary>
     public event PipelineRecordRetryingEventHandler<TPipelineRecord>? OnPipelineRecordRetrying;
+    public event PipelineRecordDeadLetteredEventHandler<TPipelineRecord>? OnPipelineRecordDeadLettered;
+    public event PipelineDeadLetterWriteFailedEventHandler<TPipelineRecord>? OnPipelineDeadLetterWriteFailed;
     public event PipelineSaturationChangedEventHandler? OnSaturationChanged;
     public event PipelinePublishRejectedEventHandler<TPipelineRecord>? OnPublishRejected;
 
@@ -212,6 +217,15 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
                         PipelineErrorAction.SkipRecord));
                 ObserveFlowControlState();
                 return PipelineErrorAction.SkipRecord;
+            case PipelineErrorAction.DeadLetter:
+                await HandleDeadLetterAsync(container, container.Fault).ConfigureAwait(false);
+                OnPipelineContainerFaultHandled?.Invoke(
+                    this,
+                    new PipelineContainerFaultHandledEventHandlerArgs<PipelineContainer<TPipelineRecord>>(
+                        container,
+                        PipelineErrorAction.DeadLetter));
+                ObserveFlowControlState();
+                return PipelineErrorAction.DeadLetter;
             case PipelineErrorAction.StopPipeline:
                 OnPipelineContainerFaultHandled?.Invoke(
                     this,
@@ -244,6 +258,8 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         IList<IPipelineSegment<TPipelineRecord>> segments,
         PipelineErrorHandler<TPipelineRecord>? errorHandler = null,
         PipelineHostOptions? hostOptions = null,
+        IPipelineDeadLetterDestination<TPipelineRecord>? deadLetterDestination = null,
+        PipelineDeadLetterOptions? deadLetterOptions = null,
         PipelineFlowControlOptions? flowControlOptions = null,
         IPipelinePerformanceCollector? performanceCollector = null,
         bool emitRetryEvents = true)
@@ -260,6 +276,8 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         this._segments = segments;
         this._errorHandler = errorHandler;
         _hostOptions = hostOptions ?? new PipelineHostOptions();
+        _deadLetterDestination = deadLetterDestination;
+        _deadLetterOptions = (deadLetterOptions ?? new PipelineDeadLetterOptions()).Validate();
         _flowControlOptions = (flowControlOptions ?? new PipelineFlowControlOptions()).Validate();
         _performanceCollector = performanceCollector ?? new PipelinePerformanceCollector(new PipelineMetricsOptions());
         _emitRetryEvents = emitRetryEvents;
@@ -820,6 +838,63 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         }
     }
 
+    private async Task HandleDeadLetterAsync(
+        PipelineContainer<TPipelineRecord> container,
+        PipelineFaultState fault)
+    {
+        var deadLetterRecord = CreateDeadLetterRecord(container, fault);
+
+        if (_deadLetterDestination is null)
+        {
+            var configurationException = new InvalidOperationException(
+                $"Pipeline '{_name}' resolved a faulted record to '{PipelineErrorAction.DeadLetter}', but no dead-letter destination is configured.");
+            var configurationFault = CreatePipelineFaultState(
+                configurationException,
+                "PipelineDeadLetterDestination",
+                PipelineComponentKind.Pipeline,
+                configurationException.Message);
+
+            _performanceCollector.RecordDeadLetterFailure();
+            RaiseDeadLetterWriteFailed(container.Record, deadLetterRecord, configurationException);
+            FaultPipeline(configurationFault);
+            throw configurationException;
+        }
+
+        try
+        {
+            await _deadLetterDestination
+                .WriteAsync(deadLetterRecord, _runtimeCancellationTokenSource?.Token ?? CancellationToken.None)
+                .ConfigureAwait(false);
+
+            _performanceCollector.RecordDeadLettered();
+            RaiseDeadLettered(container.Record, deadLetterRecord);
+        }
+        catch (Exception exception)
+        {
+            _performanceCollector.RecordDeadLetterFailure();
+            RaiseDeadLetterWriteFailed(container.Record, deadLetterRecord, exception);
+
+            if (!_deadLetterOptions.TreatDeadLetterFailureAsPipelineFault)
+            {
+                Logger.LogWarning(
+                    exception,
+                    "Dead-letter write failed in pipeline {PipelineName}, but runtime is configured to continue.",
+                    _name);
+                return;
+            }
+
+            var componentName = _deadLetterDestination.GetType().Name;
+            var deadLetterFault = CreatePipelineFaultState(
+                exception,
+                componentName,
+                PipelineComponentKind.Destination,
+                exception.Message);
+
+            FaultPipeline(deadLetterFault);
+            throw;
+        }
+    }
+
     private PipelineDistributedStatus GetDistributedStatus()
     {
         lock (_distributionLock)
@@ -896,6 +971,56 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
             metadata.GetValue(DistributedMetadataKeys.PartitionKey),
             TryParseInt(metadata.GetValue(DistributedMetadataKeys.PartitionId)),
             TryParseLong(metadata.GetValue(DistributedMetadataKeys.Offset)));
+    }
+
+    private PipelineDeadLetterRecord<TPipelineRecord> CreateDeadLetterRecord(
+        PipelineContainer<TPipelineRecord> container,
+        PipelineFaultState fault)
+    {
+        var deadLetterRecord = new PipelineDeadLetterRecord<TPipelineRecord>
+        {
+            Record = container.Record,
+            Fault = fault,
+            Metadata = _deadLetterOptions.CloneMetadata
+                ? container.Metadata.Clone()
+                : container.Metadata,
+            SegmentHistory = container.SegmentHistory.ToArray(),
+            RetryHistory = container.RetryHistory.ToArray(),
+            CreatedAtUtc = container.CreatedAtUtc,
+            DeadLetteredAtUtc = DateTimeOffset.UtcNow,
+            Distribution = BuildDistributionContext(container.Metadata)
+        };
+        deadLetterRecord.Validate();
+        return deadLetterRecord;
+    }
+
+    private void RaiseDeadLettered(
+        TPipelineRecord record,
+        PipelineDeadLetterRecord<TPipelineRecord> deadLetterRecord)
+    {
+        if (!_deadLetterOptions.EmitDeadLetterEvents)
+        {
+            return;
+        }
+
+        OnPipelineRecordDeadLettered?.Invoke(
+            this,
+            new PipelineRecordDeadLetteredEventArgs<TPipelineRecord>(record, deadLetterRecord));
+    }
+
+    private void RaiseDeadLetterWriteFailed(
+        TPipelineRecord record,
+        PipelineDeadLetterRecord<TPipelineRecord> deadLetterRecord,
+        Exception exception)
+    {
+        if (!_deadLetterOptions.EmitDeadLetterEvents)
+        {
+            return;
+        }
+
+        OnPipelineDeadLetterWriteFailed?.Invoke(
+            this,
+            new PipelineDeadLetterWriteFailedEventArgs<TPipelineRecord>(record, deadLetterRecord, exception));
     }
 
     private void RaiseWorkerStartedIfNeeded()

--- a/src/Pipelinez/Core/PipelineBuilder.cs
+++ b/src/Pipelinez/Core/PipelineBuilder.cs
@@ -1,6 +1,7 @@
 using Ardalis.GuardClauses;
 using Microsoft.Extensions.Logging;
 using Pipelinez.Core.Distributed;
+using Pipelinez.Core.DeadLettering;
 using Pipelinez.Core.Destination;
 using Pipelinez.Core.ErrorHandling;
 using Pipelinez.Core.FlowControl;
@@ -31,8 +32,10 @@ public class PipelineBuilder<T>(string pipelineName)
     private IPipelineDestination<T>? _destination;
     private PipelineExecutionOptions? _destinationExecutionOptions;
     private PipelineRetryPolicy<T>? _destinationRetryPolicy;
+    private IPipelineDeadLetterDestination<T>? _deadLetterDestination;
     private PipelineErrorHandler<T>? _errorHandler;
     private PipelineHostOptions _hostOptions = new();
+    private PipelineDeadLetterOptions _deadLetterOptions = new();
     private PipelineFlowControlOptions _flowControlOptions = new();
     private PipelinePerformanceOptions _performanceOptions = new();
     private PipelineRetryOptions<T> _retryOptions = new();
@@ -154,6 +157,12 @@ public class PipelineBuilder<T>(string pipelineName)
         return WithDestination(new InMemoryPipelineDestination<T>());
     }
 
+    public PipelineBuilder<T> WithDeadLetterDestination(IPipelineDeadLetterDestination<T> deadLetterDestination)
+    {
+        _deadLetterDestination = Guard.Against.Null(deadLetterDestination, nameof(deadLetterDestination));
+        return this;
+    }
+
     #endregion
 
     #region Logging
@@ -167,6 +176,12 @@ public class PipelineBuilder<T>(string pipelineName)
     #endregion
 
     #region Hosting
+
+    public PipelineBuilder<T> UseDeadLetterOptions(PipelineDeadLetterOptions options)
+    {
+        _deadLetterOptions = Guard.Against.Null(options, nameof(options)).Validate();
+        return this;
+    }
 
     public PipelineBuilder<T> UseHostOptions(PipelineHostOptions options)
     {
@@ -288,6 +303,8 @@ public class PipelineBuilder<T>(string pipelineName)
             _segments.Select(registration => registration.Segment).ToList(),
             _errorHandler,
             _hostOptions,
+            _deadLetterDestination,
+            _deadLetterOptions,
             _flowControlOptions,
             performanceCollector,
             _retryOptions.EmitRetryEvents);

--- a/src/Pipelinez/Core/Record/Metadata/MetadataCollection.cs
+++ b/src/Pipelinez/Core/Record/Metadata/MetadataCollection.cs
@@ -98,6 +98,18 @@ public class MetadataCollection : IList<MetadataRecord>
         Add(new MetadataRecord(key, value));
     }
 
+    public MetadataCollection Clone()
+    {
+        var clone = new MetadataCollection();
+
+        foreach (var item in _internalList)
+        {
+            clone.Add(new MetadataRecord(item.Key, item.Value));
+        }
+
+        return clone;
+    }
+
     public MetadataRecord this[int index]
     {
         get => _internalList[index];

--- a/src/tests/Pipelinez.Kafka.Tests/EndToEnd/KafkaPipelineDeadLetterTests.cs
+++ b/src/tests/Pipelinez.Kafka.Tests/EndToEnd/KafkaPipelineDeadLetterTests.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using Confluent.Kafka;
+using Pipelinez.Core;
+using Pipelinez.Core.ErrorHandling;
+using Pipelinez.Kafka;
+using Pipelinez.Kafka.Record;
+using Pipelinez.Kafka.Tests.Infrastructure;
+using Pipelinez.Kafka.Tests.Models;
+using Xunit;
+
+namespace Pipelinez.Kafka.Tests.EndToEnd;
+
+[Collection(KafkaIntegrationCollection.Name)]
+public sealed class KafkaPipelineDeadLetterTests(KafkaTestCluster cluster)
+{
+    [Fact]
+    public async Task KafkaPipeline_DeadLetter_Publishes_Faulted_Record_To_DeadLetter_Topic_And_Continues()
+    {
+        var scenarioName = nameof(KafkaPipeline_DeadLetter_Publishes_Faulted_Record_To_DeadLetter_Topic_And_Continues);
+        var sourceTopic = await cluster.CreateTopicAsync($"{scenarioName}-source").ConfigureAwait(false);
+        var destinationTopic = await cluster.CreateTopicAsync($"{scenarioName}-destination").ConfigureAwait(false);
+        var deadLetterTopic = await cluster.CreateTopicAsync($"{scenarioName}-deadletter").ConfigureAwait(false);
+        var consumerGroup = KafkaTopicNameFactory.CreateConsumerGroupName("pipelinez", scenarioName);
+
+        var pipeline = Pipeline<TestKafkaRecord>.New(scenarioName)
+            .WithKafkaSource(
+                cluster.CreateSourceOptions(sourceTopic, consumerGroup),
+                (string key, string value) => new TestKafkaRecord
+                {
+                    Key = key,
+                    Value = value
+                })
+            .AddSegment(new ConditionalFaultingKafkaSegment("bad"), new object())
+            .WithKafkaDestination(
+                cluster.CreateDestinationOptions(destinationTopic),
+                (TestKafkaRecord record) => new Message<string, string>
+                {
+                    Key = record.Key,
+                    Value = record.Value
+                })
+            .WithKafkaDeadLetterDestination(
+                cluster.CreateDestinationOptions(deadLetterTopic),
+                deadLetter => new Message<string, string>
+                {
+                    Key = deadLetter.Record.Key,
+                    Value = JsonSerializer.Serialize(new
+                    {
+                        key = deadLetter.Record.Key,
+                        value = deadLetter.Record.Value,
+                        component = deadLetter.Fault.ComponentName,
+                        retryCount = deadLetter.RetryHistory.Count,
+                        topic = deadLetter.Metadata.GetValue(KafkaMetadataKeys.SOURCE_TOPIC_NAME),
+                        partition = deadLetter.Metadata.GetValue(KafkaMetadataKeys.SOURCE_PARTITION),
+                        offset = deadLetter.Metadata.GetValue(KafkaMetadataKeys.SOURCE_OFFSET)
+                    })
+                })
+            .WithErrorHandler(_ => PipelineErrorAction.DeadLetter)
+            .Build();
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+
+        await cluster.ProduceAsync(
+            sourceTopic,
+            new[]
+            {
+                KafkaPipelineTestHelpers.CreateMessage("bad-1", "bad"),
+                KafkaPipelineTestHelpers.CreateMessage("good-1", "good")
+            }).ConfigureAwait(false);
+
+        var outputMessages = await cluster
+            .ConsumeAsync(
+                destinationTopic,
+                expectedCount: 1,
+                consumerGroup: KafkaTopicNameFactory.CreateConsumerGroupName("probe", $"{scenarioName}-destination"))
+            .ConfigureAwait(false);
+
+        var deadLetterMessages = await cluster
+            .ConsumeAsync(
+                deadLetterTopic,
+                expectedCount: 1,
+                consumerGroup: KafkaTopicNameFactory.CreateConsumerGroupName("probe", $"{scenarioName}-deadletter"))
+            .ConfigureAwait(false);
+
+        await pipeline.CompleteAsync().ConfigureAwait(false);
+        await pipeline.Completion.ConfigureAwait(false);
+
+        Assert.Single(outputMessages);
+        Assert.Equal("good-1", outputMessages[0].Message.Key);
+        Assert.Equal("good", outputMessages[0].Message.Value);
+
+        var deadLetterMessage = Assert.Single(deadLetterMessages);
+        Assert.Equal("bad-1", deadLetterMessage.Message.Key);
+
+        using var document = JsonDocument.Parse(deadLetterMessage.Message.Value);
+        var root = document.RootElement;
+        Assert.Equal("bad-1", root.GetProperty("key").GetString());
+        Assert.Equal("bad", root.GetProperty("value").GetString());
+        Assert.Equal(nameof(ConditionalFaultingKafkaSegment), root.GetProperty("component").GetString());
+        Assert.Equal(0, root.GetProperty("retryCount").GetInt32());
+        Assert.Equal(sourceTopic, root.GetProperty("topic").GetString());
+        Assert.Equal("0", root.GetProperty("partition").GetString());
+        Assert.Equal("0", root.GetProperty("offset").GetString());
+
+        var snapshot = pipeline.GetPerformanceSnapshot();
+        Assert.Equal(1, snapshot.TotalDeadLetteredCount);
+        Assert.Equal(0, snapshot.TotalDeadLetterFailureCount);
+        Assert.Equal(1, snapshot.TotalRecordsCompleted);
+        Assert.Equal(1, snapshot.TotalRecordsFaulted);
+    }
+}

--- a/src/tests/Pipelinez.Tests/Core/DeadLetterTests/Models/CollectingDestination.cs
+++ b/src/tests/Pipelinez.Tests/Core/DeadLetterTests/Models/CollectingDestination.cs
@@ -1,0 +1,20 @@
+using System.Collections.Concurrent;
+using Pipelinez.Core.Destination;
+using Pipelinez.Tests.Core.SourceDestTests.Models;
+
+namespace Pipelinez.Tests.Core.DeadLetterTests.Models;
+
+public sealed class CollectingDestination : PipelineDestination<TestPipelineRecord>
+{
+    public ConcurrentQueue<TestPipelineRecord> Records { get; } = new();
+
+    protected override Task ExecuteAsync(TestPipelineRecord record, CancellationToken cancellationToken)
+    {
+        Records.Enqueue(record);
+        return Task.CompletedTask;
+    }
+
+    protected override void Initialize()
+    {
+    }
+}

--- a/src/tests/Pipelinez.Tests/Core/DeadLetterTests/Models/ThrowingDeadLetterDestination.cs
+++ b/src/tests/Pipelinez.Tests/Core/DeadLetterTests/Models/ThrowingDeadLetterDestination.cs
@@ -1,0 +1,20 @@
+using Pipelinez.Core.DeadLettering;
+using Pipelinez.Core.Record;
+
+namespace Pipelinez.Tests.Core.DeadLetterTests.Models;
+
+public sealed class ThrowingDeadLetterDestination<T> : IPipelineDeadLetterDestination<T>
+    where T : PipelineRecord
+{
+    private readonly Exception _exception;
+
+    public ThrowingDeadLetterDestination(Exception exception)
+    {
+        _exception = exception;
+    }
+
+    public Task WriteAsync(PipelineDeadLetterRecord<T> deadLetterRecord, CancellationToken cancellationToken)
+    {
+        throw _exception;
+    }
+}

--- a/src/tests/Pipelinez.Tests/Core/DeadLetterTests/PipelineDeadLetterTests.cs
+++ b/src/tests/Pipelinez.Tests/Core/DeadLetterTests/PipelineDeadLetterTests.cs
@@ -1,0 +1,166 @@
+using Pipelinez.Core;
+using Pipelinez.Core.DeadLettering;
+using Pipelinez.Core.ErrorHandling;
+using Pipelinez.Core.Eventing;
+using Pipelinez.Core.FaultHandling;
+using Pipelinez.Core.Retry;
+using Pipelinez.Core.Status;
+using Pipelinez.Tests.Core.DeadLetterTests.Models;
+using Pipelinez.Tests.Core.ErrorHandlingTests.Models;
+using Pipelinez.Tests.Core.SourceDestTests.Models;
+
+namespace Pipelinez.Tests.Core.DeadLetterTests;
+
+public sealed class PipelineDeadLetterTests
+{
+    [Fact]
+    public async Task Pipeline_DeadLetter_Writes_Faulted_Record_And_Allows_Later_Records_To_Continue()
+    {
+        var deadLetters = new InMemoryDeadLetterDestination<TestPipelineRecord>();
+        var destination = new CollectingDestination();
+        var faultEvents = new List<PipelineRecordFaultedEventArgs<TestPipelineRecord>>();
+        var deadLetterEvents = new List<PipelineRecordDeadLetteredEventArgs<TestPipelineRecord>>();
+
+        var pipeline = Pipeline<TestPipelineRecord>.New(nameof(Pipeline_DeadLetter_Writes_Faulted_Record_And_Allows_Later_Records_To_Continue))
+            .UseRetryOptions(new PipelineRetryOptions<TestPipelineRecord>
+            {
+                DefaultSegmentPolicy = PipelineRetryPolicy<TestPipelineRecord>
+                    .FixedDelay(2, TimeSpan.Zero)
+                    .Handle<InvalidOperationException>()
+            })
+            .WithInMemorySource("config")
+            .AddSegment(new ConditionalFaultingSegment(), "config")
+            .WithDestination(destination)
+            .WithDeadLetterDestination(deadLetters)
+            .WithErrorHandler(_ => PipelineErrorAction.DeadLetter)
+            .Build();
+
+        pipeline.OnPipelineRecordFaulted += (_, args) => faultEvents.Add(args);
+        pipeline.OnPipelineRecordDeadLettered += (_, args) => deadLetterEvents.Add(args);
+
+        await pipeline.StartPipelineAsync();
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = ConditionalFaultingSegment.FaultingValue });
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = "good" });
+        await pipeline.CompleteAsync();
+
+        Assert.Equal(PipelineExecutionStatus.Completed, pipeline.GetStatus().Status);
+        Assert.Single(faultEvents);
+        Assert.Single(deadLetterEvents);
+        Assert.Single(destination.Records);
+        Assert.Single(deadLetters.Records);
+
+        var goodRecord = Assert.Single(destination.Records);
+        Assert.Equal("good|processed", goodRecord.Data);
+
+        var deadLetter = Assert.Single(deadLetters.Records);
+        Assert.Equal(ConditionalFaultingSegment.FaultingValue, deadLetter.Record.Data);
+        Assert.Equal(nameof(ConditionalFaultingSegment), deadLetter.Fault.ComponentName);
+        Assert.Equal(PipelineComponentKind.Segment, deadLetter.Fault.ComponentKind);
+        Assert.Single(deadLetter.RetryHistory);
+        Assert.Single(deadLetter.SegmentHistory);
+        Assert.False(deadLetter.SegmentHistory[0].Succeeded);
+        Assert.True(deadLetter.DeadLetteredAtUtc >= deadLetter.CreatedAtUtc);
+
+        var snapshot = pipeline.GetPerformanceSnapshot();
+        Assert.Equal(1, snapshot.TotalRecordsFaulted);
+        Assert.Equal(1, snapshot.TotalDeadLetteredCount);
+        Assert.Equal(0, snapshot.TotalDeadLetterFailureCount);
+    }
+
+    [Fact]
+    public async Task Pipeline_DeadLetter_Without_Configured_Destination_Faults_The_Runtime()
+    {
+        PipelineFaultedEventArgs? pipelineFault = null;
+
+        var pipeline = Pipeline<TestPipelineRecord>.New(nameof(Pipeline_DeadLetter_Without_Configured_Destination_Faults_The_Runtime))
+            .WithInMemorySource("config")
+            .AddSegment(new ConditionalFaultingSegment(), "config")
+            .WithInMemoryDestination("config")
+            .WithErrorHandler(_ => PipelineErrorAction.DeadLetter)
+            .Build();
+
+        pipeline.OnPipelineFaulted += (_, args) => pipelineFault = args;
+
+        await pipeline.StartPipelineAsync();
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = ConditionalFaultingSegment.FaultingValue });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await pipeline.Completion);
+
+        Assert.Contains("no dead-letter destination is configured", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(pipelineFault);
+        Assert.Equal("PipelineDeadLetterDestination", pipelineFault!.ComponentName);
+        Assert.Equal(PipelineComponentKind.Pipeline, pipelineFault.ComponentKind);
+        Assert.Equal(1, pipeline.GetPerformanceSnapshot().TotalDeadLetterFailureCount);
+        Assert.Equal(PipelineExecutionStatus.Faulted, pipeline.GetStatus().Status);
+    }
+
+    [Fact]
+    public async Task Pipeline_DeadLetter_Write_Failure_Faults_The_Runtime_By_Default()
+    {
+        var deadLetterException = new InvalidOperationException("Dead-letter write failed.");
+        var deadLetterFailures = new List<PipelineDeadLetterWriteFailedEventArgs<TestPipelineRecord>>();
+        PipelineFaultedEventArgs? pipelineFault = null;
+
+        var pipeline = Pipeline<TestPipelineRecord>.New(nameof(Pipeline_DeadLetter_Write_Failure_Faults_The_Runtime_By_Default))
+            .WithInMemorySource("config")
+            .AddSegment(new ConditionalFaultingSegment(), "config")
+            .WithInMemoryDestination("config")
+            .WithDeadLetterDestination(new ThrowingDeadLetterDestination<TestPipelineRecord>(deadLetterException))
+            .WithErrorHandler(_ => PipelineErrorAction.DeadLetter)
+            .Build();
+
+        pipeline.OnPipelineDeadLetterWriteFailed += (_, args) => deadLetterFailures.Add(args);
+        pipeline.OnPipelineFaulted += (_, args) => pipelineFault = args;
+
+        await pipeline.StartPipelineAsync();
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = ConditionalFaultingSegment.FaultingValue });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await pipeline.Completion);
+
+        Assert.Equal(deadLetterException.Message, exception.Message);
+        Assert.Single(deadLetterFailures);
+        Assert.NotNull(pipelineFault);
+        Assert.StartsWith("ThrowingDeadLetterDestination", pipelineFault!.ComponentName, StringComparison.Ordinal);
+        Assert.Equal(PipelineComponentKind.Destination, pipelineFault.ComponentKind);
+        Assert.Equal(1, pipeline.GetPerformanceSnapshot().TotalDeadLetterFailureCount);
+    }
+
+    [Fact]
+    public async Task Pipeline_DeadLetter_Write_Failure_Can_Be_Configured_To_Continue()
+    {
+        var destination = new CollectingDestination();
+        var deadLetterFailures = new List<PipelineDeadLetterWriteFailedEventArgs<TestPipelineRecord>>();
+
+        var pipeline = Pipeline<TestPipelineRecord>.New(nameof(Pipeline_DeadLetter_Write_Failure_Can_Be_Configured_To_Continue))
+            .UseDeadLetterOptions(new PipelineDeadLetterOptions
+            {
+                TreatDeadLetterFailureAsPipelineFault = false
+            })
+            .WithInMemorySource("config")
+            .AddSegment(new ConditionalFaultingSegment(), "config")
+            .WithDestination(destination)
+            .WithDeadLetterDestination(
+                new ThrowingDeadLetterDestination<TestPipelineRecord>(
+                    new InvalidOperationException("Dead-letter failure is tolerated.")))
+            .WithErrorHandler(_ => PipelineErrorAction.DeadLetter)
+            .Build();
+
+        pipeline.OnPipelineDeadLetterWriteFailed += (_, args) => deadLetterFailures.Add(args);
+
+        await pipeline.StartPipelineAsync();
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = ConditionalFaultingSegment.FaultingValue });
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = "good" });
+        await pipeline.CompleteAsync();
+
+        Assert.Equal(PipelineExecutionStatus.Completed, pipeline.GetStatus().Status);
+        Assert.Single(deadLetterFailures);
+        var goodRecord = Assert.Single(destination.Records);
+        Assert.Equal("good|processed", goodRecord.Data);
+
+        var snapshot = pipeline.GetPerformanceSnapshot();
+        Assert.Equal(1, snapshot.TotalDeadLetterFailureCount);
+        Assert.Equal(0, snapshot.TotalDeadLetteredCount);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds first-class dead-letter handling to Pipelinez so faulted records can be preserved explicitly instead of only being skipped, rethrown, or used to fault the pipeline.

## What Changed

### Core dead-letter model
- Added `PipelineErrorAction.DeadLetter`
- Added `PipelineDeadLetterRecord<T>` to capture:
  - the original record
  - fault state
  - metadata
  - segment execution history
  - retry history
  - created/dead-lettered timestamps
  - distribution context
- Added `IPipelineDeadLetterDestination<T>`
- Added `PipelineDeadLetterOptions`

### Builder and consumer API
- Added `WithDeadLetterDestination(...)`
- Added `UseDeadLetterOptions(...)`
- Added `InMemoryDeadLetterDestination<T>` for simple runtime use and test scenarios
- Extended Kafka builder support with `WithKafkaDeadLetterDestination(...)`

### Runtime behavior
- Wired dead-letter handling into the existing terminal fault path
- Dead-lettering now happens after retries are exhausted and the error handler resolves `DeadLetter`
- Dead-lettered records are treated as handled terminal faults
- Dead-lettered records do not execute normal destination logic
- Dead-lettered records do not raise normal completion events
- Kafka source bookkeeping now treats dead-lettered records as safe terminal outcomes so progress can still advance correctly

### Failure behavior
- If `DeadLetter` is returned without a configured dead-letter destination, the pipeline faults with a configuration error
- By default, dead-letter write failures fault the pipeline
- This behavior can be relaxed with `PipelineDeadLetterOptions.TreatDeadLetterFailureAsPipelineFault = false`

### Eventing and observability
- Added `OnPipelineRecordDeadLettered`
- Added `OnPipelineDeadLetterWriteFailed`
- Added dead-letter counters to performance snapshots:
  - `TotalDeadLetteredCount`
  - `TotalDeadLetterFailureCount`

### Kafka integration
- Added a Kafka dead-letter destination implementation that:
  - maps `PipelineDeadLetterRecord<T>` to Kafka messages
  - copies original pipeline headers
  - adds dead-letter fault metadata headers
  - awaits broker acknowledgement before considering the dead-letter write successful

## Testing
Added coverage for:
- dead-lettering a faulted record and continuing later records
- dead-letter envelope contents
- dead-lettering without a configured destination faulting the pipeline
- dead-letter write failure faulting the pipeline by default
- optional non-faulting dead-letter write failure behavior
- Kafka dead-letter topic publishing for faulted records
- Kafka dead-letter payload preservation for fault and source metadata

## Documentation
- Updated the root README to document dead-letter configuration and usage
- Updated the architectural overview to describe dead-letter runtime behavior, events, metrics, and Kafka dead-letter support
- Marked the dead-letter roadmap item as implemented

## Result
Pipelinez now has a formal dead-letter capability that fits into the existing retry and error-handling model, supports both in-memory and Kafka-backed destinations, and preserves enough context to inspect or replay failed records later.