### PR TITLE
Adding operational tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Pipelinez is a small .NET 8 framework for building record-processing pipelines w
 - explicit flow control and saturation observability
 - optional distributed execution for transport-backed sources
 - explicit performance tuning and runtime performance snapshots
+- health snapshots, health checks, and meter-based runtime metrics
+- correlation-aware diagnostics for records and faults
 - transport extensions such as Kafka
 
 ## How It Works
@@ -351,6 +353,43 @@ pipeline.OnPipelineRecordDeadLettered += (_, args) =>
 
 Kafka-backed pipelines can route failures to a dead-letter topic through `WithKafkaDeadLetterDestination(...)`.
 
+## Operational Tooling
+
+Pipelinez now includes a first-class operational surface for hosts and operators.
+
+Available capabilities include:
+
+- `GetHealthStatus()`
+- `GetOperationalSnapshot()`
+- `PipelineHealthCheck<T>` for `Microsoft.Extensions.Diagnostics.HealthChecks`
+- meter-based runtime metrics under `Pipelinez.Runtime`
+- correlation IDs stamped into pipeline metadata and surfaced through event diagnostics
+
+Example shape:
+
+```csharp
+using Pipelinez.Core.Operational;
+
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .UseOperationalOptions(new PipelineOperationalOptions
+    {
+        EnableHealthChecks = true,
+        EnableMetrics = true,
+        EnableCorrelationIds = true
+    })
+    .WithInMemorySource(new object())
+    .WithInMemoryDestination("config")
+    .Build();
+
+var health = pipeline.GetHealthStatus();
+var snapshot = pipeline.GetOperationalSnapshot();
+
+Console.WriteLine(health.State);
+Console.WriteLine(snapshot.Performance.RecordsPerSecond);
+```
+
+For OpenTelemetry-style metrics registration, add the `Pipelinez.Runtime` meter to your metrics pipeline.
+
 ## Error Handling
 
 Pipelinez supports explicit fault handling through `WithErrorHandler(...)`.
@@ -445,6 +484,7 @@ Current implemented capabilities include:
 - distributed runtime mode and worker/partition observability
 - partition-aware Kafka scaling with partition execution state and drain events
 - performance tuning options, batching support, and runtime performance snapshots
+- operational health snapshots, health-check integration, runtime meter metrics, and correlation IDs
 - Kafka source and destination support
 - Docker-backed Kafka integration coverage, including multi-worker distributed tests
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -54,6 +54,7 @@ The core builder currently supports:
 - `WithDeadLetterDestination(...)`
 - `UseHostOptions(...)`
 - `UseDeadLetterOptions(...)`
+- `UseOperationalOptions(...)`
 - `UseFlowControlOptions(...)`
 - `UsePerformanceOptions(...)`
 - `UseRetryOptions(...)`
@@ -218,6 +219,100 @@ Per-component snapshots expose:
 - average execution latency
 
 This gives consumers a lightweight built-in way to inspect pipeline behavior during testing, demos, or hosted execution.
+
+## Operational Tooling Model
+
+Pipelinez now has a first-class operational surface layered on top of the existing status, eventing, and performance model.
+
+### Operational Options
+
+`UseOperationalOptions(...)` configures:
+
+- health-check enablement
+- meter-based metrics enablement
+- correlation ID stamping
+- degraded-state thresholds for saturation, retries, dead-lettering, publish rejection, and partition draining
+
+### Health Status
+
+`Pipeline<T>.GetHealthStatus()` returns a `PipelineHealthStatus` with:
+
+- `PipelineName`
+- `State`
+- `Reasons`
+- `ObservedAtUtc`
+- current `PipelineStatus`
+- current `PipelinePerformanceSnapshot`
+- the last pipeline-level fault when one exists
+
+Supported health states are:
+
+- `Starting`
+- `Healthy`
+- `Degraded`
+- `Unhealthy`
+- `Completed`
+
+### Operational Snapshot
+
+`Pipeline<T>.GetOperationalSnapshot()` returns a `PipelineOperationalSnapshot` that combines:
+
+- `PipelineStatus`
+- `PipelinePerformanceSnapshot`
+- `PipelineHealthStatus`
+- last pipeline fault
+- last successful completion timestamp
+- last dead-letter timestamp
+
+This gives hosts a single operator-oriented read model without replacing the existing lower-level APIs.
+
+### Health Check Integration
+
+Pipelinez now includes `PipelineHealthCheck<T>`, which implements `IHealthCheck` and maps runtime health into the standard .NET health-check model.
+
+This allows ASP.NET Core and worker-service hosts to expose pipeline health through standard endpoints such as `/health`.
+
+### Meter-Based Metrics
+
+Pipelinez now emits runtime metrics through the `Pipelinez.Runtime` meter.
+
+Current instruments include counters for:
+
+- published records
+- completed records
+- faulted records
+- retry attempts
+- retry recoveries
+- retry exhaustions
+- dead-letter writes
+- dead-letter failures
+- publish rejections
+
+It also exposes observable gauges for:
+
+- current buffered record count
+- owned partition count
+- current records-per-second
+- current health-state value
+
+### Correlation IDs And Diagnostics
+
+Pipelinez now stamps a correlation ID into record metadata when a record first enters the pipeline, unless one already exists.
+
+The metadata key is:
+
+- `pipelinez.correlation.id`
+
+Correlation context is then surfaced through `PipelineRecordDiagnosticContext` on:
+
+- `OnPipelineRecordCompleted`
+- `OnPipelineRecordFaulted`
+- `OnPipelineRecordRetrying`
+- `OnPublishRejected`
+- `OnPipelineRecordDeadLettered`
+- `OnPipelineDeadLetterWriteFailed`
+
+This makes it easier to correlate logs, faults, retries, and dead-letter outcomes back to one logical record flow.
 
 ### Destination Batching
 
@@ -531,6 +626,7 @@ For distributed sources, this status reflects live ownership while the worker is
 
 Logging is managed through the internal `LoggingManager`, which wraps an `ILoggerFactory`. If the caller never supplies a logger factory, the runtime falls back to a null logger factory.
 The runtime now also exposes additive performance metrics through `GetPerformanceSnapshot()` rather than relying only on logs for throughput diagnostics, including retry counts, retry recovery/exhaustion totals, publish wait totals, publish rejection totals, and peak buffered depth.
+Those same operational signals can now also flow through the `Pipelinez.Runtime` meter and the health/operational snapshot APIs.
 
 ## Kafka Integration
 
@@ -712,6 +808,7 @@ The major architectural work called out in the earlier planning docs has been im
 - explicit retry policies with retry history, retry events, and retry-aware performance counters
 - explicit dead-letter flows with in-memory and Kafka dead-letter destinations
 - explicit flow-control policies with publish results, saturation status, and pressure metrics
+- explicit operational tooling with health snapshots, health checks, meter metrics, and correlation-aware diagnostics
 
 The remaining work is mostly future evolution work rather than foundational cleanup. Likely areas include broader transport coverage, schema-registry integration tests, and further runtime ergonomics.
 

--- a/src/Pipelinez/Core/Eventing/Eventing.cs
+++ b/src/Pipelinez/Core/Eventing/Eventing.cs
@@ -2,6 +2,7 @@ using Ardalis.GuardClauses;
 using Pipelinez.Core.DeadLettering;
 using Pipelinez.Core.Distributed;
 using Pipelinez.Core.FaultHandling;
+using Pipelinez.Core.Operational;
 using Pipelinez.Core.Record;
 
 namespace Pipelinez.Core.Eventing;
@@ -52,12 +53,16 @@ public sealed class PipelineRecordCompletedEventHandlerArgs<T>
 
     public PipelineRecordDistributionContext? Distribution { get; }
 
+    public PipelineRecordDiagnosticContext? Diagnostic { get; }
+
     public PipelineRecordCompletedEventHandlerArgs(
         T record,
-        PipelineRecordDistributionContext? distribution = null)
+        PipelineRecordDistributionContext? distribution = null,
+        PipelineRecordDiagnosticContext? diagnostic = null)
     {
         Record = record;
         Distribution = distribution;
+        Diagnostic = diagnostic;
     }
 }
 
@@ -91,12 +96,14 @@ public sealed class PipelineRecordFaultedEventArgs<T> where T : PipelineRecord
         T record,
         PipelineContainer<T> container,
         PipelineFaultState fault,
-        PipelineRecordDistributionContext? distribution = null)
+        PipelineRecordDistributionContext? distribution = null,
+        PipelineRecordDiagnosticContext? diagnostic = null)
     {
         Record = Guard.Against.Null(record, nameof(record));
         Container = Guard.Against.Null(container, nameof(container));
         Fault = Guard.Against.Null(fault, nameof(fault));
         Distribution = distribution;
+        Diagnostic = diagnostic;
     }
 
     public T Record { get; }
@@ -106,6 +113,8 @@ public sealed class PipelineRecordFaultedEventArgs<T> where T : PipelineRecord
     public PipelineFaultState Fault { get; }
 
     public PipelineRecordDistributionContext? Distribution { get; }
+
+    public PipelineRecordDiagnosticContext? Diagnostic { get; }
 }
 
 public sealed class PipelineRecordRetryingEventArgs<T> where T : PipelineRecord
@@ -117,7 +126,8 @@ public sealed class PipelineRecordRetryingEventArgs<T> where T : PipelineRecord
         int attemptNumber,
         int maxAttempts,
         TimeSpan delay,
-        PipelineRecordDistributionContext? distribution = null)
+        PipelineRecordDistributionContext? distribution = null,
+        PipelineRecordDiagnosticContext? diagnostic = null)
     {
         Record = Guard.Against.Null(record, nameof(record));
         Container = Guard.Against.Null(container, nameof(container));
@@ -126,6 +136,7 @@ public sealed class PipelineRecordRetryingEventArgs<T> where T : PipelineRecord
         MaxAttempts = Guard.Against.NegativeOrZero(maxAttempts, nameof(maxAttempts));
         Delay = delay;
         Distribution = distribution;
+        Diagnostic = diagnostic;
     }
 
     public T Record { get; }
@@ -141,6 +152,8 @@ public sealed class PipelineRecordRetryingEventArgs<T> where T : PipelineRecord
     public TimeSpan Delay { get; }
 
     public PipelineRecordDistributionContext? Distribution { get; }
+
+    public PipelineRecordDiagnosticContext? Diagnostic { get; }
 
     public string ComponentName => Fault.ComponentName;
 
@@ -173,11 +186,13 @@ public sealed class PipelinePublishRejectedEventArgs<T> where T : PipelineRecord
     public PipelinePublishRejectedEventArgs(
         T record,
         FlowControl.PipelinePublishResultReason reason,
-        DateTimeOffset observedAtUtc)
+        DateTimeOffset observedAtUtc,
+        PipelineRecordDiagnosticContext? diagnostic = null)
     {
         Record = Guard.Against.Null(record, nameof(record));
         Reason = reason;
         ObservedAtUtc = observedAtUtc;
+        Diagnostic = diagnostic;
     }
 
     public T Record { get; }
@@ -185,21 +200,27 @@ public sealed class PipelinePublishRejectedEventArgs<T> where T : PipelineRecord
     public FlowControl.PipelinePublishResultReason Reason { get; }
 
     public DateTimeOffset ObservedAtUtc { get; }
+
+    public PipelineRecordDiagnosticContext? Diagnostic { get; }
 }
 
 public sealed class PipelineRecordDeadLetteredEventArgs<T> where T : PipelineRecord
 {
     public PipelineRecordDeadLetteredEventArgs(
         T record,
-        PipelineDeadLetterRecord<T> deadLetterRecord)
+        PipelineDeadLetterRecord<T> deadLetterRecord,
+        PipelineRecordDiagnosticContext? diagnostic = null)
     {
         Record = Guard.Against.Null(record, nameof(record));
         DeadLetterRecord = Guard.Against.Null(deadLetterRecord, nameof(deadLetterRecord));
+        Diagnostic = diagnostic;
     }
 
     public T Record { get; }
 
     public PipelineDeadLetterRecord<T> DeadLetterRecord { get; }
+
+    public PipelineRecordDiagnosticContext? Diagnostic { get; }
 }
 
 public sealed class PipelineDeadLetterWriteFailedEventArgs<T> where T : PipelineRecord
@@ -207,11 +228,13 @@ public sealed class PipelineDeadLetterWriteFailedEventArgs<T> where T : Pipeline
     public PipelineDeadLetterWriteFailedEventArgs(
         T record,
         PipelineDeadLetterRecord<T> deadLetterRecord,
-        Exception exception)
+        Exception exception,
+        PipelineRecordDiagnosticContext? diagnostic = null)
     {
         Record = Guard.Against.Null(record, nameof(record));
         DeadLetterRecord = Guard.Against.Null(deadLetterRecord, nameof(deadLetterRecord));
         Exception = Guard.Against.Null(exception, nameof(exception));
+        Diagnostic = diagnostic;
     }
 
     public T Record { get; }
@@ -219,6 +242,8 @@ public sealed class PipelineDeadLetterWriteFailedEventArgs<T> where T : Pipeline
     public PipelineDeadLetterRecord<T> DeadLetterRecord { get; }
 
     public Exception Exception { get; }
+
+    public PipelineRecordDiagnosticContext? Diagnostic { get; }
 }
 
 public delegate void PipelineFaultedEventHandler(object sender, PipelineFaultedEventArgs args);

--- a/src/Pipelinez/Core/IPipeline.cs
+++ b/src/Pipelinez/Core/IPipeline.cs
@@ -2,6 +2,7 @@ using Pipelinez.Core.Distributed;
 using Pipelinez.Core.DeadLettering;
 using Pipelinez.Core.Eventing;
 using Pipelinez.Core.FlowControl;
+using Pipelinez.Core.Operational;
 using Pipelinez.Core.Performance;
 using Pipelinez.Core.Record;
 using Pipelinez.Core.Status;
@@ -42,6 +43,10 @@ public interface IPipeline<T> where T : PipelineRecord
     PipelineRuntimeContext GetRuntimeContext();
 
     PipelinePerformanceSnapshot GetPerformanceSnapshot();
+
+    PipelineHealthStatus GetHealthStatus();
+
+    PipelineOperationalSnapshot GetOperationalSnapshot();
     
     #region Eventing
     

--- a/src/Pipelinez/Core/Operational/IPipelineMetricsEmitter.cs
+++ b/src/Pipelinez/Core/Operational/IPipelineMetricsEmitter.cs
@@ -1,0 +1,26 @@
+namespace Pipelinez.Core.Operational;
+
+internal interface IPipelineMetricsEmitter : IDisposable
+{
+    void RecordPublished();
+
+    void RecordCompleted();
+
+    void RecordFaulted();
+
+    void RecordRetryAttempt();
+
+    void RecordRetryRecovery();
+
+    void RecordRetryExhausted();
+
+    void RecordDeadLettered();
+
+    void RecordDeadLetterFailure();
+
+    void RecordPublishRejected();
+
+    void ObserveBufferedCount(int totalBufferedCount);
+
+    void ObserveOwnedPartitionCount(int ownedPartitionCount);
+}

--- a/src/Pipelinez/Core/Operational/PipelineHealthCheck.cs
+++ b/src/Pipelinez/Core/Operational/PipelineHealthCheck.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Pipelinez.Core.Record;
+
+namespace Pipelinez.Core.Operational;
+
+public sealed class PipelineHealthCheck<T> : IHealthCheck
+    where T : PipelineRecord
+{
+    private readonly IPipeline<T> _pipeline;
+    private readonly bool _includeComponentDiagnostics;
+
+    public PipelineHealthCheck(IPipeline<T> pipeline, bool includeComponentDiagnostics = true)
+    {
+        _pipeline = pipeline ?? throw new ArgumentNullException(nameof(pipeline));
+        _includeComponentDiagnostics = includeComponentDiagnostics;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var health = _pipeline.GetHealthStatus();
+        var data = new Dictionary<string, object>
+        {
+            ["pipeline.name"] = health.PipelineName,
+            ["pipeline.health_state"] = health.State.ToString(),
+            ["pipeline.reason"] = health.Reason ?? string.Empty,
+            ["pipeline.records_per_second"] = health.Performance.RecordsPerSecond,
+            ["pipeline.total_faulted"] = health.Performance.TotalRecordsFaulted,
+            ["pipeline.total_deadlettered"] = health.Performance.TotalDeadLetteredCount,
+            ["pipeline.total_publish_rejected"] = health.Performance.TotalPublishRejectedCount
+        };
+
+        if (_includeComponentDiagnostics)
+        {
+            data["pipeline.components"] = string.Join(
+                ",",
+                health.RuntimeStatus.Components.Select(component => $"{component.Name}:{component.Status}"));
+        }
+
+        var result = health.State switch
+        {
+            PipelineHealthState.Starting => HealthCheckResult.Healthy("Pipeline is starting.", data: data),
+            PipelineHealthState.Healthy => HealthCheckResult.Healthy("Pipeline is healthy.", data),
+            PipelineHealthState.Completed => HealthCheckResult.Healthy("Pipeline completed successfully.", data),
+            PipelineHealthState.Degraded => HealthCheckResult.Degraded(health.Reason ?? "Pipeline is degraded.", data: data),
+            PipelineHealthState.Unhealthy => HealthCheckResult.Unhealthy(
+                health.Reason ?? "Pipeline is unhealthy.",
+                health.LastPipelineFault?.Exception,
+                data),
+            _ => HealthCheckResult.Unhealthy("Unknown pipeline health state.", data: data)
+        };
+
+        return Task.FromResult(result);
+    }
+}

--- a/src/Pipelinez/Core/Operational/PipelineHealthState.cs
+++ b/src/Pipelinez/Core/Operational/PipelineHealthState.cs
@@ -1,0 +1,10 @@
+namespace Pipelinez.Core.Operational;
+
+public enum PipelineHealthState
+{
+    Starting = 0,
+    Healthy = 1,
+    Degraded = 2,
+    Unhealthy = 3,
+    Completed = 4
+}

--- a/src/Pipelinez/Core/Operational/PipelineHealthStatus.cs
+++ b/src/Pipelinez/Core/Operational/PipelineHealthStatus.cs
@@ -1,0 +1,43 @@
+using Ardalis.GuardClauses;
+using Pipelinez.Core.FaultHandling;
+using Pipelinez.Core.Performance;
+using Pipelinez.Core.Status;
+
+namespace Pipelinez.Core.Operational;
+
+public sealed class PipelineHealthStatus
+{
+    public PipelineHealthStatus(
+        string pipelineName,
+        PipelineHealthState state,
+        IReadOnlyList<string> reasons,
+        DateTimeOffset observedAtUtc,
+        PipelineStatus runtimeStatus,
+        PipelinePerformanceSnapshot performance,
+        PipelineFaultState? lastPipelineFault = null)
+    {
+        PipelineName = Guard.Against.NullOrWhiteSpace(pipelineName, nameof(pipelineName));
+        State = state;
+        Reasons = Guard.Against.Null(reasons, nameof(reasons)).ToArray();
+        ObservedAtUtc = observedAtUtc;
+        RuntimeStatus = Guard.Against.Null(runtimeStatus, nameof(runtimeStatus));
+        Performance = Guard.Against.Null(performance, nameof(performance));
+        LastPipelineFault = lastPipelineFault;
+    }
+
+    public string PipelineName { get; }
+
+    public PipelineHealthState State { get; }
+
+    public IReadOnlyList<string> Reasons { get; }
+
+    public string? Reason => Reasons.Count == 0 ? null : string.Join("; ", Reasons);
+
+    public DateTimeOffset ObservedAtUtc { get; }
+
+    public PipelineStatus RuntimeStatus { get; }
+
+    public PipelinePerformanceSnapshot Performance { get; }
+
+    public PipelineFaultState? LastPipelineFault { get; }
+}

--- a/src/Pipelinez/Core/Operational/PipelineMetricsEmitter.cs
+++ b/src/Pipelinez/Core/Operational/PipelineMetricsEmitter.cs
@@ -1,0 +1,157 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Pipelinez.Core.Distributed;
+
+namespace Pipelinez.Core.Operational;
+
+internal sealed class PipelineMetricsEmitter : IPipelineMetricsEmitter, IDisposable
+{
+    internal const string MeterName = "Pipelinez.Runtime";
+
+    private static readonly Meter Meter = new(MeterName);
+    private static readonly Counter<long> RecordsPublishedCounter = Meter.CreateCounter<long>("pipelinez.records.published");
+    private static readonly Counter<long> RecordsCompletedCounter = Meter.CreateCounter<long>("pipelinez.records.completed");
+    private static readonly Counter<long> RecordsFaultedCounter = Meter.CreateCounter<long>("pipelinez.records.faulted");
+    private static readonly Counter<long> RetryAttemptsCounter = Meter.CreateCounter<long>("pipelinez.retry.attempts");
+    private static readonly Counter<long> RetryRecoveriesCounter = Meter.CreateCounter<long>("pipelinez.retry.recoveries");
+    private static readonly Counter<long> RetryExhaustionsCounter = Meter.CreateCounter<long>("pipelinez.retry.exhaustions");
+    private static readonly Counter<long> DeadLetteredCounter = Meter.CreateCounter<long>("pipelinez.deadletter.count");
+    private static readonly Counter<long> DeadLetterFailuresCounter = Meter.CreateCounter<long>("pipelinez.deadletter.failures");
+    private static readonly Counter<long> PublishRejectedCounter = Meter.CreateCounter<long>("pipelinez.publish.rejected");
+    private static readonly ConcurrentDictionary<Guid, PipelineMetricsEmitter> Emitters = new();
+    private static readonly ObservableGauge<int> BufferedRecordsGauge = Meter.CreateObservableGauge<int>(
+        "pipelinez.buffered_records",
+        ObserveBufferedRecords);
+    private static readonly ObservableGauge<int> OwnedPartitionsGauge = Meter.CreateObservableGauge<int>(
+        "pipelinez.owned_partitions",
+        ObserveOwnedPartitions);
+    private static readonly ObservableGauge<double> RecordsPerSecondGauge = Meter.CreateObservableGauge<double>(
+        "pipelinez.records_per_second",
+        ObserveRecordsPerSecond);
+    private static readonly ObservableGauge<int> HealthStateGauge = Meter.CreateObservableGauge<int>(
+        "pipelinez.health_state",
+        ObserveHealthState);
+
+    private readonly Guid _registrationId = Guid.NewGuid();
+    private readonly string _pipelineName;
+    private readonly string _workerId;
+    private readonly PipelineExecutionMode _executionMode;
+    private readonly Func<double> _recordsPerSecondProvider;
+    private readonly Func<PipelineHealthState> _healthStateProvider;
+    private int _bufferedCount;
+    private int _ownedPartitionCount;
+
+    public PipelineMetricsEmitter(
+        string pipelineName,
+        string workerId,
+        PipelineExecutionMode executionMode,
+        Func<double> recordsPerSecondProvider,
+        Func<PipelineHealthState> healthStateProvider)
+    {
+        _pipelineName = pipelineName;
+        _workerId = workerId;
+        _executionMode = executionMode;
+        _recordsPerSecondProvider = recordsPerSecondProvider;
+        _healthStateProvider = healthStateProvider;
+        Emitters[_registrationId] = this;
+    }
+
+    public void Dispose()
+    {
+        Emitters.TryRemove(_registrationId, out _);
+    }
+
+    public void RecordPublished()
+    {
+        RecordsPublishedCounter.Add(1, BuildTags());
+    }
+
+    public void RecordCompleted()
+    {
+        RecordsCompletedCounter.Add(1, BuildTags());
+    }
+
+    public void RecordFaulted()
+    {
+        RecordsFaultedCounter.Add(1, BuildTags());
+    }
+
+    public void RecordRetryAttempt()
+    {
+        RetryAttemptsCounter.Add(1, BuildTags());
+    }
+
+    public void RecordRetryRecovery()
+    {
+        RetryRecoveriesCounter.Add(1, BuildTags());
+    }
+
+    public void RecordRetryExhausted()
+    {
+        RetryExhaustionsCounter.Add(1, BuildTags());
+    }
+
+    public void RecordDeadLettered()
+    {
+        DeadLetteredCounter.Add(1, BuildTags());
+    }
+
+    public void RecordDeadLetterFailure()
+    {
+        DeadLetterFailuresCounter.Add(1, BuildTags());
+    }
+
+    public void RecordPublishRejected()
+    {
+        PublishRejectedCounter.Add(1, BuildTags());
+    }
+
+    public void ObserveBufferedCount(int totalBufferedCount)
+    {
+        _bufferedCount = totalBufferedCount;
+    }
+
+    public void ObserveOwnedPartitionCount(int ownedPartitionCount)
+    {
+        _ownedPartitionCount = ownedPartitionCount;
+    }
+
+    private TagList BuildTags()
+    {
+        return new TagList
+        {
+            { "pipeline.name", _pipelineName },
+            { "pipeline.mode", _executionMode.ToString() },
+            { "worker.id", _workerId }
+        };
+    }
+
+    private Measurement<int> GetBufferedMeasurement() => new(_bufferedCount, BuildTags());
+
+    private Measurement<int> GetOwnedPartitionsMeasurement() => new(_ownedPartitionCount, BuildTags());
+
+    private Measurement<double> GetRecordsPerSecondMeasurement() => new(_recordsPerSecondProvider(), BuildTags());
+
+    private Measurement<int> GetHealthStateMeasurement() => new((int)_healthStateProvider(), BuildTags());
+
+    private static IEnumerable<Measurement<int>> ObserveBufferedRecords()
+    {
+        return Emitters.Values.Select(emitter => emitter.GetBufferedMeasurement()).ToArray();
+    }
+
+    private static IEnumerable<Measurement<int>> ObserveOwnedPartitions()
+    {
+        return Emitters.Values.Select(emitter => emitter.GetOwnedPartitionsMeasurement()).ToArray();
+    }
+
+    private static IEnumerable<Measurement<double>> ObserveRecordsPerSecond()
+    {
+        return Emitters.Values.Select(emitter => emitter.GetRecordsPerSecondMeasurement()).ToArray();
+    }
+
+    private static IEnumerable<Measurement<int>> ObserveHealthState()
+    {
+        return Emitters.Values.Select(emitter => emitter.GetHealthStateMeasurement()).ToArray();
+    }
+}

--- a/src/Pipelinez/Core/Operational/PipelineOperationalMetadataKeys.cs
+++ b/src/Pipelinez/Core/Operational/PipelineOperationalMetadataKeys.cs
@@ -1,0 +1,6 @@
+namespace Pipelinez.Core.Operational;
+
+public static class PipelineOperationalMetadataKeys
+{
+    public const string CorrelationId = "pipelinez.correlation.id";
+}

--- a/src/Pipelinez/Core/Operational/PipelineOperationalOptions.cs
+++ b/src/Pipelinez/Core/Operational/PipelineOperationalOptions.cs
@@ -1,0 +1,34 @@
+using Ardalis.GuardClauses;
+
+namespace Pipelinez.Core.Operational;
+
+public sealed class PipelineOperationalOptions
+{
+    public bool EnableHealthChecks { get; init; } = true;
+
+    public bool EnableMetrics { get; init; } = true;
+
+    public bool EnableCorrelationIds { get; init; } = true;
+
+    public bool IncludeComponentDiagnosticsInHealthResults { get; init; } = true;
+
+    public double SaturationDegradedThreshold { get; init; } = 0.90d;
+
+    public long RetryExhaustionDegradedThreshold { get; init; } = 1;
+
+    public long DeadLetterDegradedThreshold { get; init; } = 1;
+
+    public long PublishRejectionDegradedThreshold { get; init; } = 1;
+
+    public int DrainingPartitionDegradedThreshold { get; init; } = 1;
+
+    public PipelineOperationalOptions Validate()
+    {
+        Guard.Against.OutOfRange(SaturationDegradedThreshold, nameof(SaturationDegradedThreshold), 0d, 1d);
+        Guard.Against.Negative(RetryExhaustionDegradedThreshold, nameof(RetryExhaustionDegradedThreshold));
+        Guard.Against.Negative(DeadLetterDegradedThreshold, nameof(DeadLetterDegradedThreshold));
+        Guard.Against.Negative(PublishRejectionDegradedThreshold, nameof(PublishRejectionDegradedThreshold));
+        Guard.Against.Negative(DrainingPartitionDegradedThreshold, nameof(DrainingPartitionDegradedThreshold));
+        return this;
+    }
+}

--- a/src/Pipelinez/Core/Operational/PipelineOperationalSnapshot.cs
+++ b/src/Pipelinez/Core/Operational/PipelineOperationalSnapshot.cs
@@ -1,0 +1,41 @@
+using Ardalis.GuardClauses;
+using Pipelinez.Core.FaultHandling;
+using Pipelinez.Core.Performance;
+using Pipelinez.Core.Status;
+
+namespace Pipelinez.Core.Operational;
+
+public sealed class PipelineOperationalSnapshot
+{
+    public PipelineOperationalSnapshot(
+        PipelineStatus status,
+        PipelinePerformanceSnapshot performance,
+        PipelineHealthStatus health,
+        DateTimeOffset observedAtUtc,
+        PipelineFaultState? lastPipelineFault = null,
+        DateTimeOffset? lastRecordCompletedAtUtc = null,
+        DateTimeOffset? lastDeadLetteredAtUtc = null)
+    {
+        Status = Guard.Against.Null(status, nameof(status));
+        Performance = Guard.Against.Null(performance, nameof(performance));
+        Health = Guard.Against.Null(health, nameof(health));
+        ObservedAtUtc = observedAtUtc;
+        LastPipelineFault = lastPipelineFault;
+        LastRecordCompletedAtUtc = lastRecordCompletedAtUtc;
+        LastDeadLetteredAtUtc = lastDeadLetteredAtUtc;
+    }
+
+    public PipelineStatus Status { get; }
+
+    public PipelinePerformanceSnapshot Performance { get; }
+
+    public PipelineHealthStatus Health { get; }
+
+    public DateTimeOffset ObservedAtUtc { get; }
+
+    public PipelineFaultState? LastPipelineFault { get; }
+
+    public DateTimeOffset? LastRecordCompletedAtUtc { get; }
+
+    public DateTimeOffset? LastDeadLetteredAtUtc { get; }
+}

--- a/src/Pipelinez/Core/Operational/PipelineRecordDiagnosticContext.cs
+++ b/src/Pipelinez/Core/Operational/PipelineRecordDiagnosticContext.cs
@@ -1,0 +1,30 @@
+using Ardalis.GuardClauses;
+
+namespace Pipelinez.Core.Operational;
+
+public sealed class PipelineRecordDiagnosticContext
+{
+    public PipelineRecordDiagnosticContext(
+        string correlationId,
+        string pipelineName,
+        string instanceId,
+        string workerId,
+        string? componentName = null)
+    {
+        CorrelationId = Guard.Against.NullOrWhiteSpace(correlationId, nameof(correlationId));
+        PipelineName = Guard.Against.NullOrWhiteSpace(pipelineName, nameof(pipelineName));
+        InstanceId = Guard.Against.NullOrWhiteSpace(instanceId, nameof(instanceId));
+        WorkerId = Guard.Against.NullOrWhiteSpace(workerId, nameof(workerId));
+        ComponentName = componentName;
+    }
+
+    public string CorrelationId { get; }
+
+    public string PipelineName { get; }
+
+    public string InstanceId { get; }
+
+    public string WorkerId { get; }
+
+    public string? ComponentName { get; }
+}

--- a/src/Pipelinez/Core/Performance/IPipelinePerformanceCollector.cs
+++ b/src/Pipelinez/Core/Performance/IPipelinePerformanceCollector.cs
@@ -1,7 +1,11 @@
+using Pipelinez.Core.Operational;
+
 namespace Pipelinez.Core.Performance;
 
 internal interface IPipelinePerformanceCollector
 {
+    void ConfigureMetricsEmitter(IPipelineMetricsEmitter? metricsEmitter);
+
     void RecordPublished(string componentName);
 
     void RecordCompleted(DateTimeOffset createdAtUtc);

--- a/src/Pipelinez/Core/Performance/PipelinePerformanceCollector.cs
+++ b/src/Pipelinez/Core/Performance/PipelinePerformanceCollector.cs
@@ -1,4 +1,5 @@
 using Ardalis.GuardClauses;
+using Pipelinez.Core.Operational;
 
 namespace Pipelinez.Core.Performance;
 
@@ -15,6 +16,7 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
     private readonly PipelineMetricsOptions _metricsOptions;
     private readonly Dictionary<string, ComponentAccumulator> _components = new(StringComparer.Ordinal);
     private readonly DateTimeOffset _startedAtUtc = DateTimeOffset.UtcNow;
+    private IPipelineMetricsEmitter? _metricsEmitter;
 
     private long _publishedCount;
     private long _completedCount;
@@ -35,6 +37,11 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
         _metricsOptions = Guard.Against.Null(metricsOptions, nameof(metricsOptions));
     }
 
+    public void ConfigureMetricsEmitter(IPipelineMetricsEmitter? metricsEmitter)
+    {
+        _metricsEmitter = metricsEmitter;
+    }
+
     public void RecordPublished(string componentName)
     {
         if (!_metricsOptions.EnableRuntimeMetrics)
@@ -47,6 +54,8 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
             _publishedCount++;
             GetOrAddComponent(componentName).ProcessedCount++;
         }
+
+        _metricsEmitter?.RecordPublished();
     }
 
     public void RecordCompleted(DateTimeOffset createdAtUtc)
@@ -61,6 +70,8 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
             _completedCount++;
             _totalEndToEndLatencyTicks += (DateTimeOffset.UtcNow - createdAtUtc).Ticks;
         }
+
+        _metricsEmitter?.RecordCompleted();
     }
 
     public void RecordFaulted(DateTimeOffset createdAtUtc)
@@ -75,6 +86,8 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
             _faultedCount++;
             _totalEndToEndLatencyTicks += (DateTimeOffset.UtcNow - createdAtUtc).Ticks;
         }
+
+        _metricsEmitter?.RecordFaulted();
     }
 
     public void RecordComponentExecution(string componentName, TimeSpan duration, bool succeeded)
@@ -112,6 +125,8 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
         {
             _retryCount++;
         }
+
+        _metricsEmitter?.RecordRetryAttempt();
     }
 
     public void RecordRetryRecovery()
@@ -125,6 +140,8 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
         {
             _retryRecoveries++;
         }
+
+        _metricsEmitter?.RecordRetryRecovery();
     }
 
     public void RecordRetryExhausted()
@@ -138,6 +155,8 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
         {
             _retryExhaustions++;
         }
+
+        _metricsEmitter?.RecordRetryExhausted();
     }
 
     public void RecordDeadLettered()
@@ -151,6 +170,8 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
         {
             _deadLetterCount++;
         }
+
+        _metricsEmitter?.RecordDeadLettered();
     }
 
     public void RecordDeadLetterFailure()
@@ -164,6 +185,8 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
         {
             _deadLetterFailureCount++;
         }
+
+        _metricsEmitter?.RecordDeadLetterFailure();
     }
 
     public void RecordPublishWait(TimeSpan waitDuration)
@@ -191,6 +214,8 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
         {
             _publishRejectedCount++;
         }
+
+        _metricsEmitter?.RecordPublishRejected();
     }
 
     public void ObserveBufferedCount(int totalBufferedCount)
@@ -207,6 +232,8 @@ internal sealed class PipelinePerformanceCollector : IPipelinePerformanceCollect
                 _peakBufferedCount = totalBufferedCount;
             }
         }
+
+        _metricsEmitter?.ObserveBufferedCount(totalBufferedCount);
     }
 
     public PipelinePerformanceSnapshot CreateSnapshot()

--- a/src/Pipelinez/Core/Pipeline.cs
+++ b/src/Pipelinez/Core/Pipeline.cs
@@ -10,6 +10,7 @@ using Pipelinez.Core.Eventing;
 using Pipelinez.Core.FaultHandling;
 using Pipelinez.Core.FlowControl;
 using Pipelinez.Core.Logging;
+using Pipelinez.Core.Operational;
 using Pipelinez.Core.Performance;
 using Pipelinez.Core.Record;
 using Pipelinez.Core.Retry;
@@ -57,7 +58,9 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     private readonly IPipelineDeadLetterDestination<TPipelineRecord>? _deadLetterDestination;
     private readonly PipelineDeadLetterOptions _deadLetterOptions;
     private readonly PipelineFlowControlOptions _flowControlOptions;
+    private readonly PipelineOperationalOptions _operationalOptions;
     private readonly IPipelinePerformanceCollector _performanceCollector;
+    private readonly IPipelineMetricsEmitter? _metricsEmitter;
     private readonly bool _emitRetryEvents;
     private readonly string _instanceId;
     private readonly string _workerId;
@@ -75,6 +78,8 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     private bool _workerStoppingRaised;
     private bool? _lastObservedSaturationWarningState;
     private bool? _lastObservedSaturationState;
+    private DateTimeOffset? _lastRecordCompletedAtUtc;
+    private DateTimeOffset? _lastDeadLetteredAtUtc;
     
     #endregion
     
@@ -171,11 +176,13 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         // 2 - lets pipeline users know that the record has completed
         OnPipelineContainerCompelted?.Invoke(this, evt);
         _performanceCollector.RecordCompleted(evt.Container.CreatedAtUtc);
+        _lastRecordCompletedAtUtc = DateTimeOffset.UtcNow;
         OnPipelineRecordCompleted?.Invoke(
             this,
             new PipelineRecordCompletedEventHandlerArgs<TPipelineRecord>(
                 evt.Container.Record,
-                BuildDistributionContext(evt.Container.Metadata)));
+                BuildDistributionContext(evt.Container.Metadata),
+                BuildDiagnosticContext(evt.Container.Metadata)));
         ObserveFlowControlState();
     }
 
@@ -194,7 +201,8 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
                 container.Record,
                 container,
                 container.Fault,
-                BuildDistributionContext(container.Metadata)));
+                BuildDistributionContext(container.Metadata),
+                BuildDiagnosticContext(container.Metadata, container.Fault.ComponentName)));
         if (container.RetryHistory.Count > 0)
         {
             _performanceCollector.RecordRetryExhausted();
@@ -260,6 +268,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         PipelineHostOptions? hostOptions = null,
         IPipelineDeadLetterDestination<TPipelineRecord>? deadLetterDestination = null,
         PipelineDeadLetterOptions? deadLetterOptions = null,
+        PipelineOperationalOptions? operationalOptions = null,
         PipelineFlowControlOptions? flowControlOptions = null,
         IPipelinePerformanceCollector? performanceCollector = null,
         bool emitRetryEvents = true)
@@ -278,6 +287,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         _hostOptions = hostOptions ?? new PipelineHostOptions();
         _deadLetterDestination = deadLetterDestination;
         _deadLetterOptions = (deadLetterOptions ?? new PipelineDeadLetterOptions()).Validate();
+        _operationalOptions = (operationalOptions ?? new PipelineOperationalOptions()).Validate();
         _flowControlOptions = (flowControlOptions ?? new PipelineFlowControlOptions()).Validate();
         _performanceCollector = performanceCollector ?? new PipelinePerformanceCollector(new PipelineMetricsOptions());
         _emitRetryEvents = emitRetryEvents;
@@ -287,6 +297,17 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         _workerId = string.IsNullOrWhiteSpace(_hostOptions.WorkerId)
             ? $"{_name}-{Guid.NewGuid():N}"
             : _hostOptions.WorkerId;
+
+        if (_operationalOptions.EnableMetrics)
+        {
+            _metricsEmitter = new PipelineMetricsEmitter(
+                _name,
+                _workerId,
+                _hostOptions.ExecutionMode,
+                () => GetPerformanceSnapshot().RecordsPerSecond,
+                GetCurrentHealthState);
+            _performanceCollector.ConfigureMetricsEmitter(_metricsEmitter);
+        }
     }
 
     internal void LinkPipeline()
@@ -504,6 +525,39 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         return _performanceCollector.CreateSnapshot();
     }
 
+    public PipelineHealthStatus GetHealthStatus()
+    {
+        var status = GetStatus();
+        var performance = GetPerformanceSnapshot();
+        var reasons = BuildHealthReasons(status, performance);
+        var healthState = DetermineHealthState(performance, reasons);
+
+        return new PipelineHealthStatus(
+            _name,
+            healthState,
+            reasons,
+            DateTimeOffset.UtcNow,
+            status,
+            performance,
+            _pipelineFault);
+    }
+
+    public PipelineOperationalSnapshot GetOperationalSnapshot()
+    {
+        var status = GetStatus();
+        var performance = GetPerformanceSnapshot();
+        var health = GetHealthStatus();
+
+        return new PipelineOperationalSnapshot(
+            status,
+            performance,
+            health,
+            DateTimeOffset.UtcNow,
+            _pipelineFault,
+            _lastRecordCompletedAtUtc,
+            _lastDeadLetteredAtUtc);
+    }
+
     internal PipelineFlowControlOptions GetFlowControlOptions()
     {
         return _flowControlOptions;
@@ -520,9 +574,13 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         ObserveFlowControlState();
     }
 
-    internal void NotifyPublishRejected(TPipelineRecord record, PipelinePublishResult publishResult)
+    internal void NotifyPublishRejected(
+        TPipelineRecord record,
+        Pipelinez.Core.Record.Metadata.MetadataCollection metadata,
+        PipelinePublishResult publishResult)
     {
         Guard.Against.Null(record, nameof(record));
+        Guard.Against.Null(metadata, nameof(metadata));
         Guard.Against.Null(publishResult, nameof(publishResult));
 
         if (publishResult.WaitDuration > TimeSpan.Zero)
@@ -536,7 +594,8 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
             new PipelinePublishRejectedEventArgs<TPipelineRecord>(
                 record,
                 publishResult.Reason,
-                DateTimeOffset.UtcNow));
+                DateTimeOffset.UtcNow,
+                BuildDiagnosticContext(metadata)));
         ObserveFlowControlState();
     }
 
@@ -613,7 +672,8 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
                 retryAttempt.AttemptNumber,
                 maxAttempts,
                 retryAttempt.DelayBeforeNextAttempt,
-                BuildDistributionContext(container.Metadata)));
+                BuildDistributionContext(container.Metadata),
+                BuildDiagnosticContext(container.Metadata, retryAttempt.ComponentName)));
 
         return Task.CompletedTask;
     }
@@ -661,6 +721,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
 
         if (assignedPartitions.Count > 0)
         {
+            _metricsEmitter?.ObserveOwnedPartitionCount(runtimeContext.OwnedPartitions.Count);
             OnPartitionsAssigned?.Invoke(this, new PipelinePartitionsAssignedEventArgs(runtimeContext, assignedPartitions));
         }
     }
@@ -692,6 +753,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
 
         if (revokedPartitions.Count > 0)
         {
+            _metricsEmitter?.ObserveOwnedPartitionCount(runtimeContext.OwnedPartitions.Count);
             OnPartitionsRevoked?.Invoke(this, new PipelinePartitionsRevokedEventArgs(runtimeContext, revokedPartitions));
         }
     }
@@ -789,6 +851,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         _cancellationRegistration.Dispose();
         _runtimeCancellationTokenSource?.Dispose();
         _runtimeCancellationTokenSource = null;
+        _metricsEmitter?.Dispose();
     }
 
     private void RequestRuntimeCancellation()
@@ -867,6 +930,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
                 .ConfigureAwait(false);
 
             _performanceCollector.RecordDeadLettered();
+            _lastDeadLetteredAtUtc = DateTimeOffset.UtcNow;
             RaiseDeadLettered(container.Record, deadLetterRecord);
         }
         catch (Exception exception)
@@ -973,6 +1037,25 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
             TryParseLong(metadata.GetValue(DistributedMetadataKeys.Offset)));
     }
 
+    private PipelineRecordDiagnosticContext BuildDiagnosticContext(
+        Pipelinez.Core.Record.Metadata.MetadataCollection metadata,
+        string? componentName = null)
+    {
+        var correlationId = metadata.GetValue(PipelineOperationalMetadataKeys.CorrelationId);
+        if (string.IsNullOrWhiteSpace(correlationId))
+        {
+            correlationId = Guid.NewGuid().ToString("N");
+            metadata.Set(PipelineOperationalMetadataKeys.CorrelationId, correlationId);
+        }
+
+        return new PipelineRecordDiagnosticContext(
+            correlationId,
+            _name,
+            _instanceId,
+            _workerId,
+            componentName);
+    }
+
     private PipelineDeadLetterRecord<TPipelineRecord> CreateDeadLetterRecord(
         PipelineContainer<TPipelineRecord> container,
         PipelineFaultState fault)
@@ -1005,7 +1088,10 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
 
         OnPipelineRecordDeadLettered?.Invoke(
             this,
-            new PipelineRecordDeadLetteredEventArgs<TPipelineRecord>(record, deadLetterRecord));
+            new PipelineRecordDeadLetteredEventArgs<TPipelineRecord>(
+                record,
+                deadLetterRecord,
+                BuildDiagnosticContext(deadLetterRecord.Metadata, deadLetterRecord.Fault.ComponentName)));
     }
 
     private void RaiseDeadLetterWriteFailed(
@@ -1020,7 +1106,11 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
 
         OnPipelineDeadLetterWriteFailed?.Invoke(
             this,
-            new PipelineDeadLetterWriteFailedEventArgs<TPipelineRecord>(record, deadLetterRecord, exception));
+            new PipelineDeadLetterWriteFailedEventArgs<TPipelineRecord>(
+                record,
+                deadLetterRecord,
+                exception,
+                BuildDiagnosticContext(deadLetterRecord.Metadata, deadLetterRecord.Fault.ComponentName)));
     }
 
     private void RaiseWorkerStartedIfNeeded()
@@ -1173,6 +1263,81 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         }
 
         return Array.Empty<PipelinePartitionExecutionState>();
+    }
+
+    private PipelineHealthState GetCurrentHealthState()
+    {
+        var status = GetStatus();
+        var performance = GetPerformanceSnapshot();
+        var reasons = BuildHealthReasons(status, performance);
+        return DetermineHealthState(performance, reasons);
+    }
+
+    private IReadOnlyList<string> BuildHealthReasons(
+        PipelineStatus status,
+        PipelinePerformanceSnapshot performance)
+    {
+        var reasons = new List<string>();
+
+        if (status.FlowControlStatus is { } flow &&
+            (flow.IsSaturated || flow.SaturationRatio >= _operationalOptions.SaturationDegradedThreshold))
+        {
+            reasons.Add("Pipeline is saturated.");
+        }
+
+        if (_operationalOptions.RetryExhaustionDegradedThreshold > 0 &&
+            performance.RetryExhaustions >= _operationalOptions.RetryExhaustionDegradedThreshold)
+        {
+            reasons.Add("Retry exhaustion threshold exceeded.");
+        }
+
+        if (_operationalOptions.DeadLetterDegradedThreshold > 0 &&
+            performance.TotalDeadLetteredCount >= _operationalOptions.DeadLetterDegradedThreshold)
+        {
+            reasons.Add("Dead-letter threshold exceeded.");
+        }
+
+        if (_operationalOptions.PublishRejectionDegradedThreshold > 0 &&
+            performance.TotalPublishRejectedCount >= _operationalOptions.PublishRejectionDegradedThreshold)
+        {
+            reasons.Add("Publish rejection threshold exceeded.");
+        }
+
+        var drainingPartitions = status.DistributedStatus?.PartitionExecution.Count(partition => partition.IsDraining) ?? 0;
+        if (_operationalOptions.DrainingPartitionDegradedThreshold > 0 &&
+            drainingPartitions >= _operationalOptions.DrainingPartitionDegradedThreshold)
+        {
+            reasons.Add("Draining partition threshold exceeded.");
+        }
+
+        if (performance.TotalDeadLetterFailureCount > 0)
+        {
+            reasons.Add("Dead-letter failures observed.");
+        }
+
+        return reasons;
+    }
+
+    private PipelineHealthState DetermineHealthState(
+        PipelinePerformanceSnapshot performance,
+        IReadOnlyList<string> reasons)
+    {
+        PipelineRuntimeState currentState;
+        lock (_stateLock)
+        {
+            currentState = _state;
+        }
+
+        return currentState switch
+        {
+            PipelineRuntimeState.NotStarted => PipelineHealthState.Starting,
+            PipelineRuntimeState.Starting => PipelineHealthState.Starting,
+            PipelineRuntimeState.Completed => PipelineHealthState.Completed,
+            PipelineRuntimeState.Faulted => PipelineHealthState.Unhealthy,
+            _ when performance.TotalDeadLetterFailureCount > 0 => PipelineHealthState.Unhealthy,
+            _ when reasons.Count > 0 => PipelineHealthState.Degraded,
+            _ => PipelineHealthState.Healthy
+        };
     }
 
 }

--- a/src/Pipelinez/Core/PipelineBuilder.cs
+++ b/src/Pipelinez/Core/PipelineBuilder.cs
@@ -6,6 +6,7 @@ using Pipelinez.Core.Destination;
 using Pipelinez.Core.ErrorHandling;
 using Pipelinez.Core.FlowControl;
 using Pipelinez.Core.Logging;
+using Pipelinez.Core.Operational;
 using Pipelinez.Core.Performance;
 using Pipelinez.Core.Record;
 using Pipelinez.Core.Retry;
@@ -37,6 +38,7 @@ public class PipelineBuilder<T>(string pipelineName)
     private PipelineHostOptions _hostOptions = new();
     private PipelineDeadLetterOptions _deadLetterOptions = new();
     private PipelineFlowControlOptions _flowControlOptions = new();
+    private PipelineOperationalOptions _operationalOptions = new();
     private PipelinePerformanceOptions _performanceOptions = new();
     private PipelineRetryOptions<T> _retryOptions = new();
 
@@ -193,6 +195,12 @@ public class PipelineBuilder<T>(string pipelineName)
 
     #region Flow Control
 
+    public PipelineBuilder<T> UseOperationalOptions(PipelineOperationalOptions options)
+    {
+        _operationalOptions = Guard.Against.Null(options, nameof(options)).Validate();
+        return this;
+    }
+
     public PipelineBuilder<T> UseFlowControlOptions(PipelineFlowControlOptions options)
     {
         _flowControlOptions = Guard.Against.Null(options, nameof(options)).Validate();
@@ -305,6 +313,7 @@ public class PipelineBuilder<T>(string pipelineName)
             _hostOptions,
             _deadLetterDestination,
             _deadLetterOptions,
+            _operationalOptions,
             _flowControlOptions,
             performanceCollector,
             _retryOptions.EmitRetryEvents);

--- a/src/Pipelinez/Core/Record/Metadata/MetadataCollection.cs
+++ b/src/Pipelinez/Core/Record/Metadata/MetadataCollection.cs
@@ -88,6 +88,9 @@ public class MetadataCollection : IList<MetadataRecord>
 
     public void Set(string key, string value)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentNullException.ThrowIfNull(value);
+
         var existingRecord = GetByKey(key);
         if (existingRecord is not null)
         {

--- a/src/Pipelinez/Core/Source/PipelineSource.cs
+++ b/src/Pipelinez/Core/Source/PipelineSource.cs
@@ -5,6 +5,7 @@ using Pipelinez.Core.Eventing;
 using Pipelinez.Core.Flow;
 using Pipelinez.Core.FlowControl;
 using Pipelinez.Core.Logging;
+using Pipelinez.Core.Operational;
 using Pipelinez.Core.Performance;
 using Pipelinez.Core.Record;
 using Pipelinez.Core.Record.Metadata;
@@ -72,6 +73,8 @@ public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecu
 
     public async Task<PipelinePublishResult> PublishAsync(T record, MetadataCollection metadata, PipelinePublishOptions options)
     {
+        EnsureCorrelationId(metadata);
+
         var container = new PipelineContainer<T>(
             Guard.Against.Null(record, nameof(record)),
             Guard.Against.Null(metadata, nameof(metadata)));
@@ -91,7 +94,7 @@ public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecu
             return publishResult;
         }
 
-        ParentPipeline.NotifyPublishRejected(record, publishResult);
+        ParentPipeline.NotifyPublishRejected(record, metadata, publishResult);
         return publishResult;
     }
 
@@ -213,5 +216,15 @@ public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecu
         }
 
         publishResult.ThrowIfNotAccepted();
+    }
+
+    private static void EnsureCorrelationId(MetadataCollection metadata)
+    {
+        if (metadata.HasKey(PipelineOperationalMetadataKeys.CorrelationId))
+        {
+            return;
+        }
+
+        metadata.Set(PipelineOperationalMetadataKeys.CorrelationId, Guid.NewGuid().ToString("N"));
     }
 }

--- a/src/Pipelinez/Pipelinez.csproj
+++ b/src/Pipelinez/Pipelinez.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="Ardalis.GuardClauses" Version="4.5.0" />
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     </ItemGroup>
 

--- a/src/tests/Pipelinez.Kafka.Tests/EndToEnd/KafkaPipelineDeadLetterTests.cs
+++ b/src/tests/Pipelinez.Kafka.Tests/EndToEnd/KafkaPipelineDeadLetterTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Confluent.Kafka;
 using Pipelinez.Core;
 using Pipelinez.Core.ErrorHandling;
+using Pipelinez.Core.Operational;
 using Pipelinez.Kafka;
 using Pipelinez.Kafka.Record;
 using Pipelinez.Kafka.Tests.Infrastructure;
@@ -49,6 +50,7 @@ public sealed class KafkaPipelineDeadLetterTests(KafkaTestCluster cluster)
                         value = deadLetter.Record.Value,
                         component = deadLetter.Fault.ComponentName,
                         retryCount = deadLetter.RetryHistory.Count,
+                        correlationId = deadLetter.Metadata.GetValue(PipelineOperationalMetadataKeys.CorrelationId),
                         topic = deadLetter.Metadata.GetValue(KafkaMetadataKeys.SOURCE_TOPIC_NAME),
                         partition = deadLetter.Metadata.GetValue(KafkaMetadataKeys.SOURCE_PARTITION),
                         offset = deadLetter.Metadata.GetValue(KafkaMetadataKeys.SOURCE_OFFSET)
@@ -91,12 +93,17 @@ public sealed class KafkaPipelineDeadLetterTests(KafkaTestCluster cluster)
         var deadLetterMessage = Assert.Single(deadLetterMessages);
         Assert.Equal("bad-1", deadLetterMessage.Message.Key);
 
+        Assert.Contains(
+            pipeline.GetHealthStatus().Reasons,
+            reason => reason.Contains("Dead-letter", StringComparison.OrdinalIgnoreCase));
+
         using var document = JsonDocument.Parse(deadLetterMessage.Message.Value);
         var root = document.RootElement;
         Assert.Equal("bad-1", root.GetProperty("key").GetString());
         Assert.Equal("bad", root.GetProperty("value").GetString());
         Assert.Equal(nameof(ConditionalFaultingKafkaSegment), root.GetProperty("component").GetString());
         Assert.Equal(0, root.GetProperty("retryCount").GetInt32());
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("correlationId").GetString()));
         Assert.Equal(sourceTopic, root.GetProperty("topic").GetString());
         Assert.Equal("0", root.GetProperty("partition").GetString());
         Assert.Equal("0", root.GetProperty("offset").GetString());

--- a/src/tests/Pipelinez.Tests/Core/OperationalTests/PipelineOperationalToolingTests.cs
+++ b/src/tests/Pipelinez.Tests/Core/OperationalTests/PipelineOperationalToolingTests.cs
@@ -1,0 +1,238 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Pipelinez.Core;
+using Pipelinez.Core.DeadLettering;
+using Pipelinez.Core.ErrorHandling;
+using Pipelinez.Core.Operational;
+using Pipelinez.Core.Retry;
+using Pipelinez.Core.Source;
+using Pipelinez.Tests.Core.DeadLetterTests.Models;
+using Pipelinez.Tests.Core.ErrorHandlingTests.Models;
+using Pipelinez.Tests.Core.RetryTests.Models;
+using Pipelinez.Tests.Core.SourceDestTests.Models;
+
+namespace Pipelinez.Tests.Core.OperationalTests;
+
+public sealed class PipelineOperationalToolingTests
+{
+    [Fact]
+    public async Task Pipeline_Health_Status_Transitions_Across_Runtime_Lifecycle()
+    {
+        var pipeline = Pipeline<TestPipelineRecord>.New(nameof(Pipeline_Health_Status_Transitions_Across_Runtime_Lifecycle))
+            .WithInMemorySource(new object())
+            .WithInMemoryDestination("config")
+            .Build();
+
+        Assert.Equal(PipelineHealthState.Starting, pipeline.GetHealthStatus().State);
+
+        await pipeline.StartPipelineAsync();
+
+        Assert.Equal(PipelineHealthState.Healthy, pipeline.GetHealthStatus().State);
+
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = "ok" });
+        await pipeline.CompleteAsync();
+        await pipeline.Completion;
+
+        Assert.Equal(PipelineHealthState.Completed, pipeline.GetHealthStatus().State);
+    }
+
+    [Fact]
+    public async Task Pipeline_Health_Status_Becomes_Degraded_When_DeadLetter_Threshold_Is_Exceeded()
+    {
+        var deadLetters = new InMemoryDeadLetterDestination<TestPipelineRecord>();
+        var destination = new CollectingDestination();
+
+        var pipeline = Pipeline<TestPipelineRecord>.New(nameof(Pipeline_Health_Status_Becomes_Degraded_When_DeadLetter_Threshold_Is_Exceeded))
+            .UseOperationalOptions(new PipelineOperationalOptions
+            {
+                DeadLetterDegradedThreshold = 1,
+                RetryExhaustionDegradedThreshold = long.MaxValue,
+                PublishRejectionDegradedThreshold = long.MaxValue,
+                DrainingPartitionDegradedThreshold = int.MaxValue,
+                SaturationDegradedThreshold = 1d
+            })
+            .WithInMemorySource(new object())
+            .AddSegment(new ConditionalFaultingSegment(), new object())
+            .WithDestination(destination)
+            .WithDeadLetterDestination(deadLetters)
+            .WithErrorHandler(_ => PipelineErrorAction.DeadLetter)
+            .Build();
+
+        await pipeline.StartPipelineAsync();
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = ConditionalFaultingSegment.FaultingValue });
+
+        await WaitForConditionAsync(() => deadLetters.Records.Count == 1);
+
+        var health = pipeline.GetHealthStatus();
+        Assert.Equal(PipelineHealthState.Degraded, health.State);
+        Assert.Contains(health.Reasons, reason => reason.Contains("Dead-letter", StringComparison.OrdinalIgnoreCase));
+
+        await pipeline.CompleteAsync();
+        await pipeline.Completion;
+    }
+
+    [Fact]
+    public async Task Pipeline_Operational_Snapshot_Includes_Last_Completion_And_Last_DeadLetter_Timestamps()
+    {
+        var deadLetters = new InMemoryDeadLetterDestination<TestPipelineRecord>();
+        var destination = new CollectingDestination();
+
+        var pipeline = Pipeline<TestPipelineRecord>.New(nameof(Pipeline_Operational_Snapshot_Includes_Last_Completion_And_Last_DeadLetter_Timestamps))
+            .WithInMemorySource(new object())
+            .AddSegment(new ConditionalFaultingSegment(), new object())
+            .WithDestination(destination)
+            .WithDeadLetterDestination(deadLetters)
+            .WithErrorHandler(context =>
+                context.Record.Data == ConditionalFaultingSegment.FaultingValue
+                    ? PipelineErrorAction.DeadLetter
+                    : PipelineErrorAction.StopPipeline)
+            .Build();
+
+        await pipeline.StartPipelineAsync();
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = ConditionalFaultingSegment.FaultingValue });
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = "good" });
+
+        await WaitForConditionAsync(() => deadLetters.Records.Count == 1 && destination.Records.Count == 1);
+
+        var snapshot = pipeline.GetOperationalSnapshot();
+        Assert.NotNull(snapshot.LastDeadLetteredAtUtc);
+        Assert.NotNull(snapshot.LastRecordCompletedAtUtc);
+        Assert.Equal(1, snapshot.Performance.TotalDeadLetteredCount);
+        Assert.Equal(1, snapshot.Performance.TotalRecordsCompleted);
+
+        await pipeline.CompleteAsync();
+        await pipeline.Completion;
+    }
+
+    [Fact]
+    public async Task Pipeline_Correlation_Id_Is_Generated_And_Preserved()
+    {
+        var source = new InMemoryPipelineSource<TestPipelineRecord>();
+        var completed = new List<string>();
+
+        var pipeline = Pipeline<TestPipelineRecord>.New(nameof(Pipeline_Correlation_Id_Is_Generated_And_Preserved))
+            .WithSource(source)
+            .WithInMemoryDestination("config")
+            .Build();
+
+        pipeline.OnPipelineRecordCompleted += (_, args) =>
+        {
+            completed.Add(args.Diagnostic!.CorrelationId);
+        };
+
+        await pipeline.StartPipelineAsync();
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = "auto" });
+
+        var preservedMetadata = new Pipelinez.Core.Record.Metadata.MetadataCollection();
+        preservedMetadata.Set(PipelineOperationalMetadataKeys.CorrelationId, "custom-correlation-id");
+        await source.PublishAsync(
+            new TestPipelineRecord { Data = "preserved" },
+            preservedMetadata);
+
+        await pipeline.CompleteAsync();
+        await pipeline.Completion;
+
+        Assert.Equal(2, completed.Count);
+        Assert.False(string.IsNullOrWhiteSpace(completed[0]));
+        Assert.Equal("custom-correlation-id", completed[1]);
+    }
+
+    [Fact]
+    public async Task Pipeline_Health_Check_Maps_Unhealthy_Runtime()
+    {
+        var pipeline = Pipeline<TestPipelineRecord>.New(nameof(Pipeline_Health_Check_Maps_Unhealthy_Runtime))
+            .WithInMemorySource(new object())
+            .AddSegment(new ConditionalFaultingSegment(), new object())
+            .WithInMemoryDestination("config")
+            .WithErrorHandler(_ => PipelineErrorAction.StopPipeline)
+            .Build();
+
+        await pipeline.StartPipelineAsync();
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = ConditionalFaultingSegment.FaultingValue });
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await pipeline.Completion);
+
+        var healthCheck = new PipelineHealthCheck<TestPipelineRecord>(pipeline);
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+    }
+
+    [Fact]
+    public async Task Pipeline_Metrics_Are_Emitted_Through_Runtime_Meter()
+    {
+        var pipelineName = nameof(Pipeline_Metrics_Are_Emitted_Through_Runtime_Meter);
+        var measurements = new Dictionary<string, long>(StringComparer.Ordinal);
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, currentListener) =>
+        {
+            if (instrument.Meter.Name == PipelineMetricsEmitter.MeterName)
+            {
+                currentListener.EnableMeasurementEvents(instrument);
+            }
+        };
+
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+        {
+            if (!HasPipelineTag(tags, pipelineName))
+            {
+                return;
+            }
+
+            measurements[instrument.Name] = measurements.GetValueOrDefault(instrument.Name) + measurement;
+        });
+        listener.Start();
+
+        var pipeline = Pipeline<TestPipelineRecord>.New(pipelineName)
+            .UseRetryOptions(new PipelineRetryOptions<TestPipelineRecord>
+            {
+                DefaultSegmentPolicy = PipelineRetryPolicy<TestPipelineRecord>
+                    .FixedDelay(3, TimeSpan.Zero)
+                    .Handle<RetryTestException>()
+            })
+            .WithInMemorySource(new object())
+            .AddSegment(new FlakySegment(failuresBeforeSuccess: 1), new object())
+            .WithInMemoryDestination("config")
+            .Build();
+
+        await pipeline.StartPipelineAsync();
+        await pipeline.PublishAsync(new TestPipelineRecord { Data = "good" });
+        await pipeline.CompleteAsync();
+        await pipeline.Completion;
+
+        Assert.True(measurements["pipelinez.records.published"] >= 1);
+        Assert.True(measurements["pipelinez.records.completed"] >= 1);
+        Assert.True(measurements["pipelinez.retry.attempts"] >= 1);
+        Assert.True(measurements["pipelinez.retry.recoveries"] >= 1);
+    }
+
+    private static async Task WaitForConditionAsync(Func<bool> predicate)
+    {
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(5);
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (predicate())
+            {
+                return;
+            }
+
+            await Task.Delay(50).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException("Timed out waiting for the expected operational test condition.");
+    }
+
+    private static bool HasPipelineTag(ReadOnlySpan<KeyValuePair<string, object?>> tags, string pipelineName)
+    {
+        foreach (var tag in tags)
+        {
+            if (tag.Key == "pipeline.name" && string.Equals(tag.Value?.ToString(), pipelineName, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds first-class operational tooling to Pipelinez so hosts and operators can inspect pipeline health, consume runtime metrics, and correlate record activity across success, retry, fault, and dead-letter flows.

## What Changed

### Operational runtime surface
- Added `PipelineOperationalOptions`
- Added `GetHealthStatus()` to the pipeline API
- Added `GetOperationalSnapshot()` to the pipeline API
- Added `PipelineHealthState`
- Added `PipelineHealthStatus`
- Added `PipelineOperationalSnapshot`

### Health model
- Added explicit health states for:
  - `Starting`
  - `Healthy`
  - `Degraded`
  - `Unhealthy`
  - `Completed`
- Added degraded-state reasoning based on operational signals such as:
  - saturation
  - retry exhaustion
  - dead-letter activity
  - publish rejection
  - draining partitions
- Added `PipelineHealthCheck<T>` for `Microsoft.Extensions.Diagnostics.HealthChecks` integration

### Metrics
- Added meter-based runtime instrumentation under the `Pipelinez.Runtime` meter
- Added counters for:
  - published records
  - completed records
  - faulted records
  - retry attempts
  - retry recoveries
  - retry exhaustions
  - dead-letter writes
  - dead-letter failures
  - publish rejections
- Added observable gauges for:
  - buffered record count
  - owned partition count
  - records per second
  - current health-state value

### Correlation and diagnostics
- Added correlation ID stamping when records enter the pipeline
- Added the metadata key:
  - `pipelinez.correlation.id`
- Added `PipelineRecordDiagnosticContext`
- Extended key record lifecycle events to include diagnostic context so correlation can be followed through:
  - completion
  - fault
  - retry
  - publish rejection
  - dead-letter success
  - dead-letter failure

### Runtime integration
- Wired operational options through the builder and pipeline runtime
- Reused the existing performance collector as the source for meter-backed metrics rather than duplicating counting logic
- Added tracking for:
  - last successful completion timestamp
  - last dead-letter timestamp
  - last pipeline fault in operational snapshots

### Kafka-backed operational behavior
- Extended Kafka-backed dead-letter coverage so correlation IDs and operational degradation signals are validated in a real broker-backed flow
- Ensured distributed partition ownership is reflected in observable metrics through the runtime meter path

## Testing
Added coverage for:
- health status transitions across startup, running, completion, and fault
- degraded health based on operational thresholds
- operational snapshot content
- correlation ID generation and preservation
- health-check result mapping
- runtime meter metric emission
- Kafka-backed correlation and degraded-health validation in dead-letter scenarios

## Documentation
- Updated the root README with operational tooling usage
- Updated the architectural overview to describe health snapshots, health checks, runtime metrics, and correlation diagnostics
- Marked the operational tooling roadmap item as implemented

## Result
Pipelinez now provides a much more complete production operations surface with:
- explicit health inspection
- standard .NET health-check integration
- meter-based runtime metrics
- correlation-aware diagnostics
- operator-friendly snapshots built on the existing runtime status and performance model