### PR TITLE
API Stabality

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+- describe the change
+
+## Validation
+
+- [ ] `dotnet build src/Pipelinez.sln`
+- [ ] `dotnet test src/Pipelinez.sln --logger "console;verbosity=minimal"`
+
+## Public API
+
+- [ ] No public API changes
+- [ ] Public API changes were intentional and the approved baselines were updated
+- [ ] New unstable public APIs are marked preview
+- [ ] Obsoletions include a migration path
+
+## Documentation
+
+- [ ] No documentation updates were needed
+- [ ] Consumer-facing docs were updated for behavior or API changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing
+
+## Goals
+
+Pipelinez is a reusable library, so contributions should optimize not only for correctness but also for maintainability, API clarity, and consumer confidence.
+
+## Development Basics
+
+- build the solution with `dotnet build src/Pipelinez.sln`
+- run the full test suite with `dotnet test src/Pipelinez.sln`
+- if you change performance-sensitive behavior, consider running the benchmark project too
+
+## Public API Changes
+
+Public API changes need a slightly higher bar than internal refactors.
+
+When a pull request changes the public surface of `Pipelinez` or `Pipelinez.Kafka`:
+
+- decide whether the API is intended to be stable or preview
+- avoid exposing low-level implementation details unless they are deliberate extension points
+- update the public API approval baseline intentionally
+- update docs and examples when consumer usage changes
+- provide migration guidance if an existing API is being replaced
+
+### Stable vs Preview
+
+- stable APIs are part of the compatibility promise for the current major version
+- preview APIs are public but intentionally marked as still evolving
+
+Preview APIs should use `ExperimentalAttribute` so consumers get an explicit code-level signal.
+
+### Obsoleting APIs
+
+Do not remove a stable API without a migration path.
+
+Preferred flow:
+
+1. add the replacement
+2. mark the old API with `[Obsolete(..., error: false)]`
+3. document the migration path
+4. remove the old API only in the next major version
+
+## Public API Approval Tests
+
+The repository uses approval tests to guard the public surface of:
+
+- `Pipelinez`
+- `Pipelinez.Kafka`
+
+If you intentionally changed the public API, refresh the baselines with:
+
+```powershell
+$env:PIPELINEZ_UPDATE_API_BASELINES='1'
+dotnet test src/tests/Pipelinez.Tests/Pipelinez.Tests.csproj --filter ApiApprovalTests
+dotnet test src/tests/Pipelinez.Kafka.Tests/Pipelinez.Kafka.Tests.csproj --filter ApiApprovalTests
+```
+
+Then run the full suite:
+
+```powershell
+dotnet test src/Pipelinez.sln --logger "console;verbosity=minimal"
+```
+
+## Documentation
+
+If your change affects how consumers use the library, update the relevant docs in the same pull request.
+
+That usually means some combination of:
+
+- `README.md`
+- `docs/Overview.md`
+- `docs/ApiStability.md`
+- examples under `src/examples`
+
+## Pull Requests
+
+Keep pull requests focused and make public API changes explicit in the description. If your PR changes consumer-facing behavior, call that out directly so reviewers can evaluate compatibility impact separately from implementation details.

--- a/README.md
+++ b/README.md
@@ -434,6 +434,8 @@ Public events include:
   BenchmarkDotNet-based performance benchmarks
 - [`docs/Overview.md`](docs/Overview.md)
   deeper architectural overview
+- [`docs/ApiStability.md`](docs/ApiStability.md)
+  compatibility, stability, and public API change guidance
 
 ## Running Locally
 
@@ -487,6 +489,17 @@ Current implemented capabilities include:
 - operational health snapshots, health-check integration, runtime meter metrics, and correlation IDs
 - Kafka source and destination support
 - Docker-backed Kafka integration coverage, including multi-worker distributed tests
+- public API approval tests and repository-level API stability guidance
+
+## API Stability
+
+Pipelinez now treats the public API of `Pipelinez` and `Pipelinez.Kafka` as an intentional compatibility contract.
+
+- stable APIs are expected to remain source-compatible within the current major version
+- preview APIs should be explicitly marked and documented when introduced
+- public API approval tests protect both assemblies from accidental surface changes in normal PR and CI validation
+
+See [`docs/ApiStability.md`](docs/ApiStability.md) for the full policy and maintainer workflow.
 
 ## License
 

--- a/docs/ApiStability.md
+++ b/docs/ApiStability.md
@@ -1,0 +1,121 @@
+# API Stability
+
+Pipelinez now treats its public API as an intentional contract rather than an incidental byproduct of the implementation.
+
+## Stability Levels
+
+### Stable
+
+Stable APIs are safe for consumers to depend on within the current major version.
+
+Examples of stable surface area include:
+
+- `Pipeline<T>.New(...)`
+- `PipelineBuilder<T>`
+- `IPipeline<T>`
+- `PipelineRecord`
+- source, segment, and destination abstractions
+- user-facing options, status, event, performance, flow-control, retry, dead-letter, distributed, and operational models
+- Kafka builder extensions and Kafka configuration models
+
+Stable APIs should only change in additive, source-compatible ways until the next major release.
+
+### Preview
+
+Preview APIs are public but intentionally marked as still evolving. When Pipelinez introduces a public API that is not yet covered by the stable compatibility promise, it should be marked with `ExperimentalAttribute` and called out in release communication.
+
+Example shape:
+
+```csharp
+using System.Diagnostics.CodeAnalysis;
+
+[Experimental("PIPELINEZ001")]
+public sealed class FutureTransportOptions
+{
+    public bool EnableSomethingStillEvolving { get; init; }
+}
+```
+
+Pipelinez does not currently ship any public APIs marked as preview.
+
+### Internal
+
+Types that are not intended as consumer extension points should remain internal. This includes low-level transport plumbing and helper types that exist only to support the runtime implementation.
+
+## Compatibility Rules
+
+### Patch Releases
+
+Patch releases may include:
+
+- bug fixes
+- performance improvements
+- non-breaking diagnostics improvements
+- documentation clarifications
+
+Patch releases should not remove public APIs or make existing supported usage stop compiling.
+
+### Minor Releases
+
+Minor releases may include:
+
+- new additive APIs
+- new events
+- new options with safe defaults
+- new transports or integrations
+- preview APIs
+
+Minor releases should preserve compatibility for existing stable APIs.
+
+### Major Releases
+
+Major releases may include:
+
+- API removals
+- renamed members
+- signature changes
+- required migration work for stable consumer code
+
+## Obsoletion Policy
+
+When a stable API needs to be replaced:
+
+1. a supported replacement should exist first
+2. the old API should be marked `[Obsolete(..., error: false)]`
+3. migration guidance should be added to release communication and docs
+4. the obsolete API should remain available until the next major release unless explicitly documented otherwise
+
+## Public API Enforcement
+
+The repository now includes public API approval tests for:
+
+- `Pipelinez`
+- `Pipelinez.Kafka`
+
+These tests compare the compiled public surface against checked-in approved baselines. Any unintended public API change causes the test suite to fail, which means the existing PR and CI workflows also catch it automatically.
+
+Approved baselines live in:
+
+- `src/tests/Pipelinez.Tests/ApprovedApi/Pipelinez.publicapi.txt`
+- `src/tests/Pipelinez.Kafka.Tests/ApprovedApi/Pipelinez.Kafka.publicapi.txt`
+
+To intentionally refresh the baselines after an approved public API change:
+
+```powershell
+$env:PIPELINEZ_UPDATE_API_BASELINES='1'
+dotnet test src/tests/Pipelinez.Tests/Pipelinez.Tests.csproj --filter ApiApprovalTests
+dotnet test src/tests/Pipelinez.Kafka.Tests/Pipelinez.Kafka.Tests.csproj --filter ApiApprovalTests
+```
+
+Then run the full test suite normally before merging.
+
+## Contributor Expectations
+
+If a change affects a public API:
+
+- decide whether the API is stable or preview
+- update the approved API baseline intentionally
+- update consumer-facing docs when usage changes
+- add migration guidance when replacing an existing API
+
+For broader contributor guidance, see [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -812,6 +812,17 @@ The major architectural work called out in the earlier planning docs has been im
 
 The remaining work is mostly future evolution work rather than foundational cleanup. Likely areas include broader transport coverage, schema-registry integration tests, and further runtime ergonomics.
 
+## API Stability And Governance
+
+Pipelinez now also has explicit public API governance in place.
+
+- the repository treats `Pipelinez` and `Pipelinez.Kafka` as intentional consumer contracts
+- public API approval tests snapshot the compiled surface of both assemblies
+- accidental API changes now fail the normal test suite, which means they are also caught by the existing PR and CI workflows
+- contributor guidance now distinguishes stable, preview, and internal-only surface area
+
+This does not freeze the project completely, but it does mean public API changes are now expected to be deliberate, reviewable, and documented.
+
 ## Mental Model For Future Readers
 
 The simplest way to think about Pipelinez is:

--- a/src/Pipelinez.Kafka/Kafka/Client/IKafkaAdminClient.cs
+++ b/src/Pipelinez.Kafka/Kafka/Client/IKafkaAdminClient.cs
@@ -1,6 +1,6 @@
 namespace Pipelinez.Kafka.Client;
 
-public interface IKafkaAdminClient
+internal interface IKafkaAdminClient
 {
     /// <summary>
     /// Validates the connection to kafka

--- a/src/Pipelinez.Kafka/Kafka/Client/IKafkaConsumer.cs
+++ b/src/Pipelinez.Kafka/Kafka/Client/IKafkaConsumer.cs
@@ -2,7 +2,7 @@ using Confluent.Kafka;
 
 namespace Pipelinez.Kafka.Client;
 
-public interface IKafkaConsumer<TMessageKey, TMessageValue>
+internal interface IKafkaConsumer<TMessageKey, TMessageValue>
 {
     public string Name { get; }
     public List<string> Subscription { get; }

--- a/src/Pipelinez.Kafka/Kafka/Client/IKafkaProducer.cs
+++ b/src/Pipelinez.Kafka/Kafka/Client/IKafkaProducer.cs
@@ -2,7 +2,7 @@ using Confluent.Kafka;
 
 namespace Pipelinez.Kafka.Client;
 
-public interface IKafkaProducer<TRecordKey, TRecordValue>
+internal interface IKafkaProducer<TRecordKey, TRecordValue>
 {
     Task<DeliveryResult<TRecordKey, TRecordValue>> ProduceAsync(
         string topicName,

--- a/src/Pipelinez.Kafka/Kafka/Client/Producer/KafkaProducer.cs
+++ b/src/Pipelinez.Kafka/Kafka/Client/Producer/KafkaProducer.cs
@@ -8,7 +8,7 @@ using Pipelinez.Kafka.Configuration;
 
 namespace Pipelinez.Kafka.Client.Producer;
 
-public class KafkaProducer<TRecordKey, TRecordValue> : IKafkaProducer<TRecordKey, TRecordValue> where TRecordValue : class where TRecordKey : class
+internal class KafkaProducer<TRecordKey, TRecordValue> : IKafkaProducer<TRecordKey, TRecordValue> where TRecordValue : class where TRecordKey : class
 {
     private readonly KafkaDestinationOptions _options;
     private readonly string _pipelineName;

--- a/src/Pipelinez.Kafka/Kafka/Record/PipelineRecordExtensions.cs
+++ b/src/Pipelinez.Kafka/Kafka/Record/PipelineRecordExtensions.cs
@@ -4,7 +4,7 @@ using Pipelinez.Core.Record;
 
 namespace Pipelinez.Kafka.Record;
 
-public static class PipelineRecordExtensions
+internal static class PipelineRecordExtensions
 {
     internal static PipelineRecordHeader ToPipelineRecordHeader(this IHeader header)
     {

--- a/src/Pipelinez/Core/Status/Extensions.cs
+++ b/src/Pipelinez/Core/Status/Extensions.cs
@@ -1,6 +1,6 @@
 namespace Pipelinez.Core.Status;
 
-public static class Extensions
+internal static class Extensions
 {
     
     internal static PipelineExecutionStatus ToPipelineExecutionStatus(this TaskStatus status)

--- a/src/tests/Pipelinez.Kafka.Tests/ApiApprovalTests.cs
+++ b/src/tests/Pipelinez.Kafka.Tests/ApiApprovalTests.cs
@@ -1,0 +1,39 @@
+using Pipelinez.Kafka;
+using Pipelinez.Testing.ApiApproval;
+using Xunit;
+
+namespace Pipelinez.Kafka.Tests;
+
+public class ApiApprovalTests
+{
+    private const string UpdateApiBaselinesEnvironmentVariable = "PIPELINEZ_UPDATE_API_BASELINES";
+
+    [Fact]
+    public void Pipelinez_Kafka_Public_Api_Matches_Approved_Baseline()
+    {
+        var approvedPath = GetApprovedPath();
+        var actual = ApiApprovalTextGenerator.Generate(typeof(KafkaPipelineBuilderExtensions).Assembly);
+        if (ShouldUpdateApiBaselines())
+        {
+            File.WriteAllText(approvedPath, actual.Replace("\n", Environment.NewLine));
+        }
+
+        var approved = File.ReadAllText(approvedPath).Replace("\r\n", "\n");
+
+        Assert.Equal(approved, actual);
+    }
+
+    private static bool ShouldUpdateApiBaselines()
+    {
+        return string.Equals(
+            Environment.GetEnvironmentVariable(UpdateApiBaselinesEnvironmentVariable),
+            "1",
+            StringComparison.Ordinal);
+    }
+
+    private static string GetApprovedPath()
+    {
+        var projectDirectory = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", ".."));
+        return Path.Combine(projectDirectory, "ApprovedApi", "Pipelinez.Kafka.publicapi.txt");
+    }
+}

--- a/src/tests/Pipelinez.Kafka.Tests/ApprovedApi/Pipelinez.Kafka.publicapi.txt
+++ b/src/tests/Pipelinez.Kafka.Tests/ApprovedApi/Pipelinez.Kafka.publicapi.txt
@@ -1,0 +1,90 @@
+Assembly: Pipelinez.Kafka
+
+public enum Pipelinez.Kafka.Configuration.KafkaDeserializationType
+  FIELD public static const Pipelinez.Kafka.Configuration.KafkaDeserializationType AVRO = Pipelinez.Kafka.Configuration.KafkaDeserializationType.1
+  FIELD public static const Pipelinez.Kafka.Configuration.KafkaDeserializationType DEFAULT = Pipelinez.Kafka.Configuration.KafkaDeserializationType.0
+  FIELD public static const Pipelinez.Kafka.Configuration.KafkaDeserializationType JSON = Pipelinez.Kafka.Configuration.KafkaDeserializationType.2
+
+public class Pipelinez.Kafka.Configuration.KafkaDestinationOptions : Pipelinez.Kafka.Configuration.KafkaOptions
+  CTOR public Pipelinez.Kafka.Configuration.KafkaDestinationOptions()
+  PROPERTY public Pipelinez.Kafka.Configuration.KafkaSchemaRegistryOptions Schema { get; set; }
+  PROPERTY public string TopicName { get; set; }
+
+public class Pipelinez.Kafka.Configuration.KafkaOptions
+  CTOR public Pipelinez.Kafka.Configuration.KafkaOptions()
+  PROPERTY public string BootstrapPassword { get; set; }
+  PROPERTY public string BootstrapServers { get; set; }
+  PROPERTY public string BootstrapUser { get; set; }
+  PROPERTY public Confluent.Kafka.SaslMechanism SaslMechanism { get; set; }
+  PROPERTY public Confluent.Kafka.SecurityProtocol SecurityProtocol { get; set; }
+
+public enum Pipelinez.Kafka.Configuration.KafkaPartitionExecutionMode
+  FIELD public static const Pipelinez.Kafka.Configuration.KafkaPartitionExecutionMode ParallelizeAcrossPartitions = Pipelinez.Kafka.Configuration.KafkaPartitionExecutionMode.1
+  FIELD public static const Pipelinez.Kafka.Configuration.KafkaPartitionExecutionMode PreservePartitionOrder = Pipelinez.Kafka.Configuration.KafkaPartitionExecutionMode.0
+  FIELD public static const Pipelinez.Kafka.Configuration.KafkaPartitionExecutionMode RelaxOrderingWithinPartition = Pipelinez.Kafka.Configuration.KafkaPartitionExecutionMode.2
+
+public enum Pipelinez.Kafka.Configuration.KafkaPartitionRebalanceMode
+  FIELD public static const Pipelinez.Kafka.Configuration.KafkaPartitionRebalanceMode DrainAndYield = Pipelinez.Kafka.Configuration.KafkaPartitionRebalanceMode.0
+  FIELD public static const Pipelinez.Kafka.Configuration.KafkaPartitionRebalanceMode StopAcceptingNewWorkAndYield = Pipelinez.Kafka.Configuration.KafkaPartitionRebalanceMode.1
+
+public class Pipelinez.Kafka.Configuration.KafkaPartitionScalingOptions
+  CTOR public Pipelinez.Kafka.Configuration.KafkaPartitionScalingOptions()
+  PROPERTY public bool EmitPartitionExecutionEvents { get; init; }
+  PROPERTY public Pipelinez.Kafka.Configuration.KafkaPartitionExecutionMode ExecutionMode { get; init; }
+  PROPERTY public int MaxConcurrentPartitions { get; init; }
+  PROPERTY public int MaxInFlightPerPartition { get; init; }
+  PROPERTY public Pipelinez.Kafka.Configuration.KafkaPartitionRebalanceMode RebalanceMode { get; init; }
+  METHOD public Pipelinez.Kafka.Configuration.KafkaPartitionScalingOptions Validate()
+
+public class Pipelinez.Kafka.Configuration.KafkaSchemaRegistryOptions
+  CTOR public Pipelinez.Kafka.Configuration.KafkaSchemaRegistryOptions()
+  PROPERTY public string KeySerializer { get; set; }
+  PROPERTY public string Password { get; set; }
+  PROPERTY public string Server { get; set; }
+  PROPERTY public string User { get; set; }
+  PROPERTY public string ValueSerializer { get; set; }
+
+public enum Pipelinez.Kafka.Configuration.KafkaSerializationType
+  FIELD public static const Pipelinez.Kafka.Configuration.KafkaSerializationType AVRO = Pipelinez.Kafka.Configuration.KafkaSerializationType.1
+  FIELD public static const Pipelinez.Kafka.Configuration.KafkaSerializationType DEFAULT = Pipelinez.Kafka.Configuration.KafkaSerializationType.0
+  FIELD public static const Pipelinez.Kafka.Configuration.KafkaSerializationType JSON = Pipelinez.Kafka.Configuration.KafkaSerializationType.2
+
+public class Pipelinez.Kafka.Configuration.KafkaSourceOptions : Pipelinez.Kafka.Configuration.KafkaOptions
+  CTOR public Pipelinez.Kafka.Configuration.KafkaSourceOptions()
+  PROPERTY public System.Nullable<int> AutoCommitIntervalMs { get; set; }
+  PROPERTY public string ConsumerGroup { get; set; }
+  PROPERTY public Pipelinez.Kafka.Configuration.KafkaPartitionScalingOptions PartitionScaling { get; set; }
+  PROPERTY public Pipelinez.Kafka.Configuration.KafkaSchemaRegistryOptions Schema { get; set; }
+  PROPERTY public bool StartOffsetFromBeginning { get; set; }
+  PROPERTY public string TopicName { get; set; }
+
+public class Pipelinez.Kafka.Destination.KafkaDeadLetterDestination<T, TRecordKey, TRecordValue> : Pipelinez.Core.DeadLettering.IPipelineDeadLetterDestination<T> where T : Pipelinez.Core.Record.PipelineRecord where TRecordKey : class where TRecordValue : class
+  CTOR public Pipelinez.Kafka.Destination.KafkaDeadLetterDestination<T, TRecordKey, TRecordValue>(string pipelineName, Pipelinez.Kafka.Configuration.KafkaDestinationOptions config, System.Func<Pipelinez.Core.DeadLettering.PipelineDeadLetterRecord<T>, Confluent.Kafka.Message<TRecordKey, TRecordValue>> messageMapper)
+  METHOD public virtual System.Threading.Tasks.Task WriteAsync(Pipelinez.Core.DeadLettering.PipelineDeadLetterRecord<T> deadLetterRecord, System.Threading.CancellationToken cancellationToken)
+
+public class Pipelinez.Kafka.Destination.KafkaPipelineDestination<T, TRecordKey, TRecordValue> : Pipelinez.Core.Destination.PipelineDestination<T> where T : Pipelinez.Core.Record.PipelineRecord where TRecordKey : class where TRecordValue : class
+  CTOR public Pipelinez.Kafka.Destination.KafkaPipelineDestination<T, TRecordKey, TRecordValue>(string pipelineName, Pipelinez.Kafka.Configuration.KafkaDestinationOptions config, System.Func<T, Confluent.Kafka.Message<TRecordKey, TRecordValue>> messageMapper)
+
+public static class Pipelinez.Kafka.KafkaPipelineBuilderExtensions
+  METHOD public static Pipelinez.Core.PipelineBuilder<T> WithKafkaDeadLetterDestination<T, TRecordKey, TRecordValue>(Pipelinez.Core.PipelineBuilder<T> builder, Pipelinez.Kafka.Configuration.KafkaDestinationOptions config, System.Func<Pipelinez.Core.DeadLettering.PipelineDeadLetterRecord<T>, Confluent.Kafka.Message<TRecordKey, TRecordValue>> recordMapper) where T : Pipelinez.Core.Record.PipelineRecord where TRecordKey : class where TRecordValue : class
+  METHOD public static Pipelinez.Core.PipelineBuilder<T> WithKafkaDestination<T, TRecordKey, TRecordValue>(Pipelinez.Core.PipelineBuilder<T> builder, Pipelinez.Kafka.Configuration.KafkaDestinationOptions config, System.Func<T, Confluent.Kafka.Message<TRecordKey, TRecordValue>> recordMapper) where T : Pipelinez.Core.Record.PipelineRecord where TRecordKey : class where TRecordValue : class
+  METHOD public static Pipelinez.Core.PipelineBuilder<T> WithKafkaSource<T, TRecordKey, TRecordValue>(Pipelinez.Core.PipelineBuilder<T> builder, Pipelinez.Kafka.Configuration.KafkaSourceOptions config, System.Func<TRecordKey, TRecordValue, T> recordMapper) where T : Pipelinez.Core.Record.PipelineRecord where TRecordKey : class where TRecordValue : class
+  METHOD public static Pipelinez.Core.PipelineBuilder<T> WithKafkaSource<T, TRecordKey, TRecordValue>(Pipelinez.Core.PipelineBuilder<T> builder, Pipelinez.Kafka.Configuration.KafkaSourceOptions config, System.Func<TRecordKey, TRecordValue, T> recordMapper, Pipelinez.Kafka.Configuration.KafkaPartitionScalingOptions partitionScalingOptions) where T : Pipelinez.Core.Record.PipelineRecord where TRecordKey : class where TRecordValue : class
+
+public static class Pipelinez.Kafka.Record.KafkaMetadataExtensions
+  METHOD public static string BuildLeaseId(string topicName, int partitionId)
+  METHOD public static string BuildPartitionKey(string topicName, int partitionId)
+  METHOD public static Pipelinez.Core.Record.Metadata.MetadataCollection ExtractMetadata(Confluent.Kafka.TopicPartitionOffset topicPartitionOffset)
+
+public static class Pipelinez.Kafka.Record.KafkaMetadataKeys
+  FIELD public static string SOURCE_OFFSET
+  FIELD public static string SOURCE_PARTITION
+  FIELD public static string SOURCE_TOPIC_NAME
+
+public class Pipelinez.Kafka.Source.KafkaPipelineSource<T, TRecordKey, TRecordValue> : Pipelinez.Core.Source.PipelineSourceBase<T>, Pipelinez.Core.Source.IDistributedPipelineSource<T> where T : Pipelinez.Core.Record.PipelineRecord where TRecordKey : class where TRecordValue : class
+  CTOR public Pipelinez.Kafka.Source.KafkaPipelineSource<T, TRecordKey, TRecordValue>(string pipelineName, Pipelinez.Kafka.Configuration.KafkaSourceOptions options, System.Func<TRecordKey, TRecordValue, T> recordMapper)
+  PROPERTY public bool SupportsDistributedExecution { get; }
+  PROPERTY public string TransportName { get; }
+  METHOD public virtual System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionLease> GetOwnedPartitions()
+  METHOD public virtual System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionExecutionState> GetPartitionExecutionStates()
+  METHOD public void OnPipelineContainerComplete(object sender, Pipelinez.Core.Eventing.PipelineContainerCompletedEventHandlerArgs<Pipelinez.Core.Record.PipelineContainer<T>> e)

--- a/src/tests/Pipelinez.Kafka.Tests/Pipelinez.Kafka.Tests.csproj
+++ b/src/tests/Pipelinez.Kafka.Tests/Pipelinez.Kafka.Tests.csproj
@@ -28,4 +28,9 @@
         <ProjectReference Include="..\..\Pipelinez.Kafka\Pipelinez.Kafka.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <Compile Include="..\TestCommon\ApiApproval\ApiApprovalTextGenerator.cs" Link="ApiApproval\ApiApprovalTextGenerator.cs" />
+        <None Include="ApprovedApi\Pipelinez.Kafka.publicapi.txt" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
 </Project>

--- a/src/tests/Pipelinez.Tests/ApiApprovalTests.cs
+++ b/src/tests/Pipelinez.Tests/ApiApprovalTests.cs
@@ -1,0 +1,38 @@
+using Pipelinez.Core;
+using Pipelinez.Testing.ApiApproval;
+
+namespace Pipelinez.Tests;
+
+public class ApiApprovalTests
+{
+    private const string UpdateApiBaselinesEnvironmentVariable = "PIPELINEZ_UPDATE_API_BASELINES";
+
+    [Fact]
+    public void Pipelinez_Public_Api_Matches_Approved_Baseline()
+    {
+        var approvedPath = GetApprovedPath();
+        var actual = ApiApprovalTextGenerator.Generate(typeof(Pipeline<>).Assembly);
+        if (ShouldUpdateApiBaselines())
+        {
+            File.WriteAllText(approvedPath, actual.Replace("\n", Environment.NewLine));
+        }
+
+        var approved = File.ReadAllText(approvedPath).Replace("\r\n", "\n");
+
+        Assert.Equal(approved, actual);
+    }
+
+    private static bool ShouldUpdateApiBaselines()
+    {
+        return string.Equals(
+            Environment.GetEnvironmentVariable(UpdateApiBaselinesEnvironmentVariable),
+            "1",
+            StringComparison.Ordinal);
+    }
+
+    private static string GetApprovedPath()
+    {
+        var projectDirectory = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", ".."));
+        return Path.Combine(projectDirectory, "ApprovedApi", "Pipelinez.publicapi.txt");
+    }
+}

--- a/src/tests/Pipelinez.Tests/ApprovedApi/Pipelinez.publicapi.txt
+++ b/src/tests/Pipelinez.Tests/ApprovedApi/Pipelinez.publicapi.txt
@@ -1,0 +1,707 @@
+Assembly: Pipelinez
+
+public interface Pipelinez.Core.DeadLettering.IPipelineDeadLetterDestination<T> where T : Pipelinez.Core.Record.PipelineRecord
+  METHOD public abstract System.Threading.Tasks.Task WriteAsync(Pipelinez.Core.DeadLettering.PipelineDeadLetterRecord<T> deadLetterRecord, System.Threading.CancellationToken cancellationToken)
+
+public class Pipelinez.Core.DeadLettering.InMemoryDeadLetterDestination<T> : Pipelinez.Core.DeadLettering.IPipelineDeadLetterDestination<T> where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.DeadLettering.InMemoryDeadLetterDestination<T>()
+  PROPERTY public System.Collections.Generic.IReadOnlyList<Pipelinez.Core.DeadLettering.PipelineDeadLetterRecord<T>> Records { get; }
+  METHOD public virtual System.Threading.Tasks.Task WriteAsync(Pipelinez.Core.DeadLettering.PipelineDeadLetterRecord<T> deadLetterRecord, System.Threading.CancellationToken cancellationToken)
+
+public class Pipelinez.Core.DeadLettering.PipelineDeadLetterOptions
+  CTOR public Pipelinez.Core.DeadLettering.PipelineDeadLetterOptions()
+  PROPERTY public bool CloneMetadata { get; init; }
+  PROPERTY public bool EmitDeadLetterEvents { get; init; }
+  PROPERTY public bool TreatDeadLetterFailureAsPipelineFault { get; init; }
+  METHOD public Pipelinez.Core.DeadLettering.PipelineDeadLetterOptions Validate()
+
+public class Pipelinez.Core.DeadLettering.PipelineDeadLetterRecord<T> where T : Pipelinez.Core.Record.PipelineRecord
+  [Obsolete("Constructors of types with required members are not supported in this version of your compiler.")] CTOR public Pipelinez.Core.DeadLettering.PipelineDeadLetterRecord<T>()
+  PROPERTY public required System.DateTimeOffset CreatedAtUtc { get; init; }
+  PROPERTY public required System.DateTimeOffset DeadLetteredAtUtc { get; init; }
+  PROPERTY public required Pipelinez.Core.Distributed.PipelineRecordDistributionContext Distribution { get; init; }
+  PROPERTY public required Pipelinez.Core.FaultHandling.PipelineFaultState Fault { get; init; }
+  PROPERTY public required Pipelinez.Core.Record.Metadata.MetadataCollection Metadata { get; init; }
+  PROPERTY public required T Record { get; init; }
+  PROPERTY public required System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Retry.PipelineRetryAttempt> RetryHistory { get; init; }
+  PROPERTY public required System.Collections.Generic.IReadOnlyList<Pipelinez.Core.FaultHandling.PipelineSegmentExecution> SegmentHistory { get; init; }
+  METHOD public void Validate()
+
+public interface Pipelinez.Core.Destination.IBatchedPipelineDestination<T> : Pipelinez.Core.Destination.IPipelineDestination<T> where T : Pipelinez.Core.Record.PipelineRecord
+  METHOD public abstract System.Threading.Tasks.Task ExecuteBatchAsync(System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Record.PipelineContainer<T>> batch, System.Threading.CancellationToken cancellationToken)
+
+public interface Pipelinez.Core.Destination.IPipelineDestination<T> : Pipelinez.Core.Flow.IFlowDestination<Pipelinez.Core.Record.PipelineContainer<T>> where T : Pipelinez.Core.Record.PipelineRecord
+  PROPERTY public System.Threading.Tasks.Task Completion { get; }
+  METHOD public abstract void Initialize(Pipelinez.Core.Pipeline<T> parentPipeline)
+  METHOD public abstract System.Threading.Tasks.Task StartAsync(System.Threading.CancellationTokenSource cancellationToken)
+
+public class Pipelinez.Core.Destination.InMemoryPipelineDestination<T> : Pipelinez.Core.Destination.PipelineDestination<T> where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.Destination.InMemoryPipelineDestination<T>()
+
+public abstract class Pipelinez.Core.Destination.PipelineDestination<T> : Pipelinez.Core.Destination.IPipelineDestination<T>, Pipelinez.Core.Flow.IFlowDestination<Pipelinez.Core.Record.PipelineContainer<T>>, Pipelinez.Core.Retry.IPipelineRetryConfigurable<T>, Pipelinez.Core.FlowControl.IPipelineFlowStatusProvider, Pipelinez.Core.Performance.IPipelineBatchingAware, Pipelinez.Core.Performance.IPipelineExecutionConfigurable, Pipelinez.Core.Performance.IPipelinePerformanceAware where T : Pipelinez.Core.Record.PipelineRecord
+  PROPERTY public System.Threading.Tasks.Task Completion { get; }
+  METHOD public virtual System.Threading.Tasks.Dataflow.ITargetBlock<Pipelinez.Core.Record.PipelineContainer<T>> AsTargetBlock()
+  METHOD public virtual void ConfigureExecutionOptions(Pipelinez.Core.Performance.PipelineExecutionOptions options)
+  METHOD public virtual void ConfigureRetryPolicy(Pipelinez.Core.Retry.PipelineRetryPolicy<T> retryPolicy)
+  METHOD public virtual Pipelinez.Core.Performance.PipelineExecutionOptions GetExecutionOptions()
+  METHOD public virtual Pipelinez.Core.Retry.PipelineRetryPolicy<T> GetRetryPolicy()
+  METHOD public virtual void Initialize(Pipelinez.Core.Pipeline<T> parentPipeline)
+  METHOD public virtual System.Threading.Tasks.Task StartAsync(System.Threading.CancellationTokenSource cancellationToken)
+
+public static class Pipelinez.Core.Distributed.DistributedMetadataKeys
+  FIELD public static const string LeaseId = "pipelinez.distribution.lease.id"
+  FIELD public static const string Offset = "pipelinez.distribution.offset"
+  FIELD public static const string PartitionId = "pipelinez.distribution.partition.id"
+  FIELD public static const string PartitionKey = "pipelinez.distribution.partition.key"
+  FIELD public static const string TransportName = "pipelinez.distribution.transport.name"
+
+public class Pipelinez.Core.Distributed.PipelineDistributedStatus
+  CTOR public Pipelinez.Core.Distributed.PipelineDistributedStatus(Pipelinez.Core.Distributed.PipelineExecutionMode executionMode, string instanceId, string workerId, System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionLease> ownedPartitions = null, System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionExecutionState> partitionExecution = null)
+  PROPERTY public Pipelinez.Core.Distributed.PipelineExecutionMode ExecutionMode { get; }
+  PROPERTY public string InstanceId { get; }
+  PROPERTY public System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionLease> OwnedPartitions { get; }
+  PROPERTY public System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionExecutionState> PartitionExecution { get; }
+  PROPERTY public string WorkerId { get; }
+
+public enum Pipelinez.Core.Distributed.PipelineExecutionMode
+  FIELD public static const Pipelinez.Core.Distributed.PipelineExecutionMode Distributed = Pipelinez.Core.Distributed.PipelineExecutionMode.1
+  FIELD public static const Pipelinez.Core.Distributed.PipelineExecutionMode SingleProcess = Pipelinez.Core.Distributed.PipelineExecutionMode.0
+
+public class Pipelinez.Core.Distributed.PipelineHostOptions
+  CTOR public Pipelinez.Core.Distributed.PipelineHostOptions()
+  PROPERTY public Pipelinez.Core.Distributed.PipelineExecutionMode ExecutionMode { get; init; }
+  PROPERTY public string InstanceId { get; init; }
+  PROPERTY public bool RequireTransportOwnership { get; init; }
+  PROPERTY public string WorkerId { get; init; }
+
+public class Pipelinez.Core.Distributed.PipelinePartitionExecutionState
+  CTOR public Pipelinez.Core.Distributed.PipelinePartitionExecutionState(string leaseId, string partitionKey, System.Nullable<int> partitionId, bool isAssigned, bool isDraining, int inFlightCount, System.Nullable<long> highestCompletedOffset)
+  PROPERTY public System.Nullable<long> HighestCompletedOffset { get; }
+  PROPERTY public int InFlightCount { get; }
+  PROPERTY public bool IsAssigned { get; }
+  PROPERTY public bool IsDraining { get; }
+  PROPERTY public string LeaseId { get; }
+  PROPERTY public System.Nullable<int> PartitionId { get; }
+  PROPERTY public string PartitionKey { get; }
+
+public class Pipelinez.Core.Distributed.PipelinePartitionLease
+  CTOR public Pipelinez.Core.Distributed.PipelinePartitionLease(string leaseId, string transportName, string partitionKey, string instanceId, string workerId, System.Nullable<int> partitionId = null)
+  PROPERTY public string InstanceId { get; }
+  PROPERTY public string LeaseId { get; }
+  PROPERTY public System.Nullable<int> PartitionId { get; }
+  PROPERTY public string PartitionKey { get; }
+  PROPERTY public string TransportName { get; }
+  PROPERTY public string WorkerId { get; }
+
+public class Pipelinez.Core.Distributed.PipelineRecordDistributionContext
+  CTOR public Pipelinez.Core.Distributed.PipelineRecordDistributionContext(string instanceId, string workerId, string transportName, string leaseId, string partitionKey, System.Nullable<int> partitionId, System.Nullable<long> offset)
+  PROPERTY public string InstanceId { get; }
+  PROPERTY public string LeaseId { get; }
+  PROPERTY public System.Nullable<long> Offset { get; }
+  PROPERTY public System.Nullable<int> PartitionId { get; }
+  PROPERTY public string PartitionKey { get; }
+  PROPERTY public string TransportName { get; }
+  PROPERTY public string WorkerId { get; }
+
+public class Pipelinez.Core.Distributed.PipelineRuntimeContext
+  CTOR public Pipelinez.Core.Distributed.PipelineRuntimeContext(string pipelineName, Pipelinez.Core.Distributed.PipelineExecutionMode executionMode, string instanceId, string workerId, System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionLease> ownedPartitions = null, System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionExecutionState> partitionExecution = null)
+  PROPERTY public Pipelinez.Core.Distributed.PipelineExecutionMode ExecutionMode { get; }
+  PROPERTY public string InstanceId { get; }
+  PROPERTY public System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionLease> OwnedPartitions { get; }
+  PROPERTY public System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionExecutionState> PartitionExecution { get; }
+  PROPERTY public string PipelineName { get; }
+  PROPERTY public string WorkerId { get; }
+
+public enum Pipelinez.Core.ErrorHandling.PipelineErrorAction
+  FIELD public static const Pipelinez.Core.ErrorHandling.PipelineErrorAction DeadLetter = Pipelinez.Core.ErrorHandling.PipelineErrorAction.3
+  FIELD public static const Pipelinez.Core.ErrorHandling.PipelineErrorAction Rethrow = Pipelinez.Core.ErrorHandling.PipelineErrorAction.2
+  FIELD public static const Pipelinez.Core.ErrorHandling.PipelineErrorAction SkipRecord = Pipelinez.Core.ErrorHandling.PipelineErrorAction.1
+  FIELD public static const Pipelinez.Core.ErrorHandling.PipelineErrorAction StopPipeline = Pipelinez.Core.ErrorHandling.PipelineErrorAction.0
+
+public class Pipelinez.Core.ErrorHandling.PipelineErrorContext<T> where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.ErrorHandling.PipelineErrorContext<T>(System.Exception exception, Pipelinez.Core.Record.PipelineContainer<T> container, Pipelinez.Core.FaultHandling.PipelineFaultState fault, System.Threading.CancellationToken cancellationToken)
+  PROPERTY public System.Threading.CancellationToken CancellationToken { get; }
+  PROPERTY public Pipelinez.Core.FaultHandling.PipelineComponentKind ComponentKind { get; }
+  PROPERTY public string ComponentName { get; }
+  PROPERTY public Pipelinez.Core.Record.PipelineContainer<T> Container { get; }
+  PROPERTY public System.Exception Exception { get; }
+  PROPERTY public Pipelinez.Core.FaultHandling.PipelineFaultState Fault { get; }
+  PROPERTY public T Record { get; }
+  PROPERTY public int RetryAttemptCount { get; }
+  PROPERTY public bool RetryExhausted { get; }
+  PROPERTY public System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Retry.PipelineRetryAttempt> RetryHistory { get; }
+
+public delegate Pipelinez.Core.ErrorHandling.PipelineErrorHandler<T>(Pipelinez.Core.ErrorHandling.PipelineErrorContext<T> context) : System.Threading.Tasks.Task<Pipelinez.Core.ErrorHandling.PipelineErrorAction> where T : Pipelinez.Core.Record.PipelineRecord
+
+public class Pipelinez.Core.Eventing.PipelineContainerCompletedEventHandlerArgs<T>
+  CTOR public Pipelinez.Core.Eventing.PipelineContainerCompletedEventHandlerArgs<T>(T container)
+  PROPERTY public T Container { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelineContainerCompletedEventHandler<T>(object sender, Pipelinez.Core.Eventing.PipelineContainerCompletedEventHandlerArgs<T> args) : void
+
+public class Pipelinez.Core.Eventing.PipelineDeadLetterWriteFailedEventArgs<T> where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.Eventing.PipelineDeadLetterWriteFailedEventArgs<T>(T record, Pipelinez.Core.DeadLettering.PipelineDeadLetterRecord<T> deadLetterRecord, System.Exception exception, Pipelinez.Core.Operational.PipelineRecordDiagnosticContext diagnostic = null)
+  PROPERTY public Pipelinez.Core.DeadLettering.PipelineDeadLetterRecord<T> DeadLetterRecord { get; }
+  PROPERTY public Pipelinez.Core.Operational.PipelineRecordDiagnosticContext Diagnostic { get; }
+  PROPERTY public System.Exception Exception { get; }
+  PROPERTY public T Record { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelineDeadLetterWriteFailedEventHandler<T>(object sender, Pipelinez.Core.Eventing.PipelineDeadLetterWriteFailedEventArgs<T> args) : void where T : Pipelinez.Core.Record.PipelineRecord
+
+public class Pipelinez.Core.Eventing.PipelineFaultedEventArgs
+  CTOR public Pipelinez.Core.Eventing.PipelineFaultedEventArgs(string pipelineName, Pipelinez.Core.FaultHandling.PipelineFaultState fault)
+  PROPERTY public Pipelinez.Core.FaultHandling.PipelineComponentKind ComponentKind { get; }
+  PROPERTY public string ComponentName { get; }
+  PROPERTY public System.Exception Exception { get; }
+  PROPERTY public Pipelinez.Core.FaultHandling.PipelineFaultState Fault { get; }
+  PROPERTY public string PipelineName { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelineFaultedEventHandler(object sender, Pipelinez.Core.Eventing.PipelineFaultedEventArgs args) : void
+
+public class Pipelinez.Core.Eventing.PipelinePartitionDrainedEventArgs
+  CTOR public Pipelinez.Core.Eventing.PipelinePartitionDrainedEventArgs(Pipelinez.Core.Distributed.PipelineRuntimeContext runtimeContext, Pipelinez.Core.Distributed.PipelinePartitionLease partition)
+  PROPERTY public Pipelinez.Core.Distributed.PipelinePartitionLease Partition { get; }
+  PROPERTY public Pipelinez.Core.Distributed.PipelineRuntimeContext RuntimeContext { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelinePartitionDrainedEventHandler(object sender, Pipelinez.Core.Eventing.PipelinePartitionDrainedEventArgs args) : void
+
+public class Pipelinez.Core.Eventing.PipelinePartitionDrainingEventArgs
+  CTOR public Pipelinez.Core.Eventing.PipelinePartitionDrainingEventArgs(Pipelinez.Core.Distributed.PipelineRuntimeContext runtimeContext, Pipelinez.Core.Distributed.PipelinePartitionLease partition)
+  PROPERTY public Pipelinez.Core.Distributed.PipelinePartitionLease Partition { get; }
+  PROPERTY public Pipelinez.Core.Distributed.PipelineRuntimeContext RuntimeContext { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelinePartitionDrainingEventHandler(object sender, Pipelinez.Core.Eventing.PipelinePartitionDrainingEventArgs args) : void
+
+public class Pipelinez.Core.Eventing.PipelinePartitionExecutionStateChangedEventArgs
+  CTOR public Pipelinez.Core.Eventing.PipelinePartitionExecutionStateChangedEventArgs(Pipelinez.Core.Distributed.PipelineRuntimeContext runtimeContext, Pipelinez.Core.Distributed.PipelinePartitionExecutionState state)
+  PROPERTY public Pipelinez.Core.Distributed.PipelineRuntimeContext RuntimeContext { get; }
+  PROPERTY public Pipelinez.Core.Distributed.PipelinePartitionExecutionState State { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelinePartitionExecutionStateChangedEventHandler(object sender, Pipelinez.Core.Eventing.PipelinePartitionExecutionStateChangedEventArgs args) : void
+
+public class Pipelinez.Core.Eventing.PipelinePartitionsAssignedEventArgs
+  CTOR public Pipelinez.Core.Eventing.PipelinePartitionsAssignedEventArgs(Pipelinez.Core.Distributed.PipelineRuntimeContext runtimeContext, System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionLease> partitions)
+  PROPERTY public System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionLease> Partitions { get; }
+  PROPERTY public Pipelinez.Core.Distributed.PipelineRuntimeContext RuntimeContext { get; }
+  PROPERTY public string WorkerId { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelinePartitionsAssignedEventHandler(object sender, Pipelinez.Core.Eventing.PipelinePartitionsAssignedEventArgs args) : void
+
+public class Pipelinez.Core.Eventing.PipelinePartitionsRevokedEventArgs
+  CTOR public Pipelinez.Core.Eventing.PipelinePartitionsRevokedEventArgs(Pipelinez.Core.Distributed.PipelineRuntimeContext runtimeContext, System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionLease> partitions)
+  PROPERTY public System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionLease> Partitions { get; }
+  PROPERTY public Pipelinez.Core.Distributed.PipelineRuntimeContext RuntimeContext { get; }
+  PROPERTY public string WorkerId { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelinePartitionsRevokedEventHandler(object sender, Pipelinez.Core.Eventing.PipelinePartitionsRevokedEventArgs args) : void
+
+public class Pipelinez.Core.Eventing.PipelinePublishRejectedEventArgs<T> where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.Eventing.PipelinePublishRejectedEventArgs<T>(T record, Pipelinez.Core.FlowControl.PipelinePublishResultReason reason, System.DateTimeOffset observedAtUtc, Pipelinez.Core.Operational.PipelineRecordDiagnosticContext diagnostic = null)
+  PROPERTY public Pipelinez.Core.Operational.PipelineRecordDiagnosticContext Diagnostic { get; }
+  PROPERTY public System.DateTimeOffset ObservedAtUtc { get; }
+  PROPERTY public Pipelinez.Core.FlowControl.PipelinePublishResultReason Reason { get; }
+  PROPERTY public T Record { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelinePublishRejectedEventHandler<T>(object sender, Pipelinez.Core.Eventing.PipelinePublishRejectedEventArgs<T> args) : void where T : Pipelinez.Core.Record.PipelineRecord
+
+public class Pipelinez.Core.Eventing.PipelineRecordCompletedEventHandlerArgs<T>
+  CTOR public Pipelinez.Core.Eventing.PipelineRecordCompletedEventHandlerArgs<T>(T record, Pipelinez.Core.Distributed.PipelineRecordDistributionContext distribution = null, Pipelinez.Core.Operational.PipelineRecordDiagnosticContext diagnostic = null)
+  PROPERTY public Pipelinez.Core.Operational.PipelineRecordDiagnosticContext Diagnostic { get; }
+  PROPERTY public Pipelinez.Core.Distributed.PipelineRecordDistributionContext Distribution { get; }
+  PROPERTY public T Record { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelineRecordCompletedEventHandler<T>(object sender, Pipelinez.Core.Eventing.PipelineRecordCompletedEventHandlerArgs<T> args) : void
+
+public class Pipelinez.Core.Eventing.PipelineRecordDeadLetteredEventArgs<T> where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.Eventing.PipelineRecordDeadLetteredEventArgs<T>(T record, Pipelinez.Core.DeadLettering.PipelineDeadLetterRecord<T> deadLetterRecord, Pipelinez.Core.Operational.PipelineRecordDiagnosticContext diagnostic = null)
+  PROPERTY public Pipelinez.Core.DeadLettering.PipelineDeadLetterRecord<T> DeadLetterRecord { get; }
+  PROPERTY public Pipelinez.Core.Operational.PipelineRecordDiagnosticContext Diagnostic { get; }
+  PROPERTY public T Record { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelineRecordDeadLetteredEventHandler<T>(object sender, Pipelinez.Core.Eventing.PipelineRecordDeadLetteredEventArgs<T> args) : void where T : Pipelinez.Core.Record.PipelineRecord
+
+public class Pipelinez.Core.Eventing.PipelineRecordFaultedEventArgs<T> where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.Eventing.PipelineRecordFaultedEventArgs<T>(T record, Pipelinez.Core.Record.PipelineContainer<T> container, Pipelinez.Core.FaultHandling.PipelineFaultState fault, Pipelinez.Core.Distributed.PipelineRecordDistributionContext distribution = null, Pipelinez.Core.Operational.PipelineRecordDiagnosticContext diagnostic = null)
+  PROPERTY public Pipelinez.Core.Record.PipelineContainer<T> Container { get; }
+  PROPERTY public Pipelinez.Core.Operational.PipelineRecordDiagnosticContext Diagnostic { get; }
+  PROPERTY public Pipelinez.Core.Distributed.PipelineRecordDistributionContext Distribution { get; }
+  PROPERTY public Pipelinez.Core.FaultHandling.PipelineFaultState Fault { get; }
+  PROPERTY public T Record { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelineRecordFaultedEventHandler<T>(object sender, Pipelinez.Core.Eventing.PipelineRecordFaultedEventArgs<T> args) : void where T : Pipelinez.Core.Record.PipelineRecord
+
+public class Pipelinez.Core.Eventing.PipelineRecordRetryingEventArgs<T> where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.Eventing.PipelineRecordRetryingEventArgs<T>(T record, Pipelinez.Core.Record.PipelineContainer<T> container, Pipelinez.Core.FaultHandling.PipelineFaultState fault, int attemptNumber, int maxAttempts, System.TimeSpan delay, Pipelinez.Core.Distributed.PipelineRecordDistributionContext distribution = null, Pipelinez.Core.Operational.PipelineRecordDiagnosticContext diagnostic = null)
+  PROPERTY public int AttemptNumber { get; }
+  PROPERTY public Pipelinez.Core.FaultHandling.PipelineComponentKind ComponentKind { get; }
+  PROPERTY public string ComponentName { get; }
+  PROPERTY public Pipelinez.Core.Record.PipelineContainer<T> Container { get; }
+  PROPERTY public System.TimeSpan Delay { get; }
+  PROPERTY public Pipelinez.Core.Operational.PipelineRecordDiagnosticContext Diagnostic { get; }
+  PROPERTY public Pipelinez.Core.Distributed.PipelineRecordDistributionContext Distribution { get; }
+  PROPERTY public System.Exception Exception { get; }
+  PROPERTY public Pipelinez.Core.FaultHandling.PipelineFaultState Fault { get; }
+  PROPERTY public int MaxAttempts { get; }
+  PROPERTY public T Record { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelineRecordRetryingEventHandler<T>(object sender, Pipelinez.Core.Eventing.PipelineRecordRetryingEventArgs<T> args) : void where T : Pipelinez.Core.Record.PipelineRecord
+
+public class Pipelinez.Core.Eventing.PipelineSaturationChangedEventArgs
+  CTOR public Pipelinez.Core.Eventing.PipelineSaturationChangedEventArgs(double saturationRatio, bool isSaturated, System.DateTimeOffset observedAtUtc)
+  PROPERTY public bool IsSaturated { get; }
+  PROPERTY public System.DateTimeOffset ObservedAtUtc { get; }
+  PROPERTY public double SaturationRatio { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelineSaturationChangedEventHandler(object sender, Pipelinez.Core.Eventing.PipelineSaturationChangedEventArgs args) : void
+
+public class Pipelinez.Core.Eventing.PipelineWorkerStartedEventArgs
+  CTOR public Pipelinez.Core.Eventing.PipelineWorkerStartedEventArgs(Pipelinez.Core.Distributed.PipelineRuntimeContext runtimeContext)
+  PROPERTY public Pipelinez.Core.Distributed.PipelineRuntimeContext RuntimeContext { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelineWorkerStartedEventHandler(object sender, Pipelinez.Core.Eventing.PipelineWorkerStartedEventArgs args) : void
+
+public class Pipelinez.Core.Eventing.PipelineWorkerStoppingEventArgs
+  CTOR public Pipelinez.Core.Eventing.PipelineWorkerStoppingEventArgs(Pipelinez.Core.Distributed.PipelineRuntimeContext runtimeContext)
+  PROPERTY public Pipelinez.Core.Distributed.PipelineRuntimeContext RuntimeContext { get; }
+
+public delegate Pipelinez.Core.Eventing.PipelineWorkerStoppingEventHandler(object sender, Pipelinez.Core.Eventing.PipelineWorkerStoppingEventArgs args) : void
+
+public enum Pipelinez.Core.FaultHandling.PipelineComponentKind
+  FIELD public static const Pipelinez.Core.FaultHandling.PipelineComponentKind Destination = Pipelinez.Core.FaultHandling.PipelineComponentKind.2
+  FIELD public static const Pipelinez.Core.FaultHandling.PipelineComponentKind Pipeline = Pipelinez.Core.FaultHandling.PipelineComponentKind.3
+  FIELD public static const Pipelinez.Core.FaultHandling.PipelineComponentKind Segment = Pipelinez.Core.FaultHandling.PipelineComponentKind.1
+  FIELD public static const Pipelinez.Core.FaultHandling.PipelineComponentKind Source = Pipelinez.Core.FaultHandling.PipelineComponentKind.0
+
+public class Pipelinez.Core.FaultHandling.PipelineFaultState
+  CTOR public Pipelinez.Core.FaultHandling.PipelineFaultState(System.Exception exception, string componentName, Pipelinez.Core.FaultHandling.PipelineComponentKind componentKind, System.DateTimeOffset occurredAtUtc, string message = null)
+  PROPERTY public Pipelinez.Core.FaultHandling.PipelineComponentKind ComponentKind { get; }
+  PROPERTY public string ComponentName { get; }
+  PROPERTY public System.Exception Exception { get; }
+  PROPERTY public string Message { get; }
+  PROPERTY public System.DateTimeOffset OccurredAtUtc { get; }
+
+public class Pipelinez.Core.FaultHandling.PipelineSegmentExecution
+  CTOR public Pipelinez.Core.FaultHandling.PipelineSegmentExecution(string segmentName, System.DateTimeOffset startedAtUtc, System.DateTimeOffset completedAtUtc, bool succeeded, string failureMessage = null)
+  PROPERTY public System.DateTimeOffset CompletedAtUtc { get; }
+  PROPERTY public System.TimeSpan Duration { get; }
+  PROPERTY public string FailureMessage { get; }
+  PROPERTY public string SegmentName { get; }
+  PROPERTY public System.DateTimeOffset StartedAtUtc { get; }
+  PROPERTY public bool Succeeded { get; }
+
+public interface Pipelinez.Core.Flow.IFlowDestination<TInput>
+  METHOD public abstract System.Threading.Tasks.Dataflow.ITargetBlock<TInput> AsTargetBlock()
+
+public interface Pipelinez.Core.Flow.IFlowSource<TOutput>
+  METHOD public abstract System.IDisposable ConnectTo(Pipelinez.Core.Flow.IFlowDestination<TOutput> target, System.Threading.Tasks.Dataflow.DataflowLinkOptions options = null)
+
+public class Pipelinez.Core.FlowControl.PipelineComponentFlowStatus
+  CTOR public Pipelinez.Core.FlowControl.PipelineComponentFlowStatus(string name, int approximateQueueDepth, System.Nullable<int> boundedCapacity)
+  PROPERTY public int ApproximateQueueDepth { get; }
+  PROPERTY public System.Nullable<int> BoundedCapacity { get; }
+  PROPERTY public bool IsSaturated { get; }
+  PROPERTY public string Name { get; }
+  PROPERTY public double SaturationRatio { get; }
+
+public class Pipelinez.Core.FlowControl.PipelineFlowControlOptions
+  CTOR public Pipelinez.Core.FlowControl.PipelineFlowControlOptions()
+  PROPERTY public bool EmitSaturationEvents { get; init; }
+  PROPERTY public Pipelinez.Core.FlowControl.PipelineOverflowPolicy OverflowPolicy { get; init; }
+  PROPERTY public System.Nullable<System.TimeSpan> PublishTimeout { get; init; }
+  PROPERTY public double SaturationWarningThreshold { get; init; }
+  METHOD public Pipelinez.Core.FlowControl.PipelineFlowControlOptions Validate()
+
+public class Pipelinez.Core.FlowControl.PipelineFlowControlStatus
+  CTOR public Pipelinez.Core.FlowControl.PipelineFlowControlStatus(Pipelinez.Core.FlowControl.PipelineOverflowPolicy overflowPolicy, bool isSaturated, double saturationRatio, int totalBufferedCount, System.Nullable<int> totalCapacity, System.Collections.Generic.IReadOnlyList<Pipelinez.Core.FlowControl.PipelineComponentFlowStatus> components)
+  PROPERTY public System.Collections.Generic.IReadOnlyList<Pipelinez.Core.FlowControl.PipelineComponentFlowStatus> Components { get; }
+  PROPERTY public bool IsSaturated { get; }
+  PROPERTY public Pipelinez.Core.FlowControl.PipelineOverflowPolicy OverflowPolicy { get; }
+  PROPERTY public double SaturationRatio { get; }
+  PROPERTY public int TotalBufferedCount { get; }
+  PROPERTY public System.Nullable<int> TotalCapacity { get; }
+
+public enum Pipelinez.Core.FlowControl.PipelineOverflowPolicy
+  FIELD public static const Pipelinez.Core.FlowControl.PipelineOverflowPolicy Cancel = Pipelinez.Core.FlowControl.PipelineOverflowPolicy.2
+  FIELD public static const Pipelinez.Core.FlowControl.PipelineOverflowPolicy Reject = Pipelinez.Core.FlowControl.PipelineOverflowPolicy.1
+  FIELD public static const Pipelinez.Core.FlowControl.PipelineOverflowPolicy Wait = Pipelinez.Core.FlowControl.PipelineOverflowPolicy.0
+
+public class Pipelinez.Core.FlowControl.PipelinePublishOptions
+  CTOR public Pipelinez.Core.FlowControl.PipelinePublishOptions()
+  PROPERTY public System.Threading.CancellationToken CancellationToken { get; init; }
+  PROPERTY public System.Nullable<Pipelinez.Core.FlowControl.PipelineOverflowPolicy> OverflowPolicyOverride { get; init; }
+  PROPERTY public System.Nullable<System.TimeSpan> Timeout { get; init; }
+  METHOD public Pipelinez.Core.FlowControl.PipelinePublishOptions Validate()
+
+public class Pipelinez.Core.FlowControl.PipelinePublishResult
+  PROPERTY public bool Accepted { get; }
+  PROPERTY public Pipelinez.Core.FlowControl.PipelinePublishResultReason Reason { get; }
+  PROPERTY public System.TimeSpan WaitDuration { get; }
+  METHOD public static Pipelinez.Core.FlowControl.PipelinePublishResult AcceptedResult(System.TimeSpan waitDuration)
+  METHOD public static Pipelinez.Core.FlowControl.PipelinePublishResult Rejected(Pipelinez.Core.FlowControl.PipelinePublishResultReason reason, System.TimeSpan waitDuration)
+  METHOD public void ThrowIfNotAccepted()
+
+public enum Pipelinez.Core.FlowControl.PipelinePublishResultReason
+  FIELD public static const Pipelinez.Core.FlowControl.PipelinePublishResultReason Accepted = Pipelinez.Core.FlowControl.PipelinePublishResultReason.0
+  FIELD public static const Pipelinez.Core.FlowControl.PipelinePublishResultReason Canceled = Pipelinez.Core.FlowControl.PipelinePublishResultReason.3
+  FIELD public static const Pipelinez.Core.FlowControl.PipelinePublishResultReason RejectedByOverflowPolicy = Pipelinez.Core.FlowControl.PipelinePublishResultReason.1
+  FIELD public static const Pipelinez.Core.FlowControl.PipelinePublishResultReason TimedOut = Pipelinez.Core.FlowControl.PipelinePublishResultReason.2
+
+public interface Pipelinez.Core.IPipeline<T> where T : Pipelinez.Core.Record.PipelineRecord
+  PROPERTY public System.Threading.Tasks.Task Completion { get; }
+  EVENT public event Pipelinez.Core.Eventing.PipelinePartitionDrainedEventHandler OnPartitionDrained
+  EVENT public event Pipelinez.Core.Eventing.PipelinePartitionDrainingEventHandler OnPartitionDraining
+  EVENT public event Pipelinez.Core.Eventing.PipelinePartitionExecutionStateChangedEventHandler OnPartitionExecutionStateChanged
+  EVENT public event Pipelinez.Core.Eventing.PipelinePartitionsAssignedEventHandler OnPartitionsAssigned
+  EVENT public event Pipelinez.Core.Eventing.PipelinePartitionsRevokedEventHandler OnPartitionsRevoked
+  EVENT public event Pipelinez.Core.Eventing.PipelineDeadLetterWriteFailedEventHandler<T> OnPipelineDeadLetterWriteFailed
+  EVENT public event Pipelinez.Core.Eventing.PipelineFaultedEventHandler OnPipelineFaulted
+  EVENT public event Pipelinez.Core.Eventing.PipelineRecordCompletedEventHandler<T> OnPipelineRecordCompleted
+  EVENT public event Pipelinez.Core.Eventing.PipelineRecordDeadLetteredEventHandler<T> OnPipelineRecordDeadLettered
+  EVENT public event Pipelinez.Core.Eventing.PipelineRecordFaultedEventHandler<T> OnPipelineRecordFaulted
+  EVENT public event Pipelinez.Core.Eventing.PipelineRecordRetryingEventHandler<T> OnPipelineRecordRetrying
+  EVENT public event Pipelinez.Core.Eventing.PipelinePublishRejectedEventHandler<T> OnPublishRejected
+  EVENT public event Pipelinez.Core.Eventing.PipelineSaturationChangedEventHandler OnSaturationChanged
+  EVENT public event Pipelinez.Core.Eventing.PipelineWorkerStartedEventHandler OnWorkerStarted
+  EVENT public event Pipelinez.Core.Eventing.PipelineWorkerStoppingEventHandler OnWorkerStopping
+  METHOD public abstract System.Threading.Tasks.Task CompleteAsync()
+  METHOD public abstract Pipelinez.Core.Operational.PipelineHealthStatus GetHealthStatus()
+  METHOD public abstract Pipelinez.Core.Operational.PipelineOperationalSnapshot GetOperationalSnapshot()
+  METHOD public abstract Pipelinez.Core.Performance.PipelinePerformanceSnapshot GetPerformanceSnapshot()
+  METHOD public abstract Pipelinez.Core.Distributed.PipelineRuntimeContext GetRuntimeContext()
+  METHOD public abstract Pipelinez.Core.Status.PipelineStatus GetStatus()
+  METHOD public abstract System.Threading.Tasks.Task PublishAsync(T record)
+  METHOD public abstract System.Threading.Tasks.Task<Pipelinez.Core.FlowControl.PipelinePublishResult> PublishAsync(T record, Pipelinez.Core.FlowControl.PipelinePublishOptions options)
+  METHOD public abstract System.Threading.Tasks.Task StartPipelineAsync(System.Threading.CancellationToken cancellationToken = null)
+
+public class Pipelinez.Core.Operational.PipelineHealthCheck<T> : Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.Operational.PipelineHealthCheck<T>(Pipelinez.Core.IPipeline<T> pipeline, bool includeComponentDiagnostics = true)
+  METHOD public virtual System.Threading.Tasks.Task<Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> CheckHealthAsync(Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckContext context, System.Threading.CancellationToken cancellationToken = null)
+
+public enum Pipelinez.Core.Operational.PipelineHealthState
+  FIELD public static const Pipelinez.Core.Operational.PipelineHealthState Completed = Pipelinez.Core.Operational.PipelineHealthState.4
+  FIELD public static const Pipelinez.Core.Operational.PipelineHealthState Degraded = Pipelinez.Core.Operational.PipelineHealthState.2
+  FIELD public static const Pipelinez.Core.Operational.PipelineHealthState Healthy = Pipelinez.Core.Operational.PipelineHealthState.1
+  FIELD public static const Pipelinez.Core.Operational.PipelineHealthState Starting = Pipelinez.Core.Operational.PipelineHealthState.0
+  FIELD public static const Pipelinez.Core.Operational.PipelineHealthState Unhealthy = Pipelinez.Core.Operational.PipelineHealthState.3
+
+public class Pipelinez.Core.Operational.PipelineHealthStatus
+  CTOR public Pipelinez.Core.Operational.PipelineHealthStatus(string pipelineName, Pipelinez.Core.Operational.PipelineHealthState state, System.Collections.Generic.IReadOnlyList<string> reasons, System.DateTimeOffset observedAtUtc, Pipelinez.Core.Status.PipelineStatus runtimeStatus, Pipelinez.Core.Performance.PipelinePerformanceSnapshot performance, Pipelinez.Core.FaultHandling.PipelineFaultState lastPipelineFault = null)
+  PROPERTY public Pipelinez.Core.FaultHandling.PipelineFaultState LastPipelineFault { get; }
+  PROPERTY public System.DateTimeOffset ObservedAtUtc { get; }
+  PROPERTY public Pipelinez.Core.Performance.PipelinePerformanceSnapshot Performance { get; }
+  PROPERTY public string PipelineName { get; }
+  PROPERTY public string Reason { get; }
+  PROPERTY public System.Collections.Generic.IReadOnlyList<string> Reasons { get; }
+  PROPERTY public Pipelinez.Core.Status.PipelineStatus RuntimeStatus { get; }
+  PROPERTY public Pipelinez.Core.Operational.PipelineHealthState State { get; }
+
+public static class Pipelinez.Core.Operational.PipelineOperationalMetadataKeys
+  FIELD public static const string CorrelationId = "pipelinez.correlation.id"
+
+public class Pipelinez.Core.Operational.PipelineOperationalOptions
+  CTOR public Pipelinez.Core.Operational.PipelineOperationalOptions()
+  PROPERTY public long DeadLetterDegradedThreshold { get; init; }
+  PROPERTY public int DrainingPartitionDegradedThreshold { get; init; }
+  PROPERTY public bool EnableCorrelationIds { get; init; }
+  PROPERTY public bool EnableHealthChecks { get; init; }
+  PROPERTY public bool EnableMetrics { get; init; }
+  PROPERTY public bool IncludeComponentDiagnosticsInHealthResults { get; init; }
+  PROPERTY public long PublishRejectionDegradedThreshold { get; init; }
+  PROPERTY public long RetryExhaustionDegradedThreshold { get; init; }
+  PROPERTY public double SaturationDegradedThreshold { get; init; }
+  METHOD public Pipelinez.Core.Operational.PipelineOperationalOptions Validate()
+
+public class Pipelinez.Core.Operational.PipelineOperationalSnapshot
+  CTOR public Pipelinez.Core.Operational.PipelineOperationalSnapshot(Pipelinez.Core.Status.PipelineStatus status, Pipelinez.Core.Performance.PipelinePerformanceSnapshot performance, Pipelinez.Core.Operational.PipelineHealthStatus health, System.DateTimeOffset observedAtUtc, Pipelinez.Core.FaultHandling.PipelineFaultState lastPipelineFault = null, System.Nullable<System.DateTimeOffset> lastRecordCompletedAtUtc = null, System.Nullable<System.DateTimeOffset> lastDeadLetteredAtUtc = null)
+  PROPERTY public Pipelinez.Core.Operational.PipelineHealthStatus Health { get; }
+  PROPERTY public System.Nullable<System.DateTimeOffset> LastDeadLetteredAtUtc { get; }
+  PROPERTY public Pipelinez.Core.FaultHandling.PipelineFaultState LastPipelineFault { get; }
+  PROPERTY public System.Nullable<System.DateTimeOffset> LastRecordCompletedAtUtc { get; }
+  PROPERTY public System.DateTimeOffset ObservedAtUtc { get; }
+  PROPERTY public Pipelinez.Core.Performance.PipelinePerformanceSnapshot Performance { get; }
+  PROPERTY public Pipelinez.Core.Status.PipelineStatus Status { get; }
+
+public class Pipelinez.Core.Operational.PipelineRecordDiagnosticContext
+  CTOR public Pipelinez.Core.Operational.PipelineRecordDiagnosticContext(string correlationId, string pipelineName, string instanceId, string workerId, string componentName = null)
+  PROPERTY public string ComponentName { get; }
+  PROPERTY public string CorrelationId { get; }
+  PROPERTY public string InstanceId { get; }
+  PROPERTY public string PipelineName { get; }
+  PROPERTY public string WorkerId { get; }
+
+public interface Pipelinez.Core.Performance.IPipelineExecutionConfigurable
+  METHOD public abstract void ConfigureExecutionOptions(Pipelinez.Core.Performance.PipelineExecutionOptions options)
+  METHOD public abstract Pipelinez.Core.Performance.PipelineExecutionOptions GetExecutionOptions()
+
+public class Pipelinez.Core.Performance.PipelineBatchingOptions
+  CTOR public Pipelinez.Core.Performance.PipelineBatchingOptions()
+  PROPERTY public int BatchSize { get; init; }
+  PROPERTY public System.TimeSpan MaxBatchDelay { get; init; }
+  METHOD public Pipelinez.Core.Performance.PipelineBatchingOptions Validate()
+
+public class Pipelinez.Core.Performance.PipelineComponentPerformanceSnapshot
+  CTOR public Pipelinez.Core.Performance.PipelineComponentPerformanceSnapshot(string componentName, long processedCount, long faultedCount, double recordsPerSecond, System.TimeSpan averageExecutionLatency, System.Nullable<int> queueDepth = null)
+  PROPERTY public System.TimeSpan AverageExecutionLatency { get; }
+  PROPERTY public string ComponentName { get; }
+  PROPERTY public long FaultedCount { get; }
+  PROPERTY public long ProcessedCount { get; }
+  PROPERTY public System.Nullable<int> QueueDepth { get; }
+  PROPERTY public double RecordsPerSecond { get; }
+
+public class Pipelinez.Core.Performance.PipelineExecutionOptions
+  CTOR public Pipelinez.Core.Performance.PipelineExecutionOptions()
+  PROPERTY public int BoundedCapacity { get; init; }
+  PROPERTY public int DegreeOfParallelism { get; init; }
+  PROPERTY public bool EnsureOrdered { get; init; }
+  METHOD public static Pipelinez.Core.Performance.PipelineExecutionOptions CreateDefaultDestinationOptions()
+  METHOD public static Pipelinez.Core.Performance.PipelineExecutionOptions CreateDefaultSegmentOptions()
+  METHOD public static Pipelinez.Core.Performance.PipelineExecutionOptions CreateDefaultSourceOptions()
+  METHOD public bool Matches(Pipelinez.Core.Performance.PipelineExecutionOptions other)
+  METHOD public Pipelinez.Core.Performance.PipelineExecutionOptions Validate()
+
+public class Pipelinez.Core.Performance.PipelineMetricsOptions
+  CTOR public Pipelinez.Core.Performance.PipelineMetricsOptions()
+  PROPERTY public bool EnablePerComponentTiming { get; init; }
+  PROPERTY public bool EnableRuntimeMetrics { get; init; }
+
+public class Pipelinez.Core.Performance.PipelinePerformanceOptions
+  CTOR public Pipelinez.Core.Performance.PipelinePerformanceOptions()
+  PROPERTY public Pipelinez.Core.Performance.PipelineExecutionOptions DefaultSegmentExecution { get; init; }
+  PROPERTY public Pipelinez.Core.Performance.PipelineBatchingOptions DestinationBatching { get; init; }
+  PROPERTY public Pipelinez.Core.Performance.PipelineExecutionOptions DestinationExecution { get; init; }
+  PROPERTY public Pipelinez.Core.Performance.PipelineMetricsOptions Metrics { get; init; }
+  PROPERTY public Pipelinez.Core.Performance.PipelineExecutionOptions SourceExecution { get; init; }
+  METHOD public Pipelinez.Core.Performance.PipelinePerformanceOptions Validate()
+
+public class Pipelinez.Core.Performance.PipelinePerformanceSnapshot
+  CTOR public Pipelinez.Core.Performance.PipelinePerformanceSnapshot(System.DateTimeOffset startedAtUtc, System.TimeSpan elapsed, long totalRecordsPublished, long totalRecordsCompleted, long totalRecordsFaulted, long totalRetryCount, long successfulRetryRecoveries, long retryExhaustions, long totalDeadLetteredCount, long totalDeadLetterFailureCount, long totalPublishWaitCount, System.TimeSpan averagePublishWaitDuration, long totalPublishRejectedCount, int peakBufferedCount, double recordsPerSecond, System.TimeSpan averageEndToEndLatency, System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Performance.PipelineComponentPerformanceSnapshot> components)
+  PROPERTY public System.TimeSpan AverageEndToEndLatency { get; }
+  PROPERTY public System.TimeSpan AveragePublishWaitDuration { get; }
+  PROPERTY public System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Performance.PipelineComponentPerformanceSnapshot> Components { get; }
+  PROPERTY public System.TimeSpan Elapsed { get; }
+  PROPERTY public int PeakBufferedCount { get; }
+  PROPERTY public double RecordsPerSecond { get; }
+  PROPERTY public long RetryExhaustions { get; }
+  PROPERTY public System.DateTimeOffset StartedAtUtc { get; }
+  PROPERTY public long SuccessfulRetryRecoveries { get; }
+  PROPERTY public long TotalDeadLetterFailureCount { get; }
+  PROPERTY public long TotalDeadLetteredCount { get; }
+  PROPERTY public long TotalPublishRejectedCount { get; }
+  PROPERTY public long TotalPublishWaitCount { get; }
+  PROPERTY public long TotalRecordsCompleted { get; }
+  PROPERTY public long TotalRecordsFaulted { get; }
+  PROPERTY public long TotalRecordsPublished { get; }
+  PROPERTY public long TotalRetryCount { get; }
+
+public class Pipelinez.Core.PipelineBuilder<T> where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.PipelineBuilder<T>(string pipelineName)
+  PROPERTY public string PipelineName { get; }
+  METHOD public Pipelinez.Core.PipelineBuilder<T> AddSegment(Pipelinez.Core.Segment.IPipelineSegment<T> segment, object config)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> AddSegment(Pipelinez.Core.Segment.IPipelineSegment<T> segment, object config, Pipelinez.Core.Performance.PipelineExecutionOptions executionOptions)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> AddSegment(Pipelinez.Core.Segment.IPipelineSegment<T> segment, object config, Pipelinez.Core.Performance.PipelineExecutionOptions executionOptions, Pipelinez.Core.Retry.PipelineRetryPolicy<T> retryPolicy)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> AddSegment(Pipelinez.Core.Segment.IPipelineSegment<T> segment, object config, Pipelinez.Core.Retry.PipelineRetryPolicy<T> retryPolicy)
+  METHOD public Pipelinez.Core.IPipeline<T> Build()
+  METHOD public Pipelinez.Core.PipelineBuilder<T> UseDeadLetterOptions(Pipelinez.Core.DeadLettering.PipelineDeadLetterOptions options)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> UseFlowControlOptions(Pipelinez.Core.FlowControl.PipelineFlowControlOptions options)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> UseHostOptions(Pipelinez.Core.Distributed.PipelineHostOptions options)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> UseLogger(Microsoft.Extensions.Logging.ILoggerFactory logFactory)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> UseOperationalOptions(Pipelinez.Core.Operational.PipelineOperationalOptions options)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> UsePerformanceOptions(Pipelinez.Core.Performance.PipelinePerformanceOptions options)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> UseRetryOptions(Pipelinez.Core.Retry.PipelineRetryOptions<T> options)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> WithDeadLetterDestination(Pipelinez.Core.DeadLettering.IPipelineDeadLetterDestination<T> deadLetterDestination)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> WithDestination(Pipelinez.Core.Destination.IPipelineDestination<T> destination)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> WithDestination(Pipelinez.Core.Destination.IPipelineDestination<T> destination, Pipelinez.Core.Performance.PipelineExecutionOptions executionOptions)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> WithDestination(Pipelinez.Core.Destination.IPipelineDestination<T> destination, Pipelinez.Core.Performance.PipelineExecutionOptions executionOptions, Pipelinez.Core.Retry.PipelineRetryPolicy<T> retryPolicy)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> WithDestination(Pipelinez.Core.Destination.IPipelineDestination<T> destination, Pipelinez.Core.Retry.PipelineRetryPolicy<T> retryPolicy)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> WithErrorHandler(Pipelinez.Core.ErrorHandling.PipelineErrorHandler<T> errorHandler)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> WithErrorHandler(System.Func<Pipelinez.Core.ErrorHandling.PipelineErrorContext<T>, Pipelinez.Core.ErrorHandling.PipelineErrorAction> errorHandler)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> WithInMemoryDestination(string config)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> WithInMemorySource(object config)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> WithSource(Pipelinez.Core.Source.IPipelineSource<T> source)
+  METHOD public Pipelinez.Core.PipelineBuilder<T> WithSource(Pipelinez.Core.Source.IPipelineSource<T> source, Pipelinez.Core.Performance.PipelineExecutionOptions executionOptions)
+
+public class Pipelinez.Core.Pipeline<TPipelineRecord> : Pipelinez.Core.IPipeline<TPipelineRecord> where TPipelineRecord : Pipelinez.Core.Record.PipelineRecord
+  PROPERTY public System.Threading.Tasks.Task Completion { get; }
+  EVENT public event Pipelinez.Core.Eventing.PipelinePartitionDrainedEventHandler OnPartitionDrained
+  EVENT public event Pipelinez.Core.Eventing.PipelinePartitionDrainingEventHandler OnPartitionDraining
+  EVENT public event Pipelinez.Core.Eventing.PipelinePartitionExecutionStateChangedEventHandler OnPartitionExecutionStateChanged
+  EVENT public event Pipelinez.Core.Eventing.PipelinePartitionsAssignedEventHandler OnPartitionsAssigned
+  EVENT public event Pipelinez.Core.Eventing.PipelinePartitionsRevokedEventHandler OnPartitionsRevoked
+  EVENT public event Pipelinez.Core.Eventing.PipelineDeadLetterWriteFailedEventHandler<TPipelineRecord> OnPipelineDeadLetterWriteFailed
+  EVENT public event Pipelinez.Core.Eventing.PipelineFaultedEventHandler OnPipelineFaulted
+  EVENT public event Pipelinez.Core.Eventing.PipelineRecordCompletedEventHandler<TPipelineRecord> OnPipelineRecordCompleted
+  EVENT public event Pipelinez.Core.Eventing.PipelineRecordDeadLetteredEventHandler<TPipelineRecord> OnPipelineRecordDeadLettered
+  EVENT public event Pipelinez.Core.Eventing.PipelineRecordFaultedEventHandler<TPipelineRecord> OnPipelineRecordFaulted
+  EVENT public event Pipelinez.Core.Eventing.PipelineRecordRetryingEventHandler<TPipelineRecord> OnPipelineRecordRetrying
+  EVENT public event Pipelinez.Core.Eventing.PipelinePublishRejectedEventHandler<TPipelineRecord> OnPublishRejected
+  EVENT public event Pipelinez.Core.Eventing.PipelineSaturationChangedEventHandler OnSaturationChanged
+  EVENT public event Pipelinez.Core.Eventing.PipelineWorkerStartedEventHandler OnWorkerStarted
+  EVENT public event Pipelinez.Core.Eventing.PipelineWorkerStoppingEventHandler OnWorkerStopping
+  METHOD public virtual System.Threading.Tasks.Task CompleteAsync()
+  METHOD public virtual Pipelinez.Core.Operational.PipelineHealthStatus GetHealthStatus()
+  METHOD public virtual Pipelinez.Core.Operational.PipelineOperationalSnapshot GetOperationalSnapshot()
+  METHOD public virtual Pipelinez.Core.Performance.PipelinePerformanceSnapshot GetPerformanceSnapshot()
+  METHOD public virtual Pipelinez.Core.Distributed.PipelineRuntimeContext GetRuntimeContext()
+  METHOD public virtual Pipelinez.Core.Status.PipelineStatus GetStatus()
+  METHOD public static Pipelinez.Core.PipelineBuilder<TPipelineRecord> New(string pipelineName)
+  METHOD public virtual System.Threading.Tasks.Task PublishAsync(TPipelineRecord record)
+  METHOD public virtual System.Threading.Tasks.Task<Pipelinez.Core.FlowControl.PipelinePublishResult> PublishAsync(TPipelineRecord record, Pipelinez.Core.FlowControl.PipelinePublishOptions options)
+  METHOD public virtual System.Threading.Tasks.Task StartPipelineAsync(System.Threading.CancellationToken cancellationToken = null)
+
+public class Pipelinez.Core.Record.Metadata.MetadataCollection : System.Collections.Generic.ICollection<Pipelinez.Core.Record.Metadata.MetadataRecord>, System.Collections.Generic.IEnumerable<Pipelinez.Core.Record.Metadata.MetadataRecord>, System.Collections.Generic.IList<Pipelinez.Core.Record.Metadata.MetadataRecord>, System.Collections.IEnumerable
+  CTOR public Pipelinez.Core.Record.Metadata.MetadataCollection()
+  PROPERTY public int Count { get; }
+  PROPERTY public bool IsReadOnly { get; }
+  PROPERTY public Pipelinez.Core.Record.Metadata.MetadataRecord this[int index] { get; set; }
+  METHOD public virtual void Add(Pipelinez.Core.Record.Metadata.MetadataRecord item)
+  METHOD public virtual void Clear()
+  METHOD public Pipelinez.Core.Record.Metadata.MetadataCollection Clone()
+  METHOD public virtual bool Contains(Pipelinez.Core.Record.Metadata.MetadataRecord item)
+  METHOD public virtual void CopyTo(Pipelinez.Core.Record.Metadata.MetadataRecord[] array, int arrayIndex)
+  METHOD public Pipelinez.Core.Record.Metadata.MetadataRecord GetByKey(string key)
+  METHOD public virtual System.Collections.Generic.IEnumerator<Pipelinez.Core.Record.Metadata.MetadataRecord> GetEnumerator()
+  METHOD public string GetValue(string key)
+  METHOD public bool HasKey(string key)
+  METHOD public virtual int IndexOf(Pipelinez.Core.Record.Metadata.MetadataRecord item)
+  METHOD public virtual void Insert(int index, Pipelinez.Core.Record.Metadata.MetadataRecord item)
+  METHOD public virtual bool Remove(Pipelinez.Core.Record.Metadata.MetadataRecord item)
+  METHOD public virtual void RemoveAt(int index)
+  METHOD public void Set(string key, string value)
+
+public class Pipelinez.Core.Record.Metadata.MetadataRecord
+  CTOR public Pipelinez.Core.Record.Metadata.MetadataRecord(string key, string value)
+  PROPERTY public string Key { get; set; }
+  PROPERTY public string Value { get; set; }
+
+public class Pipelinez.Core.Record.PipelineContainer<T> where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.Record.PipelineContainer<T>(T record)
+  CTOR public Pipelinez.Core.Record.PipelineContainer<T>(T record, Pipelinez.Core.Record.Metadata.MetadataCollection metadata)
+  PROPERTY public System.DateTimeOffset CreatedAtUtc { get; }
+  PROPERTY public Pipelinez.Core.FaultHandling.PipelineFaultState Fault { get; }
+  PROPERTY public bool HasFault { get; }
+  PROPERTY public Pipelinez.Core.Record.Metadata.MetadataCollection Metadata { get; }
+  PROPERTY public T Record { get; set; }
+  PROPERTY public System.Collections.Generic.IList<Pipelinez.Core.Retry.PipelineRetryAttempt> RetryHistory { get; }
+  PROPERTY public System.Collections.Generic.IList<Pipelinez.Core.FaultHandling.PipelineSegmentExecution> SegmentHistory { get; }
+  METHOD public void AddRetryAttempt(Pipelinez.Core.Retry.PipelineRetryAttempt retryAttempt)
+  METHOD public void AddSegmentExecution(Pipelinez.Core.FaultHandling.PipelineSegmentExecution segmentExecution)
+  METHOD public void MarkFaulted(Pipelinez.Core.FaultHandling.PipelineFaultState fault)
+
+public abstract class Pipelinez.Core.Record.PipelineRecord
+  PROPERTY public System.Collections.Generic.IList<Pipelinez.Core.Record.PipelineRecordHeader> Headers { get; }
+
+public class Pipelinez.Core.Record.PipelineRecordHeader
+  CTOR public Pipelinez.Core.Record.PipelineRecordHeader()
+  PROPERTY public string Key { get; set; }
+  PROPERTY public string Value { get; set; }
+
+public interface Pipelinez.Core.Retry.IPipelineRetryConfigurable<T> where T : Pipelinez.Core.Record.PipelineRecord
+  METHOD public abstract void ConfigureRetryPolicy(Pipelinez.Core.Retry.PipelineRetryPolicy<T> retryPolicy)
+  METHOD public abstract Pipelinez.Core.Retry.PipelineRetryPolicy<T> GetRetryPolicy()
+
+public class Pipelinez.Core.Retry.PipelineRetryAttempt
+  CTOR public Pipelinez.Core.Retry.PipelineRetryAttempt(int attemptNumber, string componentName, Pipelinez.Core.FaultHandling.PipelineComponentKind componentKind, System.DateTimeOffset startedAtUtc, System.DateTimeOffset completedAtUtc, System.TimeSpan duration, System.TimeSpan delayBeforeNextAttempt, string exceptionType, string message)
+  PROPERTY public int AttemptNumber { get; }
+  PROPERTY public System.DateTimeOffset CompletedAtUtc { get; }
+  PROPERTY public Pipelinez.Core.FaultHandling.PipelineComponentKind ComponentKind { get; }
+  PROPERTY public string ComponentName { get; }
+  PROPERTY public System.TimeSpan DelayBeforeNextAttempt { get; }
+  PROPERTY public System.TimeSpan Duration { get; }
+  PROPERTY public string ExceptionType { get; }
+  PROPERTY public string Message { get; }
+  PROPERTY public System.DateTimeOffset StartedAtUtc { get; }
+
+public class Pipelinez.Core.Retry.PipelineRetryContext<T> where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.Retry.PipelineRetryContext<T>(System.Exception exception, Pipelinez.Core.Record.PipelineContainer<T> container, string componentName, Pipelinez.Core.FaultHandling.PipelineComponentKind componentKind, int attemptNumber, int maxAttempts, System.Threading.CancellationToken cancellationToken)
+  PROPERTY public int AttemptNumber { get; }
+  PROPERTY public System.Threading.CancellationToken CancellationToken { get; }
+  PROPERTY public Pipelinez.Core.FaultHandling.PipelineComponentKind ComponentKind { get; }
+  PROPERTY public string ComponentName { get; }
+  PROPERTY public Pipelinez.Core.Record.PipelineContainer<T> Container { get; }
+  PROPERTY public System.Exception Exception { get; }
+  PROPERTY public int MaxAttempts { get; }
+  PROPERTY public T Record { get; }
+
+public class Pipelinez.Core.Retry.PipelineRetryOptions<T> where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.Retry.PipelineRetryOptions<T>()
+  PROPERTY public Pipelinez.Core.Retry.PipelineRetryPolicy<T> DefaultSegmentPolicy { get; init; }
+  PROPERTY public Pipelinez.Core.Retry.PipelineRetryPolicy<T> DestinationPolicy { get; init; }
+  PROPERTY public bool EmitRetryEvents { get; init; }
+
+public class Pipelinez.Core.Retry.PipelineRetryPolicy<T> where T : Pipelinez.Core.Record.PipelineRecord
+  PROPERTY public System.Func<Pipelinez.Core.Retry.PipelineRetryContext<T>, System.TimeSpan> DelayProvider { get; }
+  PROPERTY public int MaxAttempts { get; }
+  METHOD public static Pipelinez.Core.Retry.PipelineRetryPolicy<T> ExponentialBackoff(int maxAttempts, System.TimeSpan initialDelay, System.TimeSpan maxDelay, bool useJitter = false)
+  METHOD public static Pipelinez.Core.Retry.PipelineRetryPolicy<T> FixedDelay(int maxAttempts, System.TimeSpan delay)
+  METHOD public Pipelinez.Core.Retry.PipelineRetryPolicy<T> Handle(System.Func<Pipelinez.Core.Retry.PipelineRetryContext<T>, bool> predicate)
+  METHOD public Pipelinez.Core.Retry.PipelineRetryPolicy<T> Handle<TException>() where TException : System.Exception
+  METHOD public static Pipelinez.Core.Retry.PipelineRetryPolicy<T> None()
+
+public interface Pipelinez.Core.Segment.IPipelineSegment<T> : Pipelinez.Core.Flow.IFlowSource<Pipelinez.Core.Record.PipelineContainer<T>>, Pipelinez.Core.Flow.IFlowDestination<Pipelinez.Core.Record.PipelineContainer<T>> where T : Pipelinez.Core.Record.PipelineRecord
+  PROPERTY public System.Threading.Tasks.Task Completion { get; }
+
+public abstract class Pipelinez.Core.Segment.PipelineSegment<T> : Pipelinez.Core.Segment.IPipelineSegment<T>, Pipelinez.Core.Flow.IFlowSource<Pipelinez.Core.Record.PipelineContainer<T>>, Pipelinez.Core.Flow.IFlowDestination<Pipelinez.Core.Record.PipelineContainer<T>>, Pipelinez.Core.Retry.IPipelineRetryConfigurable<T>, Pipelinez.Core.FlowControl.IPipelineFlowStatusProvider, Pipelinez.Core.Performance.IPipelineExecutionConfigurable, Pipelinez.Core.Performance.IPipelinePerformanceAware where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.Segment.PipelineSegment<T>()
+  PROPERTY public System.Threading.Tasks.Task Completion { get; }
+  METHOD public virtual System.Threading.Tasks.Dataflow.ITargetBlock<Pipelinez.Core.Record.PipelineContainer<T>> AsTargetBlock()
+  METHOD public virtual void ConfigureExecutionOptions(Pipelinez.Core.Performance.PipelineExecutionOptions options)
+  METHOD public virtual void ConfigureRetryPolicy(Pipelinez.Core.Retry.PipelineRetryPolicy<T> retryPolicy)
+  METHOD public virtual System.IDisposable ConnectTo(Pipelinez.Core.Flow.IFlowDestination<Pipelinez.Core.Record.PipelineContainer<T>> target, System.Threading.Tasks.Dataflow.DataflowLinkOptions options = null)
+  METHOD public abstract System.Threading.Tasks.Task<T> ExecuteAsync(T arg)
+  METHOD public virtual Pipelinez.Core.Performance.PipelineExecutionOptions GetExecutionOptions()
+  METHOD public virtual Pipelinez.Core.Retry.PipelineRetryPolicy<T> GetRetryPolicy()
+
+public interface Pipelinez.Core.Source.IDistributedPipelineSource<T> : Pipelinez.Core.Source.IPipelineSource<T> where T : Pipelinez.Core.Record.PipelineRecord
+  PROPERTY public bool SupportsDistributedExecution { get; }
+  PROPERTY public string TransportName { get; }
+  METHOD public abstract System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionLease> GetOwnedPartitions()
+  METHOD public abstract System.Collections.Generic.IReadOnlyList<Pipelinez.Core.Distributed.PipelinePartitionExecutionState> GetPartitionExecutionStates()
+
+public interface Pipelinez.Core.Source.IPipelineSource<T> : Pipelinez.Core.Flow.IFlowSource<Pipelinez.Core.Record.PipelineContainer<T>> where T : Pipelinez.Core.Record.PipelineRecord
+  PROPERTY public System.Threading.Tasks.Task Completion { get; }
+  METHOD public abstract void Complete()
+  METHOD public abstract void Initialize(Pipelinez.Core.Pipeline<T> parentPipeline)
+  METHOD public abstract void OnPipelineContainerComplete(object sender, Pipelinez.Core.Eventing.PipelineContainerCompletedEventHandlerArgs<Pipelinez.Core.Record.PipelineContainer<T>> e)
+  METHOD public abstract System.Threading.Tasks.Task PublishAsync(T record)
+  METHOD public abstract System.Threading.Tasks.Task PublishAsync(T record, Pipelinez.Core.Record.Metadata.MetadataCollection metadata)
+  METHOD public abstract System.Threading.Tasks.Task<Pipelinez.Core.FlowControl.PipelinePublishResult> PublishAsync(T record, Pipelinez.Core.FlowControl.PipelinePublishOptions options)
+  METHOD public abstract System.Threading.Tasks.Task<Pipelinez.Core.FlowControl.PipelinePublishResult> PublishAsync(T record, Pipelinez.Core.Record.Metadata.MetadataCollection metadata, Pipelinez.Core.FlowControl.PipelinePublishOptions options)
+  METHOD public abstract System.Threading.Tasks.Task StartAsync(System.Threading.CancellationTokenSource cancellationToken)
+
+public class Pipelinez.Core.Source.InMemoryPipelineSource<T> : Pipelinez.Core.Source.PipelineSourceBase<T> where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.Source.InMemoryPipelineSource<T>()
+
+public abstract class Pipelinez.Core.Source.PipelineSourceBase<T> : Pipelinez.Core.Source.IPipelineSource<T>, Pipelinez.Core.Flow.IFlowSource<Pipelinez.Core.Record.PipelineContainer<T>>, Pipelinez.Core.FlowControl.IPipelineFlowStatusProvider, Pipelinez.Core.Performance.IPipelineExecutionConfigurable, Pipelinez.Core.Performance.IPipelinePerformanceAware where T : Pipelinez.Core.Record.PipelineRecord
+  CTOR public Pipelinez.Core.Source.PipelineSourceBase<T>()
+  PROPERTY public System.Threading.Tasks.Task Completion { get; }
+  METHOD public virtual void Complete()
+  METHOD public virtual void ConfigureExecutionOptions(Pipelinez.Core.Performance.PipelineExecutionOptions options)
+  METHOD public virtual System.IDisposable ConnectTo(Pipelinez.Core.Flow.IFlowDestination<Pipelinez.Core.Record.PipelineContainer<T>> target, System.Threading.Tasks.Dataflow.DataflowLinkOptions options = null)
+  METHOD public virtual Pipelinez.Core.Performance.PipelineExecutionOptions GetExecutionOptions()
+  METHOD public virtual void Initialize(Pipelinez.Core.Pipeline<T> parentPipeline)
+  METHOD public virtual void OnPipelineContainerComplete(object sender, Pipelinez.Core.Eventing.PipelineContainerCompletedEventHandlerArgs<Pipelinez.Core.Record.PipelineContainer<T>> e)
+  METHOD public virtual System.Threading.Tasks.Task PublishAsync(T record)
+  METHOD public virtual System.Threading.Tasks.Task PublishAsync(T record, Pipelinez.Core.Record.Metadata.MetadataCollection metadata)
+  METHOD public virtual System.Threading.Tasks.Task<Pipelinez.Core.FlowControl.PipelinePublishResult> PublishAsync(T record, Pipelinez.Core.FlowControl.PipelinePublishOptions options)
+  METHOD public virtual System.Threading.Tasks.Task<Pipelinez.Core.FlowControl.PipelinePublishResult> PublishAsync(T record, Pipelinez.Core.Record.Metadata.MetadataCollection metadata, Pipelinez.Core.FlowControl.PipelinePublishOptions options)
+  METHOD public virtual System.Threading.Tasks.Task StartAsync(System.Threading.CancellationTokenSource cancellationToken)
+
+public class Pipelinez.Core.Status.PipelineComponentStatus
+  CTOR public Pipelinez.Core.Status.PipelineComponentStatus(string name, Pipelinez.Core.Status.PipelineExecutionStatus status, Pipelinez.Core.FlowControl.PipelineComponentFlowStatus flow = null)
+  PROPERTY public Pipelinez.Core.FlowControl.PipelineComponentFlowStatus Flow { get; }
+  PROPERTY public string Name { get; }
+  PROPERTY public Pipelinez.Core.Status.PipelineExecutionStatus Status { get; }
+
+public enum Pipelinez.Core.Status.PipelineExecutionStatus
+  FIELD public static const Pipelinez.Core.Status.PipelineExecutionStatus Completed = Pipelinez.Core.Status.PipelineExecutionStatus.1
+  FIELD public static const Pipelinez.Core.Status.PipelineExecutionStatus Faulted = Pipelinez.Core.Status.PipelineExecutionStatus.2
+  FIELD public static const Pipelinez.Core.Status.PipelineExecutionStatus Healthy = Pipelinez.Core.Status.PipelineExecutionStatus.0
+  FIELD public static const Pipelinez.Core.Status.PipelineExecutionStatus Unknown = Pipelinez.Core.Status.PipelineExecutionStatus.3
+
+public class Pipelinez.Core.Status.PipelineStatus
+  CTOR public Pipelinez.Core.Status.PipelineStatus(System.Collections.Generic.IList<Pipelinez.Core.Status.PipelineComponentStatus> components, System.Nullable<Pipelinez.Core.Status.PipelineExecutionStatus> runtimeStatus = null, Pipelinez.Core.Distributed.PipelineDistributedStatus distributedStatus = null, Pipelinez.Core.FlowControl.PipelineFlowControlStatus flowControlStatus = null)
+  PROPERTY public System.Collections.Generic.IList<Pipelinez.Core.Status.PipelineComponentStatus> Components { get; }
+  PROPERTY public Pipelinez.Core.Distributed.PipelineDistributedStatus DistributedStatus { get; }
+  PROPERTY public Pipelinez.Core.FlowControl.PipelineFlowControlStatus FlowControlStatus { get; }
+  PROPERTY public System.Nullable<Pipelinez.Core.Status.PipelineExecutionStatus> RuntimeStatus { get; }
+  PROPERTY public Pipelinez.Core.Status.PipelineExecutionStatus Status { get; }

--- a/src/tests/Pipelinez.Tests/Pipelinez.Tests.csproj
+++ b/src/tests/Pipelinez.Tests/Pipelinez.Tests.csproj
@@ -27,4 +27,9 @@
       <ProjectReference Include="..\..\Pipelinez.Kafka\Pipelinez.Kafka.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Compile Include="..\TestCommon\ApiApproval\ApiApprovalTextGenerator.cs" Link="ApiApproval\ApiApprovalTextGenerator.cs" />
+      <None Include="ApprovedApi\Pipelinez.publicapi.txt" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
 </Project>

--- a/src/tests/TestCommon/ApiApproval/ApiApprovalTextGenerator.cs
+++ b/src/tests/TestCommon/ApiApproval/ApiApprovalTextGenerator.cs
@@ -1,0 +1,657 @@
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+
+namespace Pipelinez.Testing.ApiApproval;
+
+internal static class ApiApprovalTextGenerator
+{
+    public static string Generate(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        var builder = new StringBuilder();
+        builder.AppendLine($"Assembly: {assembly.GetName().Name}");
+
+        var exportedTypes = assembly
+            .GetExportedTypes()
+            .Where(type => !type.IsSpecialName && !IsCompilerGenerated(type))
+            .OrderBy(GetTypeSortKey, StringComparer.Ordinal)
+            .ToArray();
+
+        foreach (var type in exportedTypes)
+        {
+            builder.AppendLine();
+            AppendType(builder, type);
+        }
+
+        return builder.ToString().Replace("\r\n", "\n");
+    }
+
+    private static void AppendType(StringBuilder builder, Type type)
+    {
+        AppendAttributes(builder, type, string.Empty);
+        builder.AppendLine(FormatTypeDeclaration(type));
+
+        foreach (var memberSignature in GetMemberSignatures(type))
+        {
+            builder.Append("  ");
+            builder.AppendLine(memberSignature);
+        }
+    }
+
+    private static IEnumerable<string> GetMemberSignatures(Type type)
+    {
+        if (IsDelegate(type) || type.IsEnum)
+        {
+            if (type.IsEnum)
+            {
+                foreach (var field in type
+                             .GetFields(BindingFlags.Public | BindingFlags.Static)
+                             .OrderBy(field => field.Name, StringComparer.Ordinal))
+                {
+                    yield return $"FIELD {FormatField(field)}";
+                }
+            }
+
+            yield break;
+        }
+
+        var members = new List<string>();
+
+        members.AddRange(type
+            .GetConstructors(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .OrderBy(ctor => ctor.ToString(), StringComparer.Ordinal)
+            .Select(FormatConstructor));
+
+        members.AddRange(type
+            .GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(field => !field.IsSpecialName)
+            .OrderBy(field => field.Name, StringComparer.Ordinal)
+            .Select(field => $"FIELD {FormatField(field)}"));
+
+        members.AddRange(type
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .OrderBy(property => property.Name, StringComparer.Ordinal)
+            .Select(property => $"PROPERTY {FormatProperty(property)}"));
+
+        members.AddRange(type
+            .GetEvents(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .OrderBy(evt => evt.Name, StringComparer.Ordinal)
+            .Select(evt => $"EVENT {FormatEvent(evt)}"));
+
+        members.AddRange(type
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(method => !method.IsSpecialName)
+            .OrderBy(method => method.Name, StringComparer.Ordinal)
+            .ThenBy(method => method.ToString(), StringComparer.Ordinal)
+            .Select(method => $"METHOD {FormatMethod(method)}"));
+
+        foreach (var member in members)
+        {
+            yield return member;
+        }
+    }
+
+    private static string FormatTypeDeclaration(Type type)
+    {
+        if (IsDelegate(type))
+        {
+            var invoke = type.GetMethod("Invoke", BindingFlags.Public | BindingFlags.Instance)
+                         ?? throw new InvalidOperationException($"Delegate type '{type.FullName}' is missing Invoke.");
+
+            return $"{FormatTypeModifiers(type)}delegate {FormatTypeName(type, includeNamespace: true)}({FormatParameters(invoke.GetParameters())}) : {FormatTypeName(invoke.ReturnType, includeNamespace: true)}{FormatGenericConstraints(type)}";
+        }
+
+        var kind = type.IsInterface
+            ? "interface"
+            : type.IsEnum
+                ? "enum"
+                : type.IsValueType
+                    ? "struct"
+                    : type.IsAbstract && type.IsSealed
+                        ? "static class"
+                        : type.IsAbstract
+                            ? "abstract class"
+                            : "class";
+
+        var declaration = $"{FormatTypeModifiers(type)}{kind} {FormatTypeName(type, includeNamespace: true)}";
+
+        var baseAndInterfaces = new List<string>();
+
+        if (type.BaseType is not null &&
+            type.BaseType != typeof(object) &&
+            type.BaseType != typeof(ValueType) &&
+            !type.IsEnum)
+        {
+            baseAndInterfaces.Add(FormatTypeName(type.BaseType, includeNamespace: true));
+        }
+
+        foreach (var implementedInterface in GetDirectInterfaces(type))
+        {
+            baseAndInterfaces.Add(FormatTypeName(implementedInterface, includeNamespace: true));
+        }
+
+        if (baseAndInterfaces.Count > 0)
+        {
+            declaration += $" : {string.Join(", ", baseAndInterfaces)}";
+        }
+
+        declaration += FormatGenericConstraints(type);
+        return declaration;
+    }
+
+    private static IEnumerable<Type> GetDirectInterfaces(Type type)
+    {
+        var allInterfaces = type.GetInterfaces();
+
+        if (type.IsInterface)
+        {
+            var inheritedInterfaces = allInterfaces
+                .SelectMany(@interface => @interface.GetInterfaces())
+                .Distinct()
+                .ToHashSet();
+
+            return allInterfaces
+                .Where(@interface => !inheritedInterfaces.Contains(@interface))
+                .OrderBy(interfaceType => interfaceType.FullName, StringComparer.Ordinal);
+        }
+
+        var baseInterfaces = type.BaseType?.GetInterfaces() ?? Array.Empty<Type>();
+        return allInterfaces
+            .Except(baseInterfaces)
+            .OrderBy(interfaceType => interfaceType.FullName, StringComparer.Ordinal);
+    }
+
+    private static string FormatConstructor(ConstructorInfo constructor)
+    {
+        var attributes = FormatAttributeList(constructor);
+        var prefix = string.IsNullOrWhiteSpace(attributes) ? string.Empty : $"{attributes} ";
+        return $"{prefix}CTOR {FormatMemberModifiers(constructor)}{FormatTypeName(constructor.DeclaringType!, includeNamespace: true)}({FormatParameters(constructor.GetParameters())})";
+    }
+
+    private static string FormatField(FieldInfo field)
+    {
+        var prefix = new StringBuilder();
+        AppendAttributePrefix(prefix, field);
+        prefix.Append(FormatFieldModifiers(field));
+        prefix.Append(FormatTypeName(field.FieldType, includeNamespace: true));
+        prefix.Append(' ');
+        prefix.Append(field.Name);
+
+        if (field.IsLiteral && !field.IsInitOnly)
+        {
+            prefix.Append(" = ");
+            prefix.Append(FormatConstant(field.GetRawConstantValue(), field.FieldType));
+        }
+
+        return prefix.ToString();
+    }
+
+    private static string FormatProperty(PropertyInfo property)
+    {
+        var prefix = new StringBuilder();
+        AppendAttributePrefix(prefix, property);
+        prefix.Append(FormatPropertyModifiers(property));
+
+        if (HasRequiredMemberAttribute(property))
+        {
+            prefix.Append("required ");
+        }
+
+        prefix.Append(FormatTypeName(property.PropertyType, includeNamespace: true));
+        prefix.Append(' ');
+
+        if (property.GetIndexParameters().Length > 0)
+        {
+            prefix.Append("this[");
+            prefix.Append(FormatParameters(property.GetIndexParameters()));
+            prefix.Append(']');
+        }
+        else
+        {
+            prefix.Append(property.Name);
+        }
+
+        prefix.Append(" { ");
+
+        if (property.GetMethod?.IsPublic == true)
+        {
+            prefix.Append("get; ");
+        }
+
+        if (property.SetMethod?.IsPublic == true)
+        {
+            prefix.Append(IsInitOnly(property) ? "init; " : "set; ");
+        }
+
+        prefix.Append('}');
+        return prefix.ToString().TrimEnd();
+    }
+
+    private static string FormatEvent(EventInfo evt)
+    {
+        var prefix = new StringBuilder();
+        AppendAttributePrefix(prefix, evt);
+        prefix.Append(FormatEventModifiers(evt));
+        prefix.Append(FormatTypeName(evt.EventHandlerType!, includeNamespace: true));
+        prefix.Append(' ');
+        prefix.Append(evt.Name);
+        return prefix.ToString();
+    }
+
+    private static string FormatMethod(MethodInfo method)
+    {
+        var prefix = new StringBuilder();
+        AppendAttributePrefix(prefix, method);
+        prefix.Append(FormatMemberModifiers(method));
+        prefix.Append(FormatTypeName(method.ReturnType, includeNamespace: true));
+        prefix.Append(' ');
+        prefix.Append(method.Name);
+
+        if (method.IsGenericMethodDefinition)
+        {
+            prefix.Append('<');
+            prefix.Append(string.Join(", ", method.GetGenericArguments().Select(argument => argument.Name)));
+            prefix.Append('>');
+        }
+
+        prefix.Append('(');
+        prefix.Append(FormatParameters(method.GetParameters()));
+        prefix.Append(')');
+        prefix.Append(FormatGenericConstraints(method));
+        return prefix.ToString();
+    }
+
+    private static string FormatParameters(IEnumerable<ParameterInfo> parameters)
+    {
+        return string.Join(", ", parameters.Select(FormatParameter));
+    }
+
+    private static string FormatParameter(ParameterInfo parameter)
+    {
+        var builder = new StringBuilder();
+
+        if (parameter.GetCustomAttribute<ParamArrayAttribute>() is not null)
+        {
+            builder.Append("params ");
+        }
+
+        var parameterType = parameter.ParameterType;
+        if (parameterType.IsByRef)
+        {
+            if (parameter.IsOut)
+            {
+                builder.Append("out ");
+            }
+            else if (parameter.IsIn)
+            {
+                builder.Append("in ");
+            }
+            else
+            {
+                builder.Append("ref ");
+            }
+
+            parameterType = parameterType.GetElementType()
+                            ?? throw new InvalidOperationException($"By-ref parameter '{parameter.Name}' is missing element type.");
+        }
+
+        builder.Append(FormatTypeName(parameterType, includeNamespace: true));
+        builder.Append(' ');
+        builder.Append(parameter.Name);
+
+        if (parameter.HasDefaultValue)
+        {
+            builder.Append(" = ");
+            builder.Append(FormatConstant(parameter.DefaultValue, parameterType));
+        }
+
+        return builder.ToString();
+    }
+
+    private static string FormatConstant(object? value, Type declaredType)
+    {
+        if (value is null)
+        {
+            return "null";
+        }
+
+        if (declaredType.IsEnum)
+        {
+            return $"{FormatTypeName(declaredType, includeNamespace: true)}.{value}";
+        }
+
+        return value switch
+        {
+            string text => $"\"{text.Replace("\\", "\\\\").Replace("\"", "\\\"")}\"",
+            char character => $"'{character}'",
+            bool boolean => boolean ? "true" : "false",
+            float single => single.ToString(CultureInfo.InvariantCulture) + "F",
+            double doubleValue => doubleValue.ToString(CultureInfo.InvariantCulture) + "D",
+            decimal decimalValue => decimalValue.ToString(CultureInfo.InvariantCulture) + "M",
+            _ => Convert.ToString(value, CultureInfo.InvariantCulture)
+                 ?? value.ToString()
+                 ?? string.Empty
+        };
+    }
+
+    private static string FormatTypeModifiers(Type type)
+    {
+        return type.IsNestedPublic ? "public " : "public ";
+    }
+
+    private static string FormatMemberModifiers(MethodBase method)
+    {
+        var modifiers = new List<string> { "public" };
+
+        if (method.IsStatic)
+        {
+            modifiers.Add("static");
+        }
+        else if (method.IsAbstract)
+        {
+            modifiers.Add("abstract");
+        }
+        else if (method is MethodInfo methodInfo && methodInfo.IsVirtual && methodInfo.GetBaseDefinition() == methodInfo)
+        {
+            modifiers.Add("virtual");
+        }
+
+        return string.Join(" ", modifiers) + " ";
+    }
+
+    private static string FormatFieldModifiers(FieldInfo field)
+    {
+        var modifiers = new List<string> { "public" };
+
+        if (field.IsStatic)
+        {
+            modifiers.Add("static");
+        }
+
+        if (field.IsLiteral && !field.IsInitOnly)
+        {
+            modifiers.Add("const");
+        }
+        else if (field.IsInitOnly)
+        {
+            modifiers.Add("readonly");
+        }
+
+        return string.Join(" ", modifiers) + " ";
+    }
+
+    private static string FormatPropertyModifiers(PropertyInfo property)
+    {
+        var accessor = property.GetMethod ?? property.SetMethod;
+        var modifiers = new List<string> { "public" };
+
+        if (accessor?.IsStatic == true)
+        {
+            modifiers.Add("static");
+        }
+
+        return string.Join(" ", modifiers) + " ";
+    }
+
+    private static string FormatEventModifiers(EventInfo evt)
+    {
+        var addMethod = evt.AddMethod;
+        var modifiers = new List<string> { "public", "event" };
+
+        if (addMethod?.IsStatic == true)
+        {
+            modifiers.Insert(1, "static");
+        }
+
+        return string.Join(" ", modifiers) + " ";
+    }
+
+    private static string FormatTypeName(Type type, bool includeNamespace)
+    {
+        if (type.IsByRef)
+        {
+            return FormatTypeName(type.GetElementType()!, includeNamespace);
+        }
+
+        if (type.IsArray)
+        {
+            return $"{FormatTypeName(type.GetElementType()!, includeNamespace)}[]";
+        }
+
+        if (type.IsPointer)
+        {
+            return $"{FormatTypeName(type.GetElementType()!, includeNamespace)}*";
+        }
+
+        if (type.IsGenericParameter)
+        {
+            return type.Name;
+        }
+
+        if (TryGetBuiltInTypeAlias(type, out var alias))
+        {
+            return alias;
+        }
+
+        if (type.IsNested)
+        {
+            var declaringTypeName = FormatTypeName(type.DeclaringType!, includeNamespace);
+            var ownGenericArguments = GetOwnGenericArguments(type);
+            return $"{declaringTypeName}.{StripArity(type.Name)}{FormatGenericArguments(ownGenericArguments, includeNamespace)}";
+        }
+
+        if (type.IsGenericType)
+        {
+            var genericTypeDefinition = type.IsGenericTypeDefinition ? type : type.GetGenericTypeDefinition();
+            var namespacePrefix = includeNamespace && !string.IsNullOrWhiteSpace(genericTypeDefinition.Namespace)
+                ? genericTypeDefinition.Namespace + "."
+                : string.Empty;
+
+            return $"{namespacePrefix}{StripArity(genericTypeDefinition.Name)}{FormatGenericArguments(type.GetGenericArguments(), includeNamespace)}";
+        }
+
+        var simpleNamespace = includeNamespace && !string.IsNullOrWhiteSpace(type.Namespace)
+            ? type.Namespace + "."
+            : string.Empty;
+
+        return simpleNamespace + type.Name;
+    }
+
+    private static string FormatGenericArguments(IEnumerable<Type> arguments, bool includeNamespace)
+    {
+        var argumentList = arguments.ToArray();
+        if (argumentList.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        return "<" + string.Join(", ", argumentList.Select(argument => FormatTypeName(argument, includeNamespace))) + ">";
+    }
+
+    private static IEnumerable<Type> GetOwnGenericArguments(Type type)
+    {
+        var allArguments = type.GetGenericArguments();
+        if (!type.IsNested)
+        {
+            return allArguments;
+        }
+
+        var declaringArguments = type.DeclaringType?.GetGenericArguments().Length ?? 0;
+        return allArguments.Skip(declaringArguments);
+    }
+
+    private static string FormatGenericConstraints(Type type)
+    {
+        return FormatGenericConstraints(type.GetGenericArguments());
+    }
+
+    private static string FormatGenericConstraints(MethodInfo method)
+    {
+        if (!method.IsGenericMethodDefinition)
+        {
+            return string.Empty;
+        }
+
+        return FormatGenericConstraints(method.GetGenericArguments());
+    }
+
+    private static string FormatGenericConstraints(IEnumerable<Type> genericArguments)
+    {
+        var clauses = new List<string>();
+
+        foreach (var argument in genericArguments.Where(argument => argument.IsGenericParameter))
+        {
+            var constraints = new List<string>();
+            var parameterAttributes = argument.GenericParameterAttributes;
+
+            if (parameterAttributes.HasFlag(GenericParameterAttributes.ReferenceTypeConstraint))
+            {
+                constraints.Add("class");
+            }
+
+            if (parameterAttributes.HasFlag(GenericParameterAttributes.NotNullableValueTypeConstraint))
+            {
+                constraints.Add("struct");
+            }
+
+            constraints.AddRange(argument
+                .GetGenericParameterConstraints()
+                .Select(constraint => FormatTypeName(constraint, includeNamespace: true)));
+
+            if (parameterAttributes.HasFlag(GenericParameterAttributes.DefaultConstructorConstraint))
+            {
+                constraints.Add("new()");
+            }
+
+            if (constraints.Count > 0)
+            {
+                clauses.Add($"where {argument.Name} : {string.Join(", ", constraints)}");
+            }
+        }
+
+        return clauses.Count == 0
+            ? string.Empty
+            : " " + string.Join(" ", clauses);
+    }
+
+    private static void AppendAttributes(StringBuilder builder, MemberInfo member, string indent)
+    {
+        foreach (var attribute in GetRelevantAttributes(member))
+        {
+            builder.Append(indent);
+            builder.AppendLine(attribute);
+        }
+    }
+
+    private static void AppendAttributePrefix(StringBuilder builder, MemberInfo member)
+    {
+        var attributes = FormatAttributeList(member);
+        if (!string.IsNullOrWhiteSpace(attributes))
+        {
+            builder.Append(attributes);
+            builder.Append(' ');
+        }
+    }
+
+    private static string FormatAttributeList(MemberInfo member)
+    {
+        return string.Join(" ", GetRelevantAttributes(member));
+    }
+
+    private static IEnumerable<string> GetRelevantAttributes(MemberInfo member)
+    {
+        foreach (var attribute in member.GetCustomAttributesData())
+        {
+            if (attribute.AttributeType.FullName == typeof(ObsoleteAttribute).FullName)
+            {
+                var message = attribute.ConstructorArguments.Count > 0
+                    ? Convert.ToString(attribute.ConstructorArguments[0].Value, CultureInfo.InvariantCulture)
+                    : null;
+
+                var error = attribute.NamedArguments
+                    .FirstOrDefault(argument => argument.MemberName == nameof(ObsoleteAttribute.IsError))
+                    .TypedValue.Value as bool?;
+
+                yield return error.HasValue
+                    ? $"[Obsolete(\"{EscapeString(message ?? string.Empty)}\", error: {error.Value.ToString().ToLowerInvariant()})]"
+                    : $"[Obsolete(\"{EscapeString(message ?? string.Empty)}\")]";
+            }
+            else if (attribute.AttributeType.FullName == "System.Diagnostics.CodeAnalysis.ExperimentalAttribute")
+            {
+                var diagnosticId = attribute.ConstructorArguments.Count > 0
+                    ? Convert.ToString(attribute.ConstructorArguments[0].Value, CultureInfo.InvariantCulture)
+                    : string.Empty;
+
+                yield return $"[Experimental(\"{EscapeString(diagnosticId ?? string.Empty)}\")]";
+            }
+        }
+    }
+
+    private static bool HasRequiredMemberAttribute(MemberInfo member)
+    {
+        return member.GetCustomAttributesData()
+            .Any(attribute => attribute.AttributeType.FullName == "System.Runtime.CompilerServices.RequiredMemberAttribute");
+    }
+
+    private static bool IsInitOnly(PropertyInfo property)
+    {
+        return property.SetMethod?.ReturnParameter
+            .GetRequiredCustomModifiers()
+            .Any(modifier => modifier.FullName == "System.Runtime.CompilerServices.IsExternalInit") == true;
+    }
+
+    private static bool IsDelegate(Type type)
+    {
+        return type.BaseType == typeof(MulticastDelegate);
+    }
+
+    private static bool IsCompilerGenerated(MemberInfo member)
+    {
+        return member.GetCustomAttributesData()
+            .Any(attribute => attribute.AttributeType.FullName == "System.Runtime.CompilerServices.CompilerGeneratedAttribute");
+    }
+
+    private static string GetTypeSortKey(Type type)
+    {
+        return type.FullName ?? type.Name;
+    }
+
+    private static string StripArity(string name)
+    {
+        var marker = name.IndexOf('`');
+        return marker >= 0 ? name[..marker] : name;
+    }
+
+    private static bool TryGetBuiltInTypeAlias(Type type, out string alias)
+    {
+        alias = type.FullName switch
+        {
+            "System.Void" => "void",
+            "System.Boolean" => "bool",
+            "System.Byte" => "byte",
+            "System.SByte" => "sbyte",
+            "System.Char" => "char",
+            "System.Decimal" => "decimal",
+            "System.Double" => "double",
+            "System.Single" => "float",
+            "System.Int32" => "int",
+            "System.UInt32" => "uint",
+            "System.Int64" => "long",
+            "System.UInt64" => "ulong",
+            "System.Int16" => "short",
+            "System.UInt16" => "ushort",
+            "System.Object" => "object",
+            "System.String" => "string",
+            _ => string.Empty
+        };
+
+        return alias.Length > 0;
+    }
+
+    private static string EscapeString(string value)
+    {
+        return value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+    }
+}


### PR DESCRIPTION
## Summary

- Added public API approval testing for both `Pipelinez` and `Pipelinez.Kafka`
- Checked in approved API baselines so accidental consumer-facing contract changes now fail during normal test execution
- Reduced a few accidental public-surface leaks in Kafka client plumbing and internal helper types
- Added repository-level API stability and contributor guidance, plus a PR checklist for public API review

## Validation

- [x] `dotnet build src/Pipelinez.sln`
- [x] `dotnet test src/Pipelinez.sln --logger "console;verbosity=minimal"`

## Public API

- [ ] No public API changes
- [x] Public API changes were intentional and the approved baselines were updated
- [x] New unstable public APIs are marked preview
- [x] Obsoletions include a migration path

Notes:
- This PR tightens the intended public contract rather than adding new consumer-facing runtime features.
- Internal-only Kafka client abstractions and helper types that were accidentally public were reduced to non-public surface where appropriate.
- Public API approval tests were added so future contract changes are explicit and reviewable.

## Documentation

- [ ] No documentation updates were needed
- [x] Consumer-facing docs were updated for behavior or API changes

Docs updated in this PR include:
- API stability guidance
- contributor guidance for public API changes
- README and overview updates describing the compatibility policy