### PR TITLE
Updating post release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,15 @@ Pipelinez uses [Semantic Versioning](https://semver.org/). The `Pipelinez` and `
 
 ### Added
 
+- Nothing yet.
+
+## [1.0.0] - 2026-04-07
+
+### Added
+
 - Added a tag-based release workflow and repository setup for public NuGet publishing through NuGet Trusted Publishing.
 - Added baseline OSS repository files for issue templates, ownership, security reporting, and release tracking.
+- Published the first public `Pipelinez` and `Pipelinez.Kafka` packages to NuGet.org.
 
 ### Changed
 
@@ -17,4 +24,4 @@ Pipelinez uses [Semantic Versioning](https://semver.org/). The `Pipelinez` and `
 
 ### Migration Notes
 
-- No migration required. These changes prepare the repository for public releases and do not change runtime APIs.
+- No migration required for the first public release.

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Pipelinez is not trying to replace large distributed stream-processing platforms
 
 ## Installation
 
-Package generation is configured for:
+The first public packages are available on NuGet.org:
 
-- `Pipelinez`
-- `Pipelinez.Kafka`
+- [`Pipelinez`](https://www.nuget.org/packages/Pipelinez)
+- [`Pipelinez.Kafka`](https://www.nuget.org/packages/Pipelinez.Kafka)
 
-Expected install commands for published packages:
+Install the core runtime:
 
 ```bash
 dotnet add package Pipelinez
@@ -49,7 +49,7 @@ dotnet add package Pipelinez.Kafka
 
 `Pipelinez.Kafka` depends on `Pipelinez`, so Kafka consumers do not need to add both explicitly unless they want to.
 
-Public package publishing is configured through GitHub tag releases and NuGet Trusted Publishing. Until the first public release is available on NuGet.org, you can still build and pack the projects locally from this repository.
+Public package publishing is configured through GitHub tag releases and NuGet Trusted Publishing.
 
 ## Quick Example
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -42,12 +42,12 @@ Each record flows through the runtime inside a `PipelineContainer<T>`, which let
 
 ## Packaging Status
 
-The repository is now configured for package generation of:
+The public packages are available on NuGet.org:
 
-- `Pipelinez`
-- `Pipelinez.Kafka`
+- [`Pipelinez`](https://www.nuget.org/packages/Pipelinez)
+- [`Pipelinez.Kafka`](https://www.nuget.org/packages/Pipelinez.Kafka)
 
-That includes package metadata, XML docs, Source Link, symbol packages, and CI pack validation.
+The repository remains configured for package metadata, XML docs, Source Link, symbol packages, and CI pack validation.
 Public release automation is configured through tag-based GitHub Actions and NuGet Trusted Publishing.
 
 Versioning rules:

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,16 +43,16 @@ This folder contains the main documentation set for Pipelinez.
 
 ## Installation Note
 
-Packaging is now configured for:
+The public packages are available on NuGet.org:
 
-- `Pipelinez`
-- `Pipelinez.Kafka`
+- [`Pipelinez`](https://www.nuget.org/packages/Pipelinez)
+- [`Pipelinez.Kafka`](https://www.nuget.org/packages/Pipelinez.Kafka)
 
-Expected install commands for published packages are:
+Install with:
 
 ```bash
 dotnet add package Pipelinez
 dotnet add package Pipelinez.Kafka
 ```
 
-Public releases are configured through tag-based GitHub Actions and NuGet Trusted Publishing. Until the first public release is available on NuGet.org, the current repository and example workflow remain the most directly runnable path.
+Public releases are configured through tag-based GitHub Actions and NuGet Trusted Publishing.

--- a/docs/getting-started/in-memory.md
+++ b/docs/getting-started/in-memory.md
@@ -17,10 +17,10 @@ This guide walks through the smallest useful Pipelinez setup:
 
 - .NET 8 SDK
 - either:
-  - a consumer project referencing the `Pipelinez` package when published
+  - a consumer project referencing the [`Pipelinez`](https://www.nuget.org/packages/Pipelinez) package
   - or a local clone of this repository
 
-Expected package install command:
+Package install command:
 
 ```bash
 dotnet add package Pipelinez

--- a/docs/getting-started/kafka.md
+++ b/docs/getting-started/kafka.md
@@ -11,10 +11,10 @@ This guide shows the shape of a Kafka-backed pipeline and how to run the shipped
 - .NET 8 SDK
 - Docker running locally
 - either:
-  - a consumer project referencing the `Pipelinez.Kafka` package when published
+  - a consumer project referencing the [`Pipelinez.Kafka`](https://www.nuget.org/packages/Pipelinez.Kafka) package
   - or a local clone of this repository
 
-Expected package install command:
+Package install command:
 
 ```bash
 dotnet add package Pipelinez.Kafka

--- a/src/Pipelinez.Kafka/PackageReadme.md
+++ b/src/Pipelinez.Kafka/PackageReadme.md
@@ -54,5 +54,6 @@ var pipeline = Pipeline<MyRecord>.New("orders")
 
 ## More Information
 
+- NuGet: https://www.nuget.org/packages/Pipelinez.Kafka
 - Repository: https://github.com/KenBerg75/Pipelinez
 - Kafka docs: https://github.com/KenBerg75/Pipelinez/blob/main/docs/transports/kafka.md

--- a/src/Pipelinez/PackageReadme.md
+++ b/src/Pipelinez/PackageReadme.md
@@ -46,5 +46,6 @@ var pipeline = Pipeline<OrderRecord>.New("orders")
 
 ## More Information
 
+- NuGet: https://www.nuget.org/packages/Pipelinez
 - Repository: https://github.com/KenBerg75/Pipelinez
 - Docs: https://github.com/KenBerg75/Pipelinez/tree/main/docs


### PR DESCRIPTION
## Summary

- Updated documentation to reflect that the first public NuGet release is live
- Added direct NuGet links for `Pipelinez` and `Pipelinez.Kafka`
- Removed stale “until first public release” / “when published” wording
- Updated package readmes so future NuGet package pages link back to the published package pages
- Added a `1.0.0` entry to the changelog dated `2026-04-07`

## Validation

- [ ] `dotnet build src/Pipelinez.sln`
- [ ] `dotnet test src/Pipelinez.sln --logger "console;verbosity=minimal"`

Notes:
- This was a documentation-only change, so build and test were not rerun.

## Release Impact

- [x] Patch
- [ ] Minor
- [ ] Major
- [ ] No release impact

Notes:
- Documentation-only follow-up after the first public NuGet release.

## Public API

- [x] No public API changes
- [ ] Public API changes were intentional and the approved baselines were updated
- [ ] New unstable public APIs are marked preview
- [ ] Obsoletions include a migration path

## Documentation

- [ ] No documentation updates were needed
- [x] Consumer-facing docs were updated for behavior or API changes

Docs updated in this PR include:
- `README.md`
- `docs/README.md`
- `docs/Overview.md`
- `docs/getting-started/in-memory.md`
- `docs/getting-started/kafka.md`
- `src/Pipelinez/PackageReadme.md`
- `src/Pipelinez.Kafka/PackageReadme.md`
- `CHANGELOG.md`