### PR TITLE
Update readme - Fix timing issue on error state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,36 @@
 # Pipelinez
 
-Typed data pipelines for .NET.
+Typed, observable record-processing pipelines for .NET.
 
-Pipelinez is a small .NET 8 framework for building record-processing pipelines with a consistent runtime model:
+Pipelinez is a .NET 8 library for building typed record-processing pipelines inside normal application code. It gives you a consistent way to move records from a source, through one or more processing steps, into a destination, with built-in lifecycle management, retries, dead-lettering, flow control, and runtime observability.
 
-- strongly typed records
-- pluggable sources, segments, and destinations
-- async startup and completion
-- fault tracking and configurable error policies
-- configurable retry policies for segments and destinations
-- dead-letter destinations for preserving failed records
-- explicit flow control and saturation observability
-- optional distributed execution for transport-backed sources
-- explicit performance tuning and runtime performance snapshots
-- health snapshots, health checks, and meter-based runtime metrics
-- correlation-aware diagnostics for records and faults
-- transport extensions such as Kafka
+If your application needs to ingest, enrich, transform, route, or publish records without hand-wiring the surrounding runtime behavior each time, Pipelinez is the layer that organizes that work.
+
+## What Pipelinez Is
+
+Pipelinez lets you define a pipeline as:
+
+- a `Source` that produces records
+- one or more `Segment`s that transform or enrich them
+- a `Destination` that writes the final result
+
+At runtime, Pipelinez manages the lifecycle, fault handling, retries, backpressure, diagnostics, and transport integration around that flow.
+
+## When To Use It
+
+Pipelinez is a good fit when you want to:
+
+- consume records from memory, Kafka, or another transport
+- apply one or more typed processing steps
+- route successful and failed records intentionally
+- observe runtime behavior with status, health, events, and metrics
+- keep pipeline logic testable without wiring TPL Dataflow and transport details by hand
+
+Pipelinez is not trying to replace large distributed stream-processing platforms. It is a focused .NET library for applications that want a typed, testable, observable pipeline runtime inside normal application code.
 
 ## Installation
 
-Package distribution is now configured for:
+Package generation is configured for:
 
 - `Pipelinez`
 - `Pipelinez.Kafka`
@@ -38,32 +49,11 @@ dotnet add package Pipelinez.Kafka
 
 `Pipelinez.Kafka` depends on `Pipelinez`, so Kafka consumers do not need to add both explicitly unless they want to.
 
-Public publishing and release/version automation are tracked separately from the packaging work itself.
-
-## How It Works
-
-A pipeline is built from three concepts:
-
-- `Source`
-  where records come from
-- `Segment`
-  one or more transformation steps
-- `Destination`
-  where processed records end up
-
-At runtime, records flow like this:
-
-`source -> segment -> segment -> destination`
-
-Each record is wrapped in a `PipelineContainer<T>` so the framework can carry:
-
-- the record payload
-- metadata
-- fault state
-- segment execution history
-- retry history
+Until public NuGet publishing is enabled, you can still build and pack the projects locally from this repository.
 
 ## Quick Example
+
+This example creates an in-memory pipeline that receives an `OrderRecord`, applies a discount, and completes through an in-memory destination.
 
 ```csharp
 using Pipelinez.Core;
@@ -102,13 +92,41 @@ await pipeline.CompleteAsync();
 await pipeline.Completion;
 ```
 
+## How It Works
+
+At a high level, records flow like this:
+
+`source -> segment -> segment -> destination`
+
+Each record is wrapped in a `PipelineContainer<T>` so the runtime can carry:
+
+- the record payload
+- metadata
+- fault state
+- segment execution history
+- retry history
+
+That container model is what allows Pipelinez to keep runtime behavior explicit without making every segment or destination manage its own bookkeeping.
+
+## Key Capabilities
+
+- typed records and pluggable sources, segments, and destinations
+- async startup, publish, completion, and shutdown behavior
+- configurable retry, error-handling, and dead-letter flows
+- explicit flow control, saturation visibility, and publish results
+- performance tuning, batching, and runtime performance snapshots
+- distributed execution and partition-aware Kafka scaling
+- health checks, metrics, correlation IDs, and runtime events
+
 ## Kafka Support
 
-Kafka support lives in the separate `Pipelinez.Kafka` assembly and extends the core builder with:
+Kafka support lives in the separate `Pipelinez.Kafka` package and adds:
 
-- `WithKafkaSource(...)`
-- `WithKafkaDestination(...)`
-- `WithKafkaDeadLetterDestination(...)`
+- Kafka source support
+- Kafka destination support
+- Kafka dead-letter destinations
+- distributed worker coordination
+- partition-aware scaling
 
 Example shape:
 
@@ -144,304 +162,31 @@ var pipeline = Pipeline<MyRecord>.New("kafka-pipeline")
     .Build();
 ```
 
-The repo also includes:
-
-- a runnable Kafka example in [`src/examples/Example.Kafka`](src/examples/Example.Kafka)
-- a Kafka data generator in [`src/examples/Example.Kafka.DataGen`](src/examples/Example.Kafka.DataGen)
-- Docker-backed Kafka integration tests in [`src/tests/Pipelinez.Kafka.Tests`](src/tests/Pipelinez.Kafka.Tests)
-
-Kafka source configuration now also supports explicit partition-aware scaling through `KafkaPartitionScalingOptions`, including:
-
-- preserving order within a partition
-- parallelizing across owned partitions
-- opt-in relaxed ordering within a partition
-- partition drain visibility during rebalance
-
-## Distributed Execution
-
-Pipelinez can run in `SingleProcess` mode or in explicit `Distributed` mode for distributed-capable sources such as Kafka.
-
-In distributed mode, the runtime surfaces:
-
-- worker identity through `PipelineHostOptions`
-- current owned partitions through `GetRuntimeContext()`
-- current partition execution state through `GetRuntimeContext()` and `GetStatus()`
-- worker lifecycle and rebalance events
-- partition drain and partition execution-state events
-- record-level distribution context on completion and fault events
-
-Example shape:
-
-```csharp
-using Pipelinez.Core.Distributed;
-
-var pipeline = Pipeline<MyRecord>.New("orders")
-    .UseHostOptions(new PipelineHostOptions
-    {
-        ExecutionMode = PipelineExecutionMode.Distributed,
-        InstanceId = Environment.MachineName,
-        WorkerId = $"orders-{Guid.NewGuid():N}"
-    })
-    .WithKafkaSource(...)
-    .WithKafkaDestination(...)
-    .Build();
-
-pipeline.OnPartitionsAssigned += (_, args) =>
-{
-    Console.WriteLine(
-        $"Worker {args.RuntimeContext.WorkerId} now owns {args.RuntimeContext.OwnedPartitions.Count} partitions.");
-};
-```
-
-Kafka-backed distributed execution is validated by multi-worker integration tests that scale workers in and out against a real Docker-hosted broker.
-
-For Kafka specifically, distributed execution now also exposes partition-aware scaling controls through `KafkaPartitionScalingOptions` so callers can choose whether to preserve partition order strictly or relax within-partition ordering deliberately.
-
-## Performance Tuning
-
-Pipelinez now exposes explicit throughput and execution controls through `UsePerformanceOptions(...)`.
-
-Available tuning areas include:
-
-- source, segment, and destination bounded capacity
-- segment degree of parallelism
-- ordered versus unordered segment execution
-- optional destination batching for batched destinations
-- runtime performance snapshots through `GetPerformanceSnapshot()`
-
-Example shape:
-
-```csharp
-using Pipelinez.Core.Performance;
-
-var pipeline = Pipeline<MyRecord>.New("high-throughput")
-    .UsePerformanceOptions(new PipelinePerformanceOptions
-    {
-        DefaultSegmentExecution = new PipelineExecutionOptions
-        {
-            BoundedCapacity = 10_000,
-            DegreeOfParallelism = Environment.ProcessorCount,
-            EnsureOrdered = false
-        }
-    })
-    .WithInMemorySource(new object())
-    .AddSegment(new MySegment(), new object())
-    .WithInMemoryDestination("config")
-    .Build();
-
-var snapshot = pipeline.GetPerformanceSnapshot();
-Console.WriteLine(snapshot.RecordsPerSecond);
-```
-
-Increasing parallelism or disabling ordering can improve throughput, but it can also change observable processing order. Those settings should be treated as explicit tradeoffs rather than passive defaults.
-
-## Flow Control
-
-Pipelinez now exposes explicit publish-time flow-control behavior in addition to component `BoundedCapacity` tuning.
-
-Flow control can be configured through:
-
-- `UseFlowControlOptions(...)`
-- `PublishAsync(record, PipelinePublishOptions)`
-
-Supported overflow behaviors include:
-
-- `PipelineOverflowPolicy.Wait`
-- `PipelineOverflowPolicy.Reject`
-- `PipelineOverflowPolicy.Cancel`
-
-Example shape:
-
-```csharp
-using Pipelinez.Core.FlowControl;
-
-var pipeline = Pipeline<MyRecord>.New("orders")
-    .UsePerformanceOptions(new PipelinePerformanceOptions
-    {
-        SourceExecution = new PipelineExecutionOptions { BoundedCapacity = 100 },
-        DestinationExecution = new PipelineExecutionOptions { BoundedCapacity = 100 }
-    })
-    .UseFlowControlOptions(new PipelineFlowControlOptions
-    {
-        OverflowPolicy = PipelineOverflowPolicy.Wait,
-        PublishTimeout = TimeSpan.FromSeconds(5),
-        SaturationWarningThreshold = 0.8
-    })
-    .WithInMemorySource(new object())
-    .WithInMemoryDestination("config")
-    .Build();
-
-var publishResult = await pipeline.PublishAsync(
-    new MyRecord(),
-    new PipelinePublishOptions
-    {
-        OverflowPolicyOverride = PipelineOverflowPolicy.Reject
-    });
-
-if (!publishResult.Accepted)
-{
-    Console.WriteLine($"Publish was not accepted: {publishResult.Reason}");
-}
-```
-
-The runtime now also surfaces flow pressure through `GetStatus().FlowControlStatus`, `OnSaturationChanged`, `OnPublishRejected`, and publish wait/rejection counters in `GetPerformanceSnapshot()`.
-
-## Retry Policies
-
-Pipelinez supports explicit retry policies for transient failures in segments and destinations.
-
-Retry configuration can be applied:
-
-- pipeline-wide through `UseRetryOptions(...)`
-- per segment through `AddSegment(..., retryPolicy)`
-- per destination through `WithDestination(..., retryPolicy)`
-
-Available policy styles include:
-
-- `PipelineRetryPolicy<T>.None()`
-- `PipelineRetryPolicy<T>.FixedDelay(...)`
-- `PipelineRetryPolicy<T>.ExponentialBackoff(...)`
-
-Example shape:
-
-```csharp
-using Pipelinez.Core.Retry;
-
-var pipeline = Pipeline<MyRecord>.New("orders")
-    .UseRetryOptions(new PipelineRetryOptions<MyRecord>
-    {
-        DefaultSegmentPolicy = PipelineRetryPolicy<MyRecord>
-            .ExponentialBackoff(
-                maxAttempts: 5,
-                initialDelay: TimeSpan.FromMilliseconds(100),
-                maxDelay: TimeSpan.FromSeconds(3),
-                useJitter: true)
-            .Handle<TimeoutException>(),
-        DestinationPolicy = PipelineRetryPolicy<MyRecord>.FixedDelay(
-            maxAttempts: 3,
-            delay: TimeSpan.FromSeconds(1))
-    })
-    .WithInMemorySource(new object())
-    .AddSegment(new MySegment(), new object())
-    .WithInMemoryDestination("config")
-    .Build();
-
-pipeline.OnPipelineRecordRetrying += (_, args) =>
-{
-    Console.WriteLine(
-        $"{args.ComponentName} retry {args.AttemptNumber}/{args.MaxAttempts} for {args.Record.Id}");
-};
-```
-
-Retry exhaustion flows into the existing `WithErrorHandler(...)` path, so consumers can still decide whether to skip, stop, or rethrow once the configured retry policy has been exhausted.
-
-## Dead-Lettering
-
-Pipelinez supports first-class dead-letter handling for faulted records.
-
-Dead-letter configuration can be applied through:
-
-- `WithDeadLetterDestination(...)`
-- `UseDeadLetterOptions(...)`
-- `WithKafkaDeadLetterDestination(...)`
-
-When an error handler returns `PipelineErrorAction.DeadLetter`, the runtime:
-
-- preserves the failed record in a `PipelineDeadLetterRecord<T>`
-- includes fault state, metadata, segment history, retry history, and distribution context
-- writes that envelope to the configured dead-letter destination
-- continues processing later records if the dead-letter write succeeds
-
-Example shape:
-
-```csharp
-using Pipelinez.Core.DeadLettering;
-
-var deadLetters = new InMemoryDeadLetterDestination<MyRecord>();
-
-var pipeline = Pipeline<MyRecord>.New("orders")
-    .WithInMemorySource(new object())
-    .AddSegment(new MySegment(), new object())
-    .WithInMemoryDestination("config")
-    .WithDeadLetterDestination(deadLetters)
-    .WithErrorHandler(_ => PipelineErrorAction.DeadLetter)
-    .Build();
-
-pipeline.OnPipelineRecordDeadLettered += (_, args) =>
-{
-    Console.WriteLine(
-        $"Dead-lettered {args.Record.Id} from {args.DeadLetterRecord.Fault.ComponentName}");
-};
-```
-
-Kafka-backed pipelines can route failures to a dead-letter topic through `WithKafkaDeadLetterDestination(...)`.
-
-## Operational Tooling
-
-Pipelinez now includes a first-class operational surface for hosts and operators.
-
-Available capabilities include:
-
-- `GetHealthStatus()`
-- `GetOperationalSnapshot()`
-- `PipelineHealthCheck<T>` for `Microsoft.Extensions.Diagnostics.HealthChecks`
-- meter-based runtime metrics under `Pipelinez.Runtime`
-- correlation IDs stamped into pipeline metadata and surfaced through event diagnostics
-
-Example shape:
-
-```csharp
-using Pipelinez.Core.Operational;
-
-var pipeline = Pipeline<MyRecord>.New("orders")
-    .UseOperationalOptions(new PipelineOperationalOptions
-    {
-        EnableHealthChecks = true,
-        EnableMetrics = true,
-        EnableCorrelationIds = true
-    })
-    .WithInMemorySource(new object())
-    .WithInMemoryDestination("config")
-    .Build();
-
-var health = pipeline.GetHealthStatus();
-var snapshot = pipeline.GetOperationalSnapshot();
-
-Console.WriteLine(health.State);
-Console.WriteLine(snapshot.Performance.RecordsPerSecond);
-```
-
-For OpenTelemetry-style metrics registration, add the `Pipelinez.Runtime` meter to your metrics pipeline.
-
-## Error Handling
-
-Pipelinez supports explicit fault handling through `WithErrorHandler(...)`.
-
-Available actions:
-
-- `SkipRecord`
-  continue processing later records
-- `DeadLetter`
-  preserve the failed record through the configured dead-letter destination and continue when that write succeeds
-- `StopPipeline`
-  fault and stop the pipeline
-- `Rethrow`
-  fault the pipeline and surface the original exception
-
-Public events include:
-
-- `OnPipelineRecordRetrying`
-- `OnSaturationChanged`
-- `OnPublishRejected`
-- `OnPipelineRecordCompleted`
-- `OnPipelineRecordFaulted`
-- `OnPipelineRecordDeadLettered`
-- `OnPipelineDeadLetterWriteFailed`
-- `OnPipelineFaulted`
-- `OnWorkerStarted`
-- `OnPartitionsAssigned`
-- `OnPartitionsRevoked`
-- `OnWorkerStopping`
+For a full walkthrough, see:
+
+- [`docs/getting-started/kafka.md`](docs/getting-started/kafka.md)
+- [`src/examples/Example.Kafka`](src/examples/Example.Kafka)
+- [`src/examples/Example.Kafka.DataGen`](src/examples/Example.Kafka.DataGen)
+- [`src/tests/Pipelinez.Kafka.Tests`](src/tests/Pipelinez.Kafka.Tests)
+
+## Learn More
+
+- New to Pipelinez: [`docs/getting-started/in-memory.md`](docs/getting-started/in-memory.md)
+- Using Kafka: [`docs/getting-started/kafka.md`](docs/getting-started/kafka.md)
+- Architecture overview: [`docs/Overview.md`](docs/Overview.md)
+- Runtime and transport internals: [`docs/README.md`](docs/README.md)
+- API compatibility policy: [`docs/ApiStability.md`](docs/ApiStability.md)
+
+Feature-specific guides:
+
+- lifecycle: [`docs/guides/lifecycle.md`](docs/guides/lifecycle.md)
+- error handling: [`docs/guides/error-handling.md`](docs/guides/error-handling.md)
+- retry: [`docs/guides/retry.md`](docs/guides/retry.md)
+- dead-lettering: [`docs/guides/dead-lettering.md`](docs/guides/dead-lettering.md)
+- flow control: [`docs/guides/flow-control.md`](docs/guides/flow-control.md)
+- distributed execution: [`docs/guides/distributed-execution.md`](docs/guides/distributed-execution.md)
+- performance: [`docs/guides/performance.md`](docs/guides/performance.md)
+- operational tooling: [`docs/guides/operational-tooling.md`](docs/guides/operational-tooling.md)
 
 ## Project Layout
 
@@ -455,20 +200,6 @@ Public events include:
   Kafka integration tests
 - [`src/benchmarks/Pipelinez.Benchmarks`](src/benchmarks/Pipelinez.Benchmarks)
   BenchmarkDotNet-based performance benchmarks
-- [`docs/README.md`](docs/README.md)
-  documentation index and guide map
-- [`docs/Overview.md`](docs/Overview.md)
-  deeper architectural overview
-- [`docs/ApiStability.md`](docs/ApiStability.md)
-  compatibility, stability, and public API change guidance
-
-## Documentation
-
-For task-oriented docs, start with:
-
-- [`docs/README.md`](docs/README.md)
-- [`docs/getting-started/in-memory.md`](docs/getting-started/in-memory.md)
-- [`docs/getting-started/kafka.md`](docs/getting-started/kafka.md)
 
 ## Running Locally
 
@@ -504,50 +235,34 @@ dotnet run --project src/examples/Example.Kafka.DataGen
 
 The Kafka examples and Kafka integration tests use Docker/Testcontainers for local broker startup unless you provide an existing broker through environment variables.
 
-## Package Validation
-
-Generate local packages:
-
-```bash
-dotnet pack src/Pipelinez/Pipelinez.csproj -c Release -o artifacts/packages -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
-dotnet pack src/Pipelinez.Kafka/Pipelinez.Kafka.csproj -c Release -o artifacts/packages -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
-```
-
-Run the local package smoke test:
-
-```powershell
-./scripts/Validate-Packages.ps1 -PackageDirectory artifacts/packages
-```
-
 ## Status
 
 Current implemented capabilities include:
 
 - async pipeline lifecycle
 - fault-aware record containers
-- segment execution history
-- configurable error policies
-- configurable retry policies with retry events and retry history
-- dead-letter destinations, dead-letter events, and dead-letter performance counters
-- configurable flow-control policies with saturation status and publish result handling
-- async destination execution
+- configurable retry, error-handling, and dead-letter flows
+- explicit flow control with publish result handling
 - distributed runtime mode and worker/partition observability
-- partition-aware Kafka scaling with partition execution state and drain events
-- performance tuning options, batching support, and runtime performance snapshots
-- operational health snapshots, health-check integration, runtime meter metrics, and correlation IDs
-- Kafka source and destination support
-- Docker-backed Kafka integration coverage, including multi-worker distributed tests
+- partition-aware Kafka scaling
+- performance tuning, batching, and runtime performance snapshots
+- operational health snapshots, health checks, metrics, and correlation IDs
+- Docker-backed Kafka integration coverage
 - public API approval tests and repository-level API stability guidance
 
 ## API Stability
 
-Pipelinez now treats the public API of `Pipelinez` and `Pipelinez.Kafka` as an intentional compatibility contract.
+Pipelinez treats the public API of `Pipelinez` and `Pipelinez.Kafka` as an intentional compatibility contract.
 
 - stable APIs are expected to remain source-compatible within the current major version
 - preview APIs should be explicitly marked and documented when introduced
 - public API approval tests protect both assemblies from accidental surface changes in normal PR and CI validation
 
 See [`docs/ApiStability.md`](docs/ApiStability.md) for the full policy and maintainer workflow.
+
+## Contributing
+
+Contributions are welcome. Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) for local setup, test expectations, and public API guidance.
 
 ## License
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -171,6 +171,7 @@ Important current semantics:
 - completing before start throws
 - `Completion` represents the pipeline run, not just one internal block
 - `CompleteAsync()` waits for downstream destination work before final completion
+- if the pipeline faults, `OnPipelineFaulted` is raised before `Completion` faults
 
 `Pipeline<T>` also tracks runtime state explicitly:
 

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -68,6 +68,8 @@ pipeline.OnPipelineRecordFaulted += (_, args) =>
 };
 ```
 
+When a fault stops the pipeline, `OnPipelineFaulted` is raised before `Completion` faults. If a fault-event subscriber throws, that subscriber exception is logged and the original pipeline fault remains the `Completion` exception.
+
 ## Related Docs
 
 - [Retry](retry.md)

--- a/docs/guides/lifecycle.md
+++ b/docs/guides/lifecycle.md
@@ -40,6 +40,7 @@ await pipeline.Completion;
 - starting twice throws.
 - `Completion` represents the full pipeline run, not just one internal block.
 - `CompleteAsync()` waits for downstream work to finish rather than only stopping ingress.
+- when the pipeline faults, `OnPipelineFaulted` is raised before `Completion` faults.
 
 ## Manual Publish With Flow Control
 

--- a/src/Pipelinez/Core/Pipeline.cs
+++ b/src/Pipelinez/Core/Pipeline.cs
@@ -819,8 +819,6 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     {
         Guard.Against.Null(fault, nameof(fault));
 
-        var shouldRaiseEvent = false;
-
         lock (_stateLock)
         {
             if (_state == PipelineRuntimeState.Completed || _state == PipelineRuntimeState.Faulted)
@@ -830,19 +828,19 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
 
             _state = PipelineRuntimeState.Faulted;
             _pipelineFault = fault;
-            shouldRaiseEvent = true;
-        }
-
-        _completionSource.TrySetException(fault.Exception);
-
-        if (!shouldRaiseEvent)
-        {
-            return;
         }
 
         HandleCancellationRequested();
         RequestRuntimeCancellation();
-        OnPipelineFaulted?.Invoke(this, new PipelineFaultedEventArgs(_name, fault));
+
+        try
+        {
+            RaisePipelineFaultedEvent(fault);
+        }
+        finally
+        {
+            _completionSource.TrySetException(fault.Exception);
+        }
     }
 
     private void CleanupRuntimeResources()
@@ -1219,6 +1217,27 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
             componentKind,
             DateTimeOffset.UtcNow,
             message ?? exception.Message);
+    }
+
+    private void RaisePipelineFaultedEvent(PipelineFaultState fault)
+    {
+        var handler = OnPipelineFaulted;
+        if (handler is null)
+        {
+            return;
+        }
+
+        try
+        {
+            handler.Invoke(this, new PipelineFaultedEventArgs(_name, fault));
+        }
+        catch (Exception exception)
+        {
+            Logger.LogError(
+                exception,
+                "An OnPipelineFaulted subscriber threw while handling a fault in pipeline {PipelineName}.",
+                _name);
+        }
     }
 
     internal void ReportPartitionDraining(PipelinePartitionLease partition)

--- a/src/tests/Pipelinez.Tests/Core/FaultHandlingTests/PipelineFaultHandlingTests.cs
+++ b/src/tests/Pipelinez.Tests/Core/FaultHandlingTests/PipelineFaultHandlingTests.cs
@@ -121,6 +121,73 @@ public class PipelineFaultHandlingTests
         Assert.Equal(PipelineExecutionStatus.Faulted, pipeline.GetStatus().Status);
     }
 
+    [Fact]
+    public async Task Pipeline_Fault_Event_Is_Raised_Before_Completion_Faults()
+    {
+        bool? completionWasCompletedWhenFaultEventRaised = null;
+        var faultEventRaised = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var pipeline = Pipeline<TestSegmentModel>.New("Pipeline_Fault_Event_Is_Raised_Before_Completion_Faults")
+            .WithInMemorySource("config")
+            .AddSegment(new FaultingSegment(), "config")
+            .WithInMemoryDestination("config")
+            .Build();
+
+        pipeline.OnPipelineFaulted += (_, _) =>
+        {
+            completionWasCompletedWhenFaultEventRaised = pipeline.Completion.IsCompleted;
+            faultEventRaised.TrySetResult();
+        };
+
+        await pipeline.StartPipelineAsync();
+        await pipeline.PublishAsync(new TestSegmentModel
+        {
+            FirstValue = 1,
+            SecondValue = 2
+        });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await pipeline.Completion);
+
+        await faultEventRaised.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(FaultingSegment.FailureMessage, exception.Message);
+        Assert.NotNull(completionWasCompletedWhenFaultEventRaised);
+        Assert.False(completionWasCompletedWhenFaultEventRaised!.Value);
+    }
+
+    [Fact]
+    public async Task Pipeline_Fault_Event_Subscriber_Exceptions_Do_Not_Replace_Original_Pipeline_Fault()
+    {
+        var faultSubscriberInvoked = false;
+
+        var pipeline = Pipeline<TestSegmentModel>.New("Pipeline_Fault_Event_Subscriber_Exceptions_Do_Not_Replace_Original_Pipeline_Fault")
+            .WithInMemorySource("config")
+            .AddSegment(new FaultingSegment(), "config")
+            .WithInMemoryDestination("config")
+            .Build();
+
+        pipeline.OnPipelineFaulted += (_, _) =>
+        {
+            faultSubscriberInvoked = true;
+            throw new InvalidOperationException("Fault subscriber failed intentionally.");
+        };
+
+        await pipeline.StartPipelineAsync();
+        await pipeline.PublishAsync(new TestSegmentModel
+        {
+            FirstValue = 3,
+            SecondValue = 4
+        });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await pipeline.Completion);
+
+        Assert.True(faultSubscriberInvoked);
+        Assert.Equal(FaultingSegment.FailureMessage, exception.Message);
+        Assert.Equal(PipelineExecutionStatus.Faulted, pipeline.GetStatus().Status);
+    }
+
     private static Pipeline<TestPipelineRecord> CreatePipeline(
         string name,
         IPipelineDestination<TestPipelineRecord> destination)


### PR DESCRIPTION
## Summary

- Refreshed the root `README.md` into a more standard OSS library landing page
- Reworked the introduction so Pipelinez is easier to understand quickly for first-time visitors
- Simplified the top-level README structure around orientation, installation, one primary example, and links to deeper docs
- Fixed the pipeline fault-ordering race so `OnPipelineFaulted` is raised before `Completion` faults
- Hardened the fault path so exceptions thrown by `OnPipelineFaulted` subscribers are logged and do not replace the original pipeline fault
- Added regression coverage for both fault-event ordering and fault-subscriber exception handling

## Validation

- [x] `dotnet build src/Pipelinez.sln`
- [x] `dotnet test src/Pipelinez.sln --logger "console;verbosity=minimal"`

Notes:
- The full test suite passed with 68/68 tests green.

## Public API

- [x] No public API changes
- [ ] Public API changes were intentional and the approved baselines were updated
- [ ] New unstable public APIs are marked preview
- [ ] Obsoletions include a migration path

Notes:
- This change updates runtime behavior and documentation, but does not change the public API surface.

## Documentation

- [ ] No documentation updates were needed
- [x] Consumer-facing docs were updated for behavior or API changes

Docs updated in this PR include:
- `README.md`
- `docs/guides/lifecycle.md`
- `docs/guides/error-handling.md`
- `docs/Overview.md`