### PR TITLE
docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,10 +432,20 @@ Public events include:
   Kafka integration tests
 - [`src/benchmarks/Pipelinez.Benchmarks`](src/benchmarks/Pipelinez.Benchmarks)
   BenchmarkDotNet-based performance benchmarks
+- [`docs/README.md`](docs/README.md)
+  documentation index and guide map
 - [`docs/Overview.md`](docs/Overview.md)
   deeper architectural overview
 - [`docs/ApiStability.md`](docs/ApiStability.md)
   compatibility, stability, and public API change guidance
+
+## Documentation
+
+For task-oriented docs, start with:
+
+- [`docs/README.md`](docs/README.md)
+- [`docs/getting-started/in-memory.md`](docs/getting-started/in-memory.md)
+- [`docs/getting-started/kafka.md`](docs/getting-started/kafka.md)
 
 ## Running Locally
 
@@ -503,4 +513,4 @@ See [`docs/ApiStability.md`](docs/ApiStability.md) for the full policy and maint
 
 ## License
 
-No license file is currently included in the repository.
+This repository is licensed under the MIT License. See [`LICENSE`](LICENSE).

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -37,6 +37,8 @@ Each record flows through the runtime inside a `PipelineContainer<T>`, which let
   sample application that builds a Kafka-backed pipeline
 - `src/examples/Example.Kafka.DataGen`
   simple Kafka publisher used to generate example traffic
+- `docs/README.md`
+  documentation index linking getting-started, guides, transport docs, operations docs, and architecture docs
 
 ## Core Runtime Design
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,50 @@
+# Documentation
+
+This folder contains the main documentation set for Pipelinez.
+
+## Start Here
+
+- [Overview](Overview.md)
+  architectural overview of the current runtime
+- [API Stability](ApiStability.md)
+  public API compatibility policy and maintainer workflow
+
+## Getting Started
+
+- [In-Memory Pipeline](getting-started/in-memory.md)
+  first end-to-end pipeline without external infrastructure
+- [Kafka Pipeline](getting-started/kafka.md)
+  first Kafka-backed pipeline using the example Docker workflow
+
+## Guides
+
+- [Lifecycle](guides/lifecycle.md)
+- [Error Handling](guides/error-handling.md)
+- [Retry](guides/retry.md)
+- [Dead-Lettering](guides/dead-lettering.md)
+- [Flow Control](guides/flow-control.md)
+- [Distributed Execution](guides/distributed-execution.md)
+- [Performance](guides/performance.md)
+- [Operational Tooling](guides/operational-tooling.md)
+
+## Transport Docs
+
+- [Kafka](transports/kafka.md)
+
+## Operations
+
+- [Troubleshooting](operations/troubleshooting.md)
+
+## Architecture
+
+- [Runtime](architecture/runtime.md)
+- [Kafka Internals](architecture/kafka.md)
+- [Testing](architecture/testing.md)
+
+## Current Installation Note
+
+Pipelinez is documented here as a source-first project. Package distribution work is planned separately, so the current getting-started guidance assumes:
+
+- cloning the repository
+- building the solution locally
+- or referencing the projects directly from source

--- a/docs/architecture/kafka.md
+++ b/docs/architecture/kafka.md
@@ -1,0 +1,83 @@
+# Kafka Internals
+
+Audience: contributors and maintainers working on the Kafka transport.
+
+## What This Covers
+
+- source and destination responsibilities
+- offset storage model
+- distributed ownership and partition-aware execution
+
+## Kafka Source Responsibilities
+
+`KafkaPipelineSource<T, TRecordKey, TRecordValue>` is responsible for:
+
+- consuming records
+- mapping Kafka key/value pairs into pipeline records
+- copying Kafka headers into record headers
+- stamping Kafka and distribution metadata
+- surfacing partition ownership into the core runtime
+- storing offsets after terminal record handling
+
+## Offset Model
+
+Kafka execution intentionally separates:
+
+- consume-time read
+- completion-time offset storage
+
+That means a message is consumed first, processed through the pipeline, and only then treated as safely advanced when the record reaches a terminal handled state.
+
+This is especially important for:
+
+- retry
+- dead-lettering
+- partition drain behavior
+- distributed rebalance handling
+
+## Partition-Aware Execution
+
+Kafka now supports explicit partition-aware scaling controls through `KafkaPartitionScalingOptions`.
+
+Key knobs:
+
+- `ExecutionMode`
+- `MaxConcurrentPartitions`
+- `MaxInFlightPerPartition`
+- `RebalanceMode`
+- `EmitPartitionExecutionEvents`
+
+The source also coordinates:
+
+- partition assignment
+- partition revocation
+- partition draining
+- pause/resume for partition-local admission
+- highest completed offset tracking
+
+## Destination Responsibilities
+
+`KafkaPipelineDestination<T, TRecordKey, TRecordValue>` is responsible for:
+
+- mapping pipeline records into Kafka messages
+- ensuring headers exist
+- copying pipeline headers into Kafka headers
+- awaiting broker acknowledgement
+
+The record is only considered completed after the broker write succeeds.
+
+## Dead-Letter Destination
+
+`KafkaDeadLetterDestination<T, TRecordKey, TRecordValue>` preserves:
+
+- the original record payload
+- dead-letter metadata and fault details
+- copied headers
+
+It then writes the mapped envelope to a Kafka dead-letter topic.
+
+## Related Docs
+
+- [Kafka](../transports/kafka.md)
+- [Distributed Execution](../guides/distributed-execution.md)
+- [Architecture: Runtime](runtime.md)

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -1,0 +1,86 @@
+# Runtime Architecture
+
+Audience: contributors and maintainers.
+
+## What This Covers
+
+- how the core runtime is assembled
+- how records move through the graph
+- where status, fault, retry, and flow-control behavior live
+
+## High-Level Shape
+
+Pipelinez is built on TPL Dataflow.
+
+```mermaid
+flowchart LR
+    A[Source] --> B[Segment]
+    B --> C[Segment]
+    C --> D[Destination]
+```
+
+The runtime graph is assembled during `Build()` and linked before the pipeline is started.
+
+## Container Model
+
+Each record moves through the runtime inside `PipelineContainer<T>`.
+
+That container carries:
+
+- the current record payload
+- metadata
+- fault state
+- segment history
+- retry history
+
+This allows the framework to keep payload data and execution context together across the whole pipeline.
+
+## Component Roles
+
+- source:
+  ingress, manual publish handling, source-side metadata stamping
+- segment:
+  transform execution, retry application, segment-history updates
+- destination:
+  terminal processing, batching, terminal fault handling handoff
+- pipeline:
+  orchestration, status, events, health, performance, and runtime coordination
+
+## Fault And Retry Flow
+
+```mermaid
+flowchart TD
+    A[Segment or Destination Fault] --> B{Retry Policy}
+    B -->|Retry| C[Retry Attempt]
+    B -->|Exhausted| D[Error Handler]
+    D -->|SkipRecord| E[Handled]
+    D -->|DeadLetter| F[Dead-Letter Destination]
+    D -->|StopPipeline| G[Pipeline Faulted]
+    D -->|Rethrow| H[Exception Surface]
+```
+
+## Flow Control
+
+Flow control is layered over bounded-capacity execution settings.
+
+Manual publish goes through:
+
+- source capacity
+- configured overflow policy
+- publish result handling
+- saturation state tracking
+
+## Operational Layer
+
+The operational surface builds on runtime state already collected by the pipeline:
+
+- `GetStatus()`
+- `GetPerformanceSnapshot()`
+- `GetHealthStatus()`
+- `GetOperationalSnapshot()`
+
+## Related Docs
+
+- [Overview](../Overview.md)
+- [Architecture: Kafka Internals](kafka.md)
+- [Architecture: Testing](testing.md)

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -1,0 +1,78 @@
+# Testing Architecture
+
+Audience: contributors and maintainers extending the test suite.
+
+## What This Covers
+
+- the current test layers
+- what belongs in core tests versus Kafka integration tests
+- API approval testing
+
+## Test Layers
+
+### Core Tests
+
+`src/tests/Pipelinez.Tests` covers transport-agnostic runtime behavior such as:
+
+- lifecycle
+- segments
+- destinations
+- faults
+- retry
+- flow control
+- performance
+- distributed runtime behavior
+- operational tooling
+
+### Kafka Integration Tests
+
+`src/tests/Pipelinez.Kafka.Tests` covers real Kafka behavior using Docker/Testcontainers.
+
+This suite validates:
+
+- source-topic to destination-topic flow
+- dead-letter topics
+- retry and fault handling with a real broker
+- distributed worker ownership and rebalance
+- partition-aware execution
+
+## API Approval Tests
+
+The repository now also includes public API approval tests for:
+
+- `Pipelinez`
+- `Pipelinez.Kafka`
+
+Those tests compare the compiled public surface to checked-in approved baselines.
+
+Baseline refresh workflow:
+
+```powershell
+$env:PIPELINEZ_UPDATE_API_BASELINES='1'
+dotnet test src/tests/Pipelinez.Tests/Pipelinez.Tests.csproj --filter ApiApprovalTests
+dotnet test src/tests/Pipelinez.Kafka.Tests/Pipelinez.Kafka.Tests.csproj --filter ApiApprovalTests
+```
+
+Then run:
+
+```bash
+dotnet test src/Pipelinez.sln --logger "console;verbosity=minimal"
+```
+
+## Test Placement Guidance
+
+Use core tests when:
+
+- the behavior is transport-agnostic
+- you can validate it with in-memory or test-double components
+
+Use Kafka integration tests when:
+
+- the behavior depends on a real broker
+- the scenario depends on Kafka offsets, partitions, rebalance, or headers
+
+## Related Docs
+
+- [Overview](../Overview.md)
+- [API Stability](../ApiStability.md)
+- [Contributing](../../CONTRIBUTING.md)

--- a/docs/getting-started/in-memory.md
+++ b/docs/getting-started/in-memory.md
@@ -1,0 +1,94 @@
+# In-Memory Pipeline
+
+Audience: application developers evaluating Pipelinez for the first time.
+
+## What This Covers
+
+This guide walks through the smallest useful Pipelinez setup:
+
+- define a record
+- add a segment
+- build an in-memory pipeline
+- start it
+- publish a record
+- complete it cleanly
+
+## Prerequisites
+
+- .NET 8 SDK
+- a local clone of this repository
+
+Pipeline packaging and distribution are tracked separately, so the current path is source-first.
+
+## Build The Solution
+
+From the repository root:
+
+```bash
+dotnet build src/Pipelinez.sln
+```
+
+## Minimal Example
+
+```csharp
+using Pipelinez.Core;
+using Pipelinez.Core.Record;
+using Pipelinez.Core.Segment;
+
+public sealed class OrderRecord : PipelineRecord
+{
+    public required string Id { get; init; }
+    public required decimal Total { get; set; }
+}
+
+public sealed class NormalizeOrderSegment : PipelineSegment<OrderRecord>
+{
+    public override Task<OrderRecord> ExecuteAsync(OrderRecord record)
+    {
+        record.Total = decimal.Round(record.Total, 2);
+        return Task.FromResult(record);
+    }
+}
+
+var pipeline = Pipeline<OrderRecord>.New("orders")
+    .WithInMemorySource(new object())
+    .AddSegment(new NormalizeOrderSegment(), new object())
+    .WithInMemoryDestination("in-memory")
+    .Build();
+
+pipeline.OnPipelineRecordCompleted += (_, args) =>
+{
+    Console.WriteLine($"{args.Record.Id} completed with total {args.Record.Total}");
+};
+
+await pipeline.StartPipelineAsync();
+await pipeline.PublishAsync(new OrderRecord { Id = "A-100", Total = 42.155m });
+await pipeline.CompleteAsync();
+await pipeline.Completion;
+```
+
+## What Happens
+
+1. `Pipeline<T>.New("orders")` creates a `PipelineBuilder<T>`.
+2. `WithInMemorySource(...)` adds a manual source that accepts `PublishAsync(...)`.
+3. `AddSegment(...)` inserts a transform step.
+4. `WithInMemoryDestination(...)` adds a sink.
+5. `Build()` validates the pipeline and links the runtime graph.
+6. `StartPipelineAsync()` activates the runtime.
+7. `PublishAsync(...)` sends a record into the source.
+8. `CompleteAsync()` stops accepting new work and lets in-flight records finish.
+9. `Completion` completes when the full pipeline run is done.
+
+## Important Behaviors
+
+- `PublishAsync(...)` before `StartPipelineAsync()` throws.
+- `CompleteAsync()` before `StartPipelineAsync()` throws.
+- calling `StartPipelineAsync()` twice throws.
+- awaiting `Completion` is the safest way to know all downstream work is done.
+
+## Next Steps
+
+- read [Lifecycle](../guides/lifecycle.md)
+- read [Error Handling](../guides/error-handling.md)
+- read [Performance](../guides/performance.md)
+- read [Kafka Pipeline](kafka.md) when you want to move beyond in-memory flow

--- a/docs/getting-started/kafka.md
+++ b/docs/getting-started/kafka.md
@@ -1,0 +1,101 @@
+# Kafka Pipeline
+
+Audience: application developers who want a real transport-backed pipeline.
+
+## What This Covers
+
+This guide shows the shape of a Kafka-backed pipeline and how to run the shipped examples with a local Docker-hosted broker.
+
+## Prerequisites
+
+- .NET 8 SDK
+- Docker running locally
+- a local clone of this repository
+
+## Fastest Path: Run The Example
+
+From the repository root:
+
+```bash
+dotnet run --project src/examples/Example.Kafka
+```
+
+This example:
+
+- starts or connects to Kafka
+- ensures the example topics exist
+- builds a Kafka source -> segment -> Kafka destination pipeline
+- publishes demo records into the source topic
+- waits for the pipeline to process them
+
+To publish additional traffic into the same source topic:
+
+```bash
+dotnet run --project src/examples/Example.Kafka.DataGen
+```
+
+## Minimal Kafka Pipeline Shape
+
+```csharp
+using Confluent.Kafka;
+using Pipelinez.Core;
+using Pipelinez.Kafka;
+using Pipelinez.Kafka.Configuration;
+
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .WithKafkaSource(
+        new KafkaSourceOptions
+        {
+            BootstrapServers = "localhost:9092",
+            TopicName = "orders-in",
+            ConsumerGroup = "orders-demo",
+            StartOffsetFromBeginning = true,
+            SecurityProtocol = SecurityProtocol.Plaintext
+        },
+        (string key, string value) => new MyRecord
+        {
+            Key = key,
+            Value = value
+        })
+    .WithKafkaDestination(
+        new KafkaDestinationOptions
+        {
+            BootstrapServers = "localhost:9092",
+            TopicName = "orders-out",
+            SecurityProtocol = SecurityProtocol.Plaintext
+        },
+        record => new Message<string, string>
+        {
+            Key = record.Key,
+            Value = record.Value
+        })
+    .Build();
+```
+
+## Local Example Environment Variables
+
+The example apps support a small environment-variable surface:
+
+- `PIPELINEZ_EXAMPLE_BOOTSTRAP_SERVERS`
+- `PIPELINEZ_EXAMPLE_KAFKA_IMAGE`
+- `PIPELINEZ_EXAMPLE_KAFKA_STARTUP_TIMEOUT_SECONDS`
+- `PIPELINEZ_EXAMPLE_KAFKA_REUSE_CONTAINER`
+- `PIPELINEZ_EXAMPLE_SOURCE_TOPIC`
+- `PIPELINEZ_EXAMPLE_DESTINATION_TOPIC`
+- `PIPELINEZ_EXAMPLE_CONSUMER_GROUP`
+- `PIPELINEZ_EXAMPLE_MESSAGE_COUNT`
+
+If `PIPELINEZ_EXAMPLE_BOOTSTRAP_SERVERS` is not set, the examples start a local Kafka container automatically.
+
+## Important Behaviors
+
+- Kafka support lives in the separate `Pipelinez.Kafka` assembly.
+- `StartOffsetFromBeginning` affects new consumer groups without committed offsets.
+- committed offsets are resumed normally when they already exist.
+- distributed Kafka execution is available when you opt into `PipelineExecutionMode.Distributed`.
+
+## Next Steps
+
+- read [Kafka Transport](../transports/kafka.md)
+- read [Distributed Execution](../guides/distributed-execution.md)
+- read [Troubleshooting](../operations/troubleshooting.md)

--- a/docs/guides/dead-lettering.md
+++ b/docs/guides/dead-lettering.md
@@ -1,0 +1,66 @@
+# Dead-Lettering
+
+Audience: application developers who want to preserve failed records for later inspection or replay.
+
+## What This Covers
+
+- `PipelineErrorAction.DeadLetter`
+- dead-letter destinations
+- `PipelineDeadLetterRecord<T>`
+- dead-letter events
+
+## In-Memory Dead-Lettering
+
+```csharp
+using Pipelinez.Core.DeadLettering;
+using Pipelinez.Core.ErrorHandling;
+
+var deadLetters = new InMemoryDeadLetterDestination<MyRecord>();
+
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .WithInMemorySource(new object())
+    .AddSegment(new MySegment(), new object())
+    .WithInMemoryDestination("config")
+    .WithDeadLetterDestination(deadLetters)
+    .WithErrorHandler(_ => PipelineErrorAction.DeadLetter)
+    .Build();
+```
+
+## What A Dead-Letter Record Contains
+
+`PipelineDeadLetterRecord<T>` preserves:
+
+- the original record
+- `PipelineFaultState`
+- metadata
+- segment history
+- retry history
+- distribution context
+- created and dead-lettered timestamps
+
+## Dead-Letter Events
+
+```csharp
+pipeline.OnPipelineRecordDeadLettered += (_, args) =>
+{
+    Console.WriteLine(
+        $"Dead-lettered {args.Record.Id} from {args.DeadLetterRecord.Fault.ComponentName}");
+};
+
+pipeline.OnPipelineDeadLetterWriteFailed += (_, args) =>
+{
+    Console.WriteLine(args.Exception.Message);
+};
+```
+
+## Important Behaviors
+
+- dead-lettering happens in the terminal fault-handling path
+- a faulted record is treated as handled after a successful dead-letter write
+- dead-lettered records do not raise the normal completion event
+- if `DeadLetter` is chosen without a configured dead-letter destination, the pipeline faults
+
+## Related Docs
+
+- [Error Handling](error-handling.md)
+- [Kafka Transport](../transports/kafka.md)

--- a/docs/guides/distributed-execution.md
+++ b/docs/guides/distributed-execution.md
@@ -1,0 +1,66 @@
+# Distributed Execution
+
+Audience: application developers running multiple workers against a distributed-capable source.
+
+## What This Covers
+
+- `PipelineExecutionMode.Distributed`
+- `PipelineHostOptions`
+- `GetRuntimeContext()`
+- worker and partition events
+- Kafka as the current distributed transport
+
+## Enable Distributed Mode
+
+```csharp
+using Pipelinez.Core.Distributed;
+
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .UseHostOptions(new PipelineHostOptions
+    {
+        ExecutionMode = PipelineExecutionMode.Distributed,
+        InstanceId = Environment.MachineName,
+        WorkerId = $"orders-{Guid.NewGuid():N}"
+    })
+    .WithKafkaSource(...)
+    .WithKafkaDestination(...)
+    .Build();
+```
+
+## Inspect Runtime Context
+
+```csharp
+var runtime = pipeline.GetRuntimeContext();
+
+Console.WriteLine(runtime.WorkerId);
+Console.WriteLine(runtime.ExecutionMode);
+Console.WriteLine(runtime.OwnedPartitions.Count);
+```
+
+## Observe Ownership Changes
+
+```csharp
+pipeline.OnPartitionsAssigned += (_, args) =>
+{
+    Console.WriteLine(
+        $"Assigned {args.Partitions.Count} partitions to {args.RuntimeContext.WorkerId}");
+};
+
+pipeline.OnPartitionDraining += (_, args) =>
+{
+    Console.WriteLine($"Draining {args.Partition.LeaseId}");
+};
+```
+
+## Important Behaviors
+
+- distributed mode requires a source that supports distributed ownership
+- Kafka is the currently implemented distributed transport
+- `GetStatus()` and `GetRuntimeContext()` both expose ownership and execution information
+- partition drain and execution-state events are intended for observability, not direct transport control
+
+## Related Docs
+
+- [Kafka Transport](../transports/kafka.md)
+- [Operational Tooling](operational-tooling.md)
+- [Architecture: Kafka Internals](../architecture/kafka.md)

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -1,0 +1,75 @@
+# Error Handling
+
+Audience: application developers deciding what should happen when a record faults.
+
+## What This Covers
+
+- default fault behavior
+- `WithErrorHandler(...)`
+- `PipelineErrorAction`
+- how error handling interacts with retry and dead-lettering
+
+## Default Behavior
+
+If no custom error handler is configured, a faulted record causes the pipeline to stop.
+
+## Configure An Error Handler
+
+```csharp
+using Pipelinez.Core.ErrorHandling;
+
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .WithInMemorySource(new object())
+    .AddSegment(new MySegment(), new object())
+    .WithInMemoryDestination("config")
+    .WithErrorHandler(context =>
+    {
+        if (context.RetryExhausted)
+        {
+            return PipelineErrorAction.DeadLetter;
+        }
+
+        return PipelineErrorAction.StopPipeline;
+    })
+    .Build();
+```
+
+## Available Actions
+
+- `SkipRecord`
+  stop processing the current faulted record and continue later records
+- `DeadLetter`
+  write the faulted record to the configured dead-letter destination
+- `StopPipeline`
+  fault and stop the runtime
+- `Rethrow`
+  fault the runtime and surface the original exception path
+
+## What You Get In `PipelineErrorContext<T>`
+
+- `Exception`
+- `Record`
+- `Container`
+- `Fault`
+- `ComponentName`
+- `ComponentKind`
+- `RetryHistory`
+- `RetryAttemptCount`
+- `RetryExhausted`
+- `CancellationToken`
+
+## Fault Event Example
+
+```csharp
+pipeline.OnPipelineRecordFaulted += (_, args) =>
+{
+    Console.WriteLine(
+        $"Record faulted in {args.Fault.ComponentName}: {args.Fault.Exception.Message}");
+};
+```
+
+## Related Docs
+
+- [Retry](retry.md)
+- [Dead-Lettering](dead-lettering.md)
+- [Troubleshooting](../operations/troubleshooting.md)

--- a/docs/guides/flow-control.md
+++ b/docs/guides/flow-control.md
@@ -1,0 +1,74 @@
+# Flow Control
+
+Audience: application developers publishing records manually into a busy pipeline.
+
+## What This Covers
+
+- pipeline saturation behavior
+- `PipelineFlowControlOptions`
+- `PipelinePublishOptions`
+- `PipelinePublishResult`
+
+## Configure Flow Control
+
+```csharp
+using Pipelinez.Core.FlowControl;
+using Pipelinez.Core.Performance;
+
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .UsePerformanceOptions(new PipelinePerformanceOptions
+    {
+        SourceExecution = new PipelineExecutionOptions { BoundedCapacity = 100 },
+        DestinationExecution = new PipelineExecutionOptions { BoundedCapacity = 100 }
+    })
+    .UseFlowControlOptions(new PipelineFlowControlOptions
+    {
+        OverflowPolicy = PipelineOverflowPolicy.Wait,
+        PublishTimeout = TimeSpan.FromSeconds(5),
+        SaturationWarningThreshold = 0.8
+    })
+    .WithInMemorySource(new object())
+    .WithInMemoryDestination("config")
+    .Build();
+```
+
+## Per-Publish Override
+
+```csharp
+var result = await pipeline.PublishAsync(
+    new MyRecord(),
+    new PipelinePublishOptions
+    {
+        Timeout = TimeSpan.FromSeconds(2),
+        OverflowPolicyOverride = PipelineOverflowPolicy.Reject
+    });
+
+if (!result.Accepted)
+{
+    Console.WriteLine(result.Reason);
+}
+```
+
+## Overflow Policies
+
+- `Wait`
+  wait for capacity
+- `Reject`
+  reject the publish immediately when saturated
+- `Cancel`
+  allow a cancellation token to end the wait
+
+## Observability
+
+Flow-control signals are exposed through:
+
+- `GetStatus().FlowControlStatus`
+- `OnSaturationChanged`
+- `OnPublishRejected`
+- publish wait and rejection counters in `GetPerformanceSnapshot()`
+
+## Related Docs
+
+- [Lifecycle](lifecycle.md)
+- [Performance](performance.md)
+- [Operational Tooling](operational-tooling.md)

--- a/docs/guides/lifecycle.md
+++ b/docs/guides/lifecycle.md
@@ -1,0 +1,64 @@
+# Lifecycle
+
+Audience: application developers working with pipeline startup, publishing, and shutdown behavior.
+
+## What This Covers
+
+- `Build()`
+- `StartPipelineAsync()`
+- `PublishAsync(...)`
+- `CompleteAsync()`
+- `Completion`
+
+## Basic Lifecycle
+
+```csharp
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .WithInMemorySource(new object())
+    .WithInMemoryDestination("config")
+    .Build();
+
+await pipeline.StartPipelineAsync();
+await pipeline.PublishAsync(new MyRecord());
+await pipeline.CompleteAsync();
+await pipeline.Completion;
+```
+
+## Lifecycle Phases
+
+1. Build the pipeline.
+2. Start the pipeline.
+3. Publish records or let the configured source run.
+4. Complete the pipeline when no more records should enter.
+5. Await `Completion` for full shutdown.
+
+## Important Behaviors
+
+- `StartPipelineAsync()` is async and should be awaited.
+- `PublishAsync(...)` before start throws.
+- `CompleteAsync()` before start throws.
+- starting twice throws.
+- `Completion` represents the full pipeline run, not just one internal block.
+- `CompleteAsync()` waits for downstream work to finish rather than only stopping ingress.
+
+## Manual Publish With Flow Control
+
+```csharp
+var result = await pipeline.PublishAsync(
+    new MyRecord(),
+    new PipelinePublishOptions
+    {
+        Timeout = TimeSpan.FromSeconds(2)
+    });
+
+if (!result.Accepted)
+{
+    Console.WriteLine(result.Reason);
+}
+```
+
+## Related Docs
+
+- [In-Memory Pipeline](../getting-started/in-memory.md)
+- [Flow Control](flow-control.md)
+- [Error Handling](error-handling.md)

--- a/docs/guides/operational-tooling.md
+++ b/docs/guides/operational-tooling.md
@@ -1,0 +1,79 @@
+# Operational Tooling
+
+Audience: operators and application developers integrating Pipelinez into hosted services.
+
+## What This Covers
+
+- health snapshots
+- operational snapshots
+- health-check integration
+- runtime metrics
+- correlation IDs
+
+## Enable Operational Features
+
+```csharp
+using Pipelinez.Core.Operational;
+
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .UseOperationalOptions(new PipelineOperationalOptions
+    {
+        EnableHealthChecks = true,
+        EnableMetrics = true,
+        EnableCorrelationIds = true,
+        DeadLetterDegradedThreshold = 1,
+        PublishRejectionDegradedThreshold = 1
+    })
+    .WithInMemorySource(new object())
+    .WithInMemoryDestination("config")
+    .Build();
+```
+
+## Read Health And Operational Snapshots
+
+```csharp
+var health = pipeline.GetHealthStatus();
+var snapshot = pipeline.GetOperationalSnapshot();
+
+Console.WriteLine(health.State);
+Console.WriteLine(snapshot.Performance.RecordsPerSecond);
+Console.WriteLine(snapshot.LastRecordCompletedAtUtc);
+```
+
+## ASP.NET Core Health Checks
+
+```csharp
+using Pipelinez.Core.Operational;
+
+builder.Services.AddSingleton(pipeline);
+builder.Services.AddHealthChecks()
+    .AddCheck("orders-pipeline", new PipelineHealthCheck<MyRecord>(pipeline));
+```
+
+## Metrics
+
+Pipelinez emits runtime metrics through the `Pipelinez.Runtime` meter.
+
+Example OpenTelemetry registration:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(metrics =>
+    {
+        metrics.AddMeter("Pipelinez.Runtime");
+    });
+```
+
+## Correlation IDs
+
+When enabled, Pipelinez stamps a correlation ID into metadata using:
+
+- `pipelinez.correlation.id`
+
+This is surfaced through event diagnostic payloads so logs and incidents can be traced across retry, fault, and dead-letter behavior.
+
+## Related Docs
+
+- [Troubleshooting](../operations/troubleshooting.md)
+- [Distributed Execution](distributed-execution.md)
+- [Architecture: Testing](../architecture/testing.md)

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -1,0 +1,67 @@
+# Performance
+
+Audience: application developers tuning throughput and understanding runtime metrics.
+
+## What This Covers
+
+- `UsePerformanceOptions(...)`
+- `PipelineExecutionOptions`
+- batching
+- `GetPerformanceSnapshot()`
+
+## Configure Execution
+
+```csharp
+using Pipelinez.Core.Performance;
+
+var pipeline = Pipeline<MyRecord>.New("high-throughput")
+    .UsePerformanceOptions(new PipelinePerformanceOptions
+    {
+        DefaultSegmentExecution = new PipelineExecutionOptions
+        {
+            BoundedCapacity = 10_000,
+            DegreeOfParallelism = Environment.ProcessorCount,
+            EnsureOrdered = false
+        },
+        DestinationBatching = new PipelineBatchingOptions
+        {
+            BatchSize = 250,
+            MaxBatchDelay = TimeSpan.FromMilliseconds(50)
+        }
+    })
+    .WithInMemorySource(new object())
+    .AddSegment(new MySegment(), new object())
+    .WithInMemoryDestination("config")
+    .Build();
+```
+
+## Read A Snapshot
+
+```csharp
+var snapshot = pipeline.GetPerformanceSnapshot();
+
+Console.WriteLine(snapshot.RecordsPerSecond);
+Console.WriteLine(snapshot.TotalRecordsCompleted);
+Console.WriteLine(snapshot.AverageEndToEndLatency);
+```
+
+## Important Tradeoffs
+
+- increasing `DegreeOfParallelism` can improve throughput
+- disabling `EnsureOrdered` can change observable completion order
+- batching improves throughput at the cost of per-record latency
+- flow-control and performance tuning work together, especially through bounded capacities
+
+## Benchmarks
+
+The repo includes a benchmark project:
+
+```bash
+dotnet run -c Release --project src/benchmarks/Pipelinez.Benchmarks
+```
+
+## Related Docs
+
+- [Flow Control](flow-control.md)
+- [Operational Tooling](operational-tooling.md)
+- [Benchmark README](../../src/benchmarks/Pipelinez.Benchmarks/README.md)

--- a/docs/guides/retry.md
+++ b/docs/guides/retry.md
@@ -1,0 +1,71 @@
+# Retry
+
+Audience: application developers handling transient failures in segments or destinations.
+
+## What This Covers
+
+- pipeline-wide retry options
+- component overrides
+- retry events
+- retry exhaustion behavior
+
+## Pipeline-Wide Retry
+
+```csharp
+using Pipelinez.Core.Retry;
+
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .UseRetryOptions(new PipelineRetryOptions<MyRecord>
+    {
+        DefaultSegmentPolicy = PipelineRetryPolicy<MyRecord>
+            .ExponentialBackoff(
+                maxAttempts: 5,
+                initialDelay: TimeSpan.FromMilliseconds(100),
+                maxDelay: TimeSpan.FromSeconds(3),
+                useJitter: true)
+            .Handle<TimeoutException>(),
+        DestinationPolicy = PipelineRetryPolicy<MyRecord>
+            .FixedDelay(maxAttempts: 3, delay: TimeSpan.FromSeconds(1))
+    })
+    .WithInMemorySource(new object())
+    .AddSegment(new MySegment(), new object())
+    .WithInMemoryDestination("config")
+    .Build();
+```
+
+## Per-Component Override
+
+```csharp
+var retryPolicy = PipelineRetryPolicy<MyRecord>
+    .FixedDelay(maxAttempts: 3, delay: TimeSpan.FromMilliseconds(250))
+    .Handle<TimeoutException>();
+
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .WithInMemorySource(new object())
+    .AddSegment(new MySegment(), new object(), retryPolicy)
+    .WithInMemoryDestination("config")
+    .Build();
+```
+
+## Retry Events
+
+```csharp
+pipeline.OnPipelineRecordRetrying += (_, args) =>
+{
+    Console.WriteLine(
+        $"{args.ComponentName} retry {args.AttemptNumber}/{args.MaxAttempts} after {args.Delay}.");
+};
+```
+
+## Important Behaviors
+
+- retries happen before terminal error handling
+- successful recovery does not leave the record in a faulted state
+- exhausted retries flow into the normal error-handler path
+- retry history is stored on `PipelineContainer<T>.RetryHistory`
+
+## Related Docs
+
+- [Error Handling](error-handling.md)
+- [Dead-Lettering](dead-lettering.md)
+- [Operational Tooling](operational-tooling.md)

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,0 +1,152 @@
+# Troubleshooting
+
+Audience: application developers and operators diagnosing common Pipelinez issues.
+
+## Publish Before Start
+
+### Symptom
+
+`PublishAsync(...)` throws before any record is accepted.
+
+### Likely Cause
+
+The pipeline was built but never started.
+
+### Fix
+
+Call `StartPipelineAsync()` before publishing records.
+
+## Start Called Twice
+
+### Symptom
+
+`StartPipelineAsync()` throws on the second call.
+
+### Likely Cause
+
+The runtime is intentionally guarded against double-start.
+
+### Fix
+
+Start the pipeline once and share the running instance.
+
+## Pipeline Never Finishes
+
+### Symptom
+
+`Completion` does not finish when you expect it to.
+
+### Likely Cause
+
+The pipeline is still accepting work or downstream work is still in flight.
+
+### Fix
+
+- call `CompleteAsync()` when ingress is done
+- then await `Completion`
+
+## Retry Exhaustion Leads To Fault Handling
+
+### Symptom
+
+A record still faults even though retry is configured.
+
+### Likely Cause
+
+Retries were exhausted and control moved to the error-handler path.
+
+### Fix
+
+Inspect:
+
+- retry policy filters
+- `MaxAttempts`
+- `OnPipelineRecordRetrying`
+- `PipelineErrorContext<T>`
+
+## DeadLetter Returned Without A Destination
+
+### Symptom
+
+The pipeline faults when the error handler returns `DeadLetter`.
+
+### Likely Cause
+
+No dead-letter destination was configured.
+
+### Fix
+
+Configure:
+
+- `WithDeadLetterDestination(...)`
+- or `WithKafkaDeadLetterDestination(...)`
+
+## Kafka Disconnect Log With `FAIL`
+
+### Symptom
+
+Kafka test or example output includes a log line containing `FAIL` and a broker disconnect.
+
+### Likely Cause
+
+This is usually a `librdkafka` client log emitted during broker shutdown, teardown, or transient disconnect handling, not a failed xUnit assertion.
+
+### Fix
+
+If tests still pass, treat it as client logging unless accompanied by actual test failures.
+
+## Docker Kafka Example Will Not Start
+
+### Symptom
+
+The Kafka example hangs or times out during startup.
+
+### Likely Cause
+
+Docker is not available locally or the selected image could not be started.
+
+### Fix
+
+- verify Docker is running
+- retry the example
+- set `PIPELINEZ_EXAMPLE_BOOTSTRAP_SERVERS` to use an existing broker instead
+
+## Distributed Worker Owns No Partitions
+
+### Symptom
+
+`GetRuntimeContext().OwnedPartitions` is empty in distributed mode.
+
+### Likely Cause
+
+Possible causes:
+
+- the source does not currently own partitions
+- another worker owns the available partitions
+- the source is not a distributed-capable transport
+
+### Fix
+
+- verify the pipeline is using Kafka
+- verify `PipelineExecutionMode.Distributed` is enabled
+- inspect assignment events such as `OnPartitionsAssigned`
+
+## StartOffsetFromBeginning Did Not Replay Existing Data
+
+### Symptom
+
+A Kafka pipeline does not replay old messages even though `StartOffsetFromBeginning = true`.
+
+### Likely Cause
+
+The consumer group already has committed offsets.
+
+### Fix
+
+Use a new consumer group when you want replay-from-beginning behavior for an existing topic.
+
+## Related Docs
+
+- [Lifecycle](../guides/lifecycle.md)
+- [Error Handling](../guides/error-handling.md)
+- [Kafka](../transports/kafka.md)

--- a/docs/transports/kafka.md
+++ b/docs/transports/kafka.md
@@ -1,0 +1,130 @@
+# Kafka
+
+Audience: application developers and operators using the Kafka transport extension.
+
+## What This Covers
+
+- Kafka source and destination setup
+- local Docker-backed development
+- dead-lettering
+- distributed execution
+- partition-aware scaling
+
+## Current Transport Status
+
+Kafka is the only transport extension currently implemented in this repository.
+
+Kafka support lives in:
+
+- `src/Pipelinez.Kafka`
+
+## Basic Configuration
+
+```csharp
+using Confluent.Kafka;
+using Pipelinez.Kafka.Configuration;
+
+var sourceOptions = new KafkaSourceOptions
+{
+    BootstrapServers = "localhost:9092",
+    TopicName = "orders-in",
+    ConsumerGroup = "orders-workers",
+    StartOffsetFromBeginning = true,
+    SecurityProtocol = SecurityProtocol.Plaintext
+};
+
+var destinationOptions = new KafkaDestinationOptions
+{
+    BootstrapServers = "localhost:9092",
+    TopicName = "orders-out",
+    SecurityProtocol = SecurityProtocol.Plaintext
+};
+```
+
+## Builder Example
+
+```csharp
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .WithKafkaSource(
+        sourceOptions,
+        (string key, string value) => new MyRecord { Key = key, Value = value })
+    .WithKafkaDestination(
+        destinationOptions,
+        record => new Message<string, string>
+        {
+            Key = record.Key,
+            Value = record.Value
+        })
+    .Build();
+```
+
+## Dead-Letter Topic Example
+
+```csharp
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .WithKafkaSource(sourceOptions, (string key, string value) => new MyRecord { Key = key, Value = value })
+    .WithKafkaDestination(destinationOptions, record => new Message<string, string> { Key = record.Key, Value = record.Value })
+    .WithKafkaDeadLetterDestination(
+        new KafkaDestinationOptions
+        {
+            BootstrapServers = "localhost:9092",
+            TopicName = "orders-dead-letter",
+            SecurityProtocol = SecurityProtocol.Plaintext
+        },
+        deadLetter => new Message<string, string>
+        {
+            Key = deadLetter.Record.Key,
+            Value = deadLetter.Record.Value
+        })
+    .Build();
+```
+
+## Partition-Aware Scaling
+
+```csharp
+var sourceOptions = new KafkaSourceOptions
+{
+    BootstrapServers = "localhost:9092",
+    TopicName = "orders-in",
+    ConsumerGroup = "orders-workers",
+    SecurityProtocol = SecurityProtocol.Plaintext,
+    PartitionScaling = new KafkaPartitionScalingOptions
+    {
+        ExecutionMode = KafkaPartitionExecutionMode.ParallelizeAcrossPartitions,
+        MaxConcurrentPartitions = 4,
+        MaxInFlightPerPartition = 1,
+        RebalanceMode = KafkaPartitionRebalanceMode.DrainAndYield
+    }
+};
+```
+
+Important rules:
+
+- `PreservePartitionOrder` keeps `MaxInFlightPerPartition` at `1`
+- `RelaxOrderingWithinPartition` is the explicit opt-in mode for more than one in-flight record per partition
+
+## Local Development
+
+The repository examples use Docker/Testcontainers for local Kafka startup.
+
+Fastest path:
+
+```bash
+dotnet run --project src/examples/Example.Kafka
+```
+
+If you want to connect to an existing broker instead of starting a container, set:
+
+- `PIPELINEZ_EXAMPLE_BOOTSTRAP_SERVERS`
+
+## Offset Behavior
+
+- committed offsets are resumed when they already exist
+- `StartOffsetFromBeginning` affects new consumer groups without stored offsets
+- completion drives explicit offset storage rather than immediate consume-time storage
+
+## Related Docs
+
+- [Getting Started: Kafka Pipeline](../getting-started/kafka.md)
+- [Distributed Execution](../guides/distributed-execution.md)
+- [Troubleshooting](../operations/troubleshooting.md)


### PR DESCRIPTION
## Summary

- Added a full layered documentation structure under `docs/`
- Added getting-started guides for in-memory and Kafka-backed pipelines
- Added focused guides for lifecycle, error handling, retry, dead-lettering, flow control, distributed execution, performance, and operational tooling
- Added Kafka transport documentation, troubleshooting guidance, and deeper architecture docs for runtime, Kafka internals, and testing
- Updated the root README and overview to link into the expanded docs set and corrected the license note

## Validation

- [x] `dotnet build src/Pipelinez.sln`
- [ ] `dotnet test src/Pipelinez.sln --logger "console;verbosity=minimal"`

## Public API

- [x] No public API changes
- [ ] Public API changes were intentional and the approved baselines were updated
- [ ] New unstable public APIs are marked preview
- [ ] Obsoletions include a migration path

## Documentation

- [ ] No documentation updates were needed
- [x] Consumer-facing docs were updated for behavior or API changes

Docs added or updated in this PR include:
- `docs/README.md`
- `docs/getting-started/*`
- `docs/guides/*`
- `docs/transports/kafka.md`
- `docs/operations/troubleshooting.md`
- `docs/architecture/*`
- `README.md`
- `docs/Overview.md`