### PR TITLE
Adding packaging components

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -38,3 +38,13 @@ jobs:
 
       - name: Test
         run: dotnet test src/Pipelinez.sln --configuration Release --no-build --logger "console;verbosity=minimal"
+
+      - name: Pack Pipelinez
+        run: dotnet pack src/Pipelinez/Pipelinez.csproj --configuration Release --no-build -o artifacts/packages -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+
+      - name: Pack Pipelinez.Kafka
+        run: dotnet pack src/Pipelinez.Kafka/Pipelinez.Kafka.csproj --configuration Release --no-build -o artifacts/packages -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+
+      - name: Validate Packages
+        shell: pwsh
+        run: ./scripts/Validate-Packages.ps1 -PackageDirectory artifacts/packages

--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -41,3 +41,13 @@ jobs:
 
       - name: Test
         run: dotnet test src/Pipelinez.sln --configuration Release --no-build --logger "console;verbosity=minimal"
+
+      - name: Pack Pipelinez
+        run: dotnet pack src/Pipelinez/Pipelinez.csproj --configuration Release --no-build -o artifacts/packages -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+
+      - name: Pack Pipelinez.Kafka
+        run: dotnet pack src/Pipelinez.Kafka/Pipelinez.Kafka.csproj --configuration Release --no-build -o artifacts/packages -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+
+      - name: Validate Packages
+        shell: pwsh
+        run: ./scripts/Validate-Packages.ps1 -PackageDirectory artifacts/packages

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ msbuild.err
 msbuild.wrn
 /todo/
 /BenchmarkDotNet.Artifacts/
+/artifacts/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,21 @@
+<Project>
+  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'Pipelinez' Or '$(MSBuildProjectName)' == 'Pipelinez.Kafka'">
+    <Authors>Ken Berg</Authors>
+    <Company>Pipelinez</Company>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/KenBerg75/Pipelinez</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/KenBerg75/Pipelinez</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(MSBuildProjectName)' == 'Pipelinez' Or '$(MSBuildProjectName)' == 'Pipelinez.Kafka'">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,29 @@ Pipelinez is a small .NET 8 framework for building record-processing pipelines w
 - correlation-aware diagnostics for records and faults
 - transport extensions such as Kafka
 
+## Installation
+
+Package distribution is now configured for:
+
+- `Pipelinez`
+- `Pipelinez.Kafka`
+
+Expected install commands for published packages:
+
+```bash
+dotnet add package Pipelinez
+```
+
+For Kafka support:
+
+```bash
+dotnet add package Pipelinez.Kafka
+```
+
+`Pipelinez.Kafka` depends on `Pipelinez`, so Kafka consumers do not need to add both explicitly unless they want to.
+
+Public publishing and release/version automation are tracked separately from the packaging work itself.
+
 ## How It Works
 
 A pipeline is built from three concepts:
@@ -480,6 +503,21 @@ dotnet run --project src/examples/Example.Kafka.DataGen
 ```
 
 The Kafka examples and Kafka integration tests use Docker/Testcontainers for local broker startup unless you provide an existing broker through environment variables.
+
+## Package Validation
+
+Generate local packages:
+
+```bash
+dotnet pack src/Pipelinez/Pipelinez.csproj -c Release -o artifacts/packages -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+dotnet pack src/Pipelinez.Kafka/Pipelinez.Kafka.csproj -c Release -o artifacts/packages -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+```
+
+Run the local package smoke test:
+
+```powershell
+./scripts/Validate-Packages.ps1 -PackageDirectory artifacts/packages
+```
 
 ## Status
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -40,6 +40,16 @@ Each record flows through the runtime inside a `PipelineContainer<T>`, which let
 - `docs/README.md`
   documentation index linking getting-started, guides, transport docs, operations docs, and architecture docs
 
+## Packaging Status
+
+The repository is now configured for package generation of:
+
+- `Pipelinez`
+- `Pipelinez.Kafka`
+
+That includes package metadata, XML docs, Source Link, symbol packages, and CI pack validation.
+Public release/version automation remains a separate concern.
+
 ## Core Runtime Design
 
 ### Pipeline Construction

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,10 +41,18 @@ This folder contains the main documentation set for Pipelinez.
 - [Kafka Internals](architecture/kafka.md)
 - [Testing](architecture/testing.md)
 
-## Current Installation Note
+## Installation Note
 
-Pipelinez is documented here as a source-first project. Package distribution work is planned separately, so the current getting-started guidance assumes:
+Packaging is now configured for:
 
-- cloning the repository
-- building the solution locally
-- or referencing the projects directly from source
+- `Pipelinez`
+- `Pipelinez.Kafka`
+
+Expected install commands for published packages are:
+
+```bash
+dotnet add package Pipelinez
+dotnet add package Pipelinez.Kafka
+```
+
+Release/version automation is tracked separately, so this docs set still focuses on the current repository and example workflow as the most directly runnable path.

--- a/docs/getting-started/in-memory.md
+++ b/docs/getting-started/in-memory.md
@@ -16,9 +16,15 @@ This guide walks through the smallest useful Pipelinez setup:
 ## Prerequisites
 
 - .NET 8 SDK
-- a local clone of this repository
+- either:
+  - a consumer project referencing the `Pipelinez` package when published
+  - or a local clone of this repository
 
-Pipeline packaging and distribution are tracked separately, so the current path is source-first.
+Expected package install command:
+
+```bash
+dotnet add package Pipelinez
+```
 
 ## Build The Solution
 

--- a/docs/getting-started/kafka.md
+++ b/docs/getting-started/kafka.md
@@ -10,7 +10,15 @@ This guide shows the shape of a Kafka-backed pipeline and how to run the shipped
 
 - .NET 8 SDK
 - Docker running locally
-- a local clone of this repository
+- either:
+  - a consumer project referencing the `Pipelinez.Kafka` package when published
+  - or a local clone of this repository
+
+Expected package install command:
+
+```bash
+dotnet add package Pipelinez.Kafka
+```
 
 ## Fastest Path: Run The Example
 

--- a/scripts/Validate-Packages.ps1
+++ b/scripts/Validate-Packages.ps1
@@ -1,0 +1,149 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PackageDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-PackageVersion {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ProjectPath
+    )
+
+    [xml]$project = Get-Content -Path $ProjectPath
+    $propertyGroups = @($project.Project.PropertyGroup)
+
+    foreach ($propertyName in 'PackageVersion', 'Version', 'VersionPrefix')
+    {
+        foreach ($group in $propertyGroups)
+        {
+            $value = $group.$propertyName
+            if ($null -ne $value -and -not [string]::IsNullOrWhiteSpace($value))
+            {
+                return $value.Trim()
+            }
+        }
+    }
+
+    return '1.0.0'
+}
+
+function Invoke-DotNet {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [string]$WorkingDirectory = (Get-Location).Path
+    )
+
+    & dotnet @Arguments | Out-Host
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw "dotnet $($Arguments -join ' ') failed."
+    }
+}
+
+$resolvedPackageDirectory = (Resolve-Path -Path $PackageDirectory).Path
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$coreProjectPath = Join-Path (Join-Path $repoRoot 'src') (Join-Path 'Pipelinez' 'Pipelinez.csproj')
+$kafkaProjectPath = Join-Path (Join-Path $repoRoot 'src') (Join-Path 'Pipelinez.Kafka' 'Pipelinez.Kafka.csproj')
+
+$coreVersion = Get-PackageVersion -ProjectPath $coreProjectPath
+$kafkaVersion = Get-PackageVersion -ProjectPath $kafkaProjectPath
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("pipelinez-package-smoke-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tempRoot | Out-Null
+
+try
+{
+    $nugetConfigPath = Join-Path $tempRoot 'NuGet.Config'
+    $packageSourceValue = $resolvedPackageDirectory.Replace('\', '/')
+    @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local" value="$packageSourceValue" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+"@ | Set-Content -Path $nugetConfigPath
+
+    $coreSmokeDirectory = Join-Path $tempRoot 'CoreSmoke'
+    Invoke-DotNet -Arguments @('new', 'console', '--framework', 'net8.0', '--output', $coreSmokeDirectory)
+    Invoke-DotNet -Arguments @('add', (Join-Path $coreSmokeDirectory 'CoreSmoke.csproj'), 'package', 'Pipelinez', '--version', $coreVersion, '--source', $resolvedPackageDirectory)
+    @"
+using Pipelinez.Core;
+using Pipelinez.Core.Record;
+
+var pipeline = Pipeline<SmokeRecord>.New("smoke")
+    .WithInMemorySource(new object())
+    .WithInMemoryDestination("config")
+    .Build();
+
+Console.WriteLine(pipeline.GetStatus().Status);
+
+public sealed class SmokeRecord : PipelineRecord
+{
+    public required string Id { get; init; }
+}
+"@ | Set-Content -Path (Join-Path $coreSmokeDirectory 'Program.cs')
+    Invoke-DotNet -Arguments @('build', (Join-Path $coreSmokeDirectory 'CoreSmoke.csproj'), '--configfile', $nugetConfigPath, '--configuration', 'Release')
+
+    $kafkaSmokeDirectory = Join-Path $tempRoot 'KafkaSmoke'
+    Invoke-DotNet -Arguments @('new', 'console', '--framework', 'net8.0', '--output', $kafkaSmokeDirectory)
+    Invoke-DotNet -Arguments @('add', (Join-Path $kafkaSmokeDirectory 'KafkaSmoke.csproj'), 'package', 'Pipelinez.Kafka', '--version', $kafkaVersion, '--source', $resolvedPackageDirectory)
+    @"
+using Confluent.Kafka;
+using Pipelinez.Core;
+using Pipelinez.Core.Record;
+using Pipelinez.Kafka;
+using Pipelinez.Kafka.Configuration;
+
+var sourceOptions = new KafkaSourceOptions
+{
+    BootstrapServers = "localhost:9092",
+    TopicName = "orders-in",
+    ConsumerGroup = "orders-smoke",
+    SecurityProtocol = SecurityProtocol.Plaintext
+};
+
+var destinationOptions = new KafkaDestinationOptions
+{
+    BootstrapServers = "localhost:9092",
+    TopicName = "orders-out",
+    SecurityProtocol = SecurityProtocol.Plaintext
+};
+
+var pipeline = Pipeline<KafkaSmokeRecord>.New("orders")
+    .WithKafkaSource(sourceOptions, (string key, string value) => new KafkaSmokeRecord
+    {
+        Key = key,
+        Value = value
+    })
+    .WithKafkaDestination(destinationOptions, record => new Message<string, string>
+    {
+        Key = record.Key,
+        Value = record.Value
+    })
+    .Build();
+
+Console.WriteLine(pipeline.GetStatus().Status);
+
+public sealed class KafkaSmokeRecord : PipelineRecord
+{
+    public required string Key { get; init; }
+    public required string Value { get; init; }
+}
+"@ | Set-Content -Path (Join-Path $kafkaSmokeDirectory 'Program.cs')
+    Invoke-DotNet -Arguments @('build', (Join-Path $kafkaSmokeDirectory 'KafkaSmoke.csproj'), '--configfile', $nugetConfigPath, '--configuration', 'Release')
+
+    Write-Host "Package smoke validation succeeded."
+}
+finally
+{
+    if (Test-Path $tempRoot)
+    {
+        Remove-Item -LiteralPath $tempRoot -Recurse -Force
+    }
+}

--- a/src/Pipelinez.Kafka/Kafka/Client/Producer/KafkaProducer.cs
+++ b/src/Pipelinez.Kafka/Kafka/Client/Producer/KafkaProducer.cs
@@ -50,8 +50,6 @@ internal class KafkaProducer<TRecordKey, TRecordValue> : IKafkaProducer<TRecordK
     /// </summary>
     /// <param name="builder"></param>
     /// <param name="options"></param>
-    /// <typeparam name="TKey">Type for the Key</typeparam>
-    /// <typeparam name="TValue">Type for the Value</typeparam>
     /// <returns></returns>
     private static ProducerBuilder<TRecordKey, TRecordValue> SetProducerSerializers(ProducerBuilder<TRecordKey, TRecordValue> builder,
         KafkaSchemaRegistryOptions? options)

--- a/src/Pipelinez.Kafka/PackageReadme.md
+++ b/src/Pipelinez.Kafka/PackageReadme.md
@@ -1,0 +1,58 @@
+# Pipelinez.Kafka
+
+Kafka transport extensions for Pipelinez.
+
+`Pipelinez.Kafka` adds:
+
+- `WithKafkaSource(...)`
+- `WithKafkaDestination(...)`
+- `WithKafkaDeadLetterDestination(...)`
+- Kafka configuration types
+- Kafka-backed distributed execution support
+- partition-aware scaling controls
+
+## Install
+
+```bash
+dotnet add package Pipelinez.Kafka
+```
+
+`Pipelinez.Kafka` depends on `Pipelinez`, so you do not need to add both explicitly unless you prefer to do so.
+
+## Quick Example
+
+```csharp
+using Confluent.Kafka;
+using Pipelinez.Core;
+using Pipelinez.Kafka;
+using Pipelinez.Kafka.Configuration;
+
+var pipeline = Pipeline<MyRecord>.New("orders")
+    .WithKafkaSource(
+        new KafkaSourceOptions
+        {
+            BootstrapServers = "localhost:9092",
+            TopicName = "orders-in",
+            ConsumerGroup = "orders-workers",
+            SecurityProtocol = SecurityProtocol.Plaintext
+        },
+        (string key, string value) => new MyRecord { Key = key, Value = value })
+    .WithKafkaDestination(
+        new KafkaDestinationOptions
+        {
+            BootstrapServers = "localhost:9092",
+            TopicName = "orders-out",
+            SecurityProtocol = SecurityProtocol.Plaintext
+        },
+        record => new Message<string, string>
+        {
+            Key = record.Key,
+            Value = record.Value
+        })
+    .Build();
+```
+
+## More Information
+
+- Repository: https://github.com/KenBerg75/Pipelinez
+- Kafka docs: https://github.com/KenBerg75/Pipelinez/blob/main/docs/transports/kafka.md

--- a/src/Pipelinez.Kafka/Pipelinez.Kafka.csproj
+++ b/src/Pipelinez.Kafka/Pipelinez.Kafka.csproj
@@ -5,6 +5,12 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <IsPackable>true</IsPackable>
+        <PackageId>Pipelinez.Kafka</PackageId>
+        <Title>Pipelinez.Kafka</Title>
+        <Description>Kafka transport extensions for Pipelinez, including Kafka-backed sources, destinations, dead-lettering, distributed execution, and partition-aware scaling.</Description>
+        <PackageTags>pipeline;kafka;confluent;messaging;distributed;dotnet</PackageTags>
+        <PackageReadmeFile>PackageReadme.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -16,6 +22,10 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Pipelinez\Pipelinez.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Include="PackageReadme.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 </Project>

--- a/src/Pipelinez/Core/Flow/IFlowSource.cs
+++ b/src/Pipelinez/Core/Flow/IFlowSource.cs
@@ -5,7 +5,7 @@ namespace Pipelinez.Core.Flow;
 /// <summary>
 /// Defines a source for a pipeline flow
 /// </summary>
-/// <typeparam name="TInput">Type this flow will publish</typeparam>
+/// <typeparam name="TOutput">Type this flow will publish</typeparam>
 public interface IFlowSource<TOutput>
 {
     IDisposable ConnectTo(IFlowDestination<TOutput> target, DataflowLinkOptions? options = null);

--- a/src/Pipelinez/Core/Pipeline.cs
+++ b/src/Pipelinez/Core/Pipeline.cs
@@ -38,7 +38,6 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     /// Initiates the build of a new pipeline with the specified PipelineRecord type
     /// </summary>
     /// <param name="pipelineName">Name of the pipeline</param>
-    /// <typeparam name="TPipelineRecord">Type of the record that will flow through the pipeline</typeparam>
     /// <returns></returns>
     public static PipelineBuilder<TPipelineRecord> New(string pipelineName)
     {

--- a/src/Pipelinez/Core/Segment/PipelineSegment.cs
+++ b/src/Pipelinez/Core/Segment/PipelineSegment.cs
@@ -36,7 +36,6 @@ public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecuti
     /// <summary>
     /// Initialize the TransformBlock
     /// </summary>
-    /// <param name="options"></param>
     private void InitializeTransformBlock()
     {
         Logger.LogTrace("Initializing Segment");

--- a/src/Pipelinez/PackageReadme.md
+++ b/src/Pipelinez/PackageReadme.md
@@ -1,0 +1,50 @@
+# Pipelinez
+
+Typed data pipelines for .NET.
+
+`Pipelinez` is the core runtime package. It provides:
+
+- typed records
+- sources, segments, and destinations
+- async startup and completion
+- fault handling and error policies
+- retry
+- dead-lettering
+- flow control
+- distributed execution abstractions
+- performance and operational tooling
+
+## Package Layout
+
+- `Pipelinez`
+  core runtime
+- `Pipelinez.Kafka`
+  Kafka transport extensions
+
+## Install
+
+```bash
+dotnet add package Pipelinez
+```
+
+## Quick Example
+
+```csharp
+using Pipelinez.Core;
+using Pipelinez.Core.Record;
+
+public sealed class OrderRecord : PipelineRecord
+{
+    public required string Id { get; init; }
+}
+
+var pipeline = Pipeline<OrderRecord>.New("orders")
+    .WithInMemorySource(new object())
+    .WithInMemoryDestination("in-memory")
+    .Build();
+```
+
+## More Information
+
+- Repository: https://github.com/KenBerg75/Pipelinez
+- Docs: https://github.com/KenBerg75/Pipelinez/tree/main/docs

--- a/src/Pipelinez/Pipelinez.csproj
+++ b/src/Pipelinez/Pipelinez.csproj
@@ -5,6 +5,12 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <IsPackable>true</IsPackable>
+        <PackageId>Pipelinez</PackageId>
+        <Title>Pipelinez</Title>
+        <Description>Typed data pipelines for .NET with explicit lifecycle, flow control, retry, dead-lettering, distributed execution, performance tuning, and operational tooling.</Description>
+        <PackageTags>pipeline;dataflow;etl;messaging;distributed;retry;observability;dotnet</PackageTags>
+        <PackageReadmeFile>PackageReadme.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -15,6 +21,10 @@
 
     <ItemGroup>
       <Folder Include="Manual\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Include="PackageReadme.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 </Project>

--- a/src/benchmarks/Pipelinez.Benchmarks/Pipelinez.Benchmarks.csproj
+++ b/src/benchmarks/Pipelinez.Benchmarks/Pipelinez.Benchmarks.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/examples/Example.Kafka.DataGen/Example.Kafka.DataGen.csproj
+++ b/src/examples/Example.Kafka.DataGen/Example.Kafka.DataGen.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/examples/Example.Kafka/Example.Kafka.csproj
+++ b/src/examples/Example.Kafka/Example.Kafka.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

- Added real package-generation support for `Pipelinez` and `Pipelinez.Kafka`
- Added shared packaging configuration, package metadata, Source Link, XML docs, and symbol package support
- Added package readmes for both library packages
- Added CI pack validation and a package smoke-test script that restores the generated packages into fresh consumer apps
- Updated docs to describe installation, package boundaries, and local package validation
- Fixed a few stale XML doc comments surfaced by enabling documentation-file generation

## Validation

- [x] `dotnet build src/Pipelinez.sln`
- [x] `dotnet test src/Pipelinez.sln --logger "console;verbosity=minimal"`

Additional validation completed:
- `dotnet pack src/Pipelinez/Pipelinez.csproj -c Release --no-build -o artifacts/packages -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg`
- `dotnet pack src/Pipelinez.Kafka/Pipelinez.Kafka.csproj -c Release --no-build -o artifacts/packages -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg`
- `./scripts/Validate-Packages.ps1 -PackageDirectory artifacts/packages`

## Public API

- [x] No public API changes
- [ ] Public API changes were intentional and the approved baselines were updated
- [ ] New unstable public APIs are marked preview
- [ ] Obsoletions include a migration path

Notes:
- This PR hardens packaging and distribution without changing the intended consumer API surface.
- The only code adjustments in runtime files were XML comment fixes needed for package-quality doc generation.

## Documentation

- [ ] No documentation updates were needed
- [x] Consumer-facing docs were updated for behavior or API changes

Docs updated in this PR include:
- package/install guidance in `README.md`
- packaging notes in `docs/README.md`
- getting-started install guidance in the in-memory and Kafka guides
- overview updates reflecting package-generation support