### PR TITLE
Updating code based documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,21 @@ Then run the full suite:
 dotnet test src/Pipelinez.sln --logger "console;verbosity=minimal"
 ```
 
+## Public API XML Documentation
+
+Both public packages enforce XML documentation coverage for public APIs during normal builds.
+
+That means:
+
+- every new public type needs a meaningful XML `<summary>`
+- public constructors, methods, properties, and events need XML docs or intentional `<inheritdoc />`
+- option/configuration properties should document important defaults and behavior interactions
+- event docs should call out important ordering or lifecycle guarantees when they matter
+
+The compiler enforces this with `CS1591` as an error for `Pipelinez` and `Pipelinez.Kafka`.
+
+If you add or change a public API, make the XML documentation update in the same pull request.
+
 ## Documentation
 
 If your change affects how consumers use the library, update the relevant docs in the same pull request.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <NoWarn>$(NoWarn);1591</NoWarn>
+    <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ dotnet add package Pipelinez.Kafka
 
 Public package publishing is configured through GitHub tag releases and NuGet Trusted Publishing.
 
+The published packages include XML IntelliSense documentation, so the public API descriptions are available directly in editors like Visual Studio and Rider.
+
 ## Quick Example
 
 This example creates an in-memory pipeline that receives an `OrderRecord`, applies a discount, and completes through an in-memory destination.

--- a/docs/ApiStability.md
+++ b/docs/ApiStability.md
@@ -96,6 +96,8 @@ The repository now includes public API approval tests for:
 
 These tests compare the compiled public surface against checked-in approved baselines. Any unintended public API change causes the test suite to fail, which means the existing PR and CI workflows also catch it automatically.
 
+The public package projects also enforce XML documentation coverage for public APIs. Missing XML docs on public members fail the build through `CS1591`, which keeps IntelliSense quality aligned with the approved public surface.
+
 Approved baselines live in:
 
 - `src/tests/Pipelinez.Tests/ApprovedApi/Pipelinez.publicapi.txt`
@@ -117,6 +119,7 @@ If a change affects a public API:
 
 - decide whether the API is stable or preview
 - update the approved API baseline intentionally
+- update or add XML documentation for the changed public members
 - update consumer-facing docs when usage changes
 - add migration guidance when replacing an existing API
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,3 +56,5 @@ dotnet add package Pipelinez.Kafka
 ```
 
 Public releases are configured through tag-based GitHub Actions and NuGet Trusted Publishing.
+
+Both public packages also ship XML IntelliSense documentation so API descriptions show up directly in supported IDEs.

--- a/src/Pipelinez.Kafka/Kafka/Configuration/KafkaConnectionOptions.cs
+++ b/src/Pipelinez.Kafka/Kafka/Configuration/KafkaConnectionOptions.cs
@@ -2,12 +2,34 @@ using Confluent.Kafka;
 
 namespace Pipelinez.Kafka.Configuration;
 
+/// <summary>
+/// Provides shared Kafka broker connection settings used by Kafka sources and destinations.
+/// </summary>
 public class KafkaOptions
 {
+    /// <summary>
+    /// Gets or sets the bootstrap broker list used to connect to the Kafka cluster.
+    /// </summary>
     public string BootstrapServers { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the SASL username used when the selected security protocol requires authentication.
+    /// </summary>
     public string BootstrapUser { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the SASL password used when the selected security protocol requires authentication.
+    /// </summary>
     public string BootstrapPassword { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the transport security protocol used for the Kafka connection.
+    /// </summary>
     public SecurityProtocol SecurityProtocol { get; set; } = SecurityProtocol.SaslSsl;
+
+    /// <summary>
+    /// Gets or sets the SASL mechanism used when SASL authentication is enabled.
+    /// </summary>
     public SaslMechanism SaslMechanism { get; set; } = SaslMechanism.Plain;
 
     internal bool UsesSaslAuthentication =>

--- a/src/Pipelinez.Kafka/Kafka/Configuration/KafkaDestinationOptions.cs
+++ b/src/Pipelinez.Kafka/Kafka/Configuration/KafkaDestinationOptions.cs
@@ -5,6 +5,13 @@ namespace Pipelinez.Kafka.Configuration;
 /// </summary>
 public class KafkaDestinationOptions : KafkaOptions
 {
+    /// <summary>
+    /// Gets or sets the Kafka topic to publish records to.
+    /// </summary>
     public string TopicName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets optional schema registry configuration used by serializers for the destination topic.
+    /// </summary>
     public KafkaSchemaRegistryOptions? Schema { get; set; } = new KafkaSchemaRegistryOptions();
 }

--- a/src/Pipelinez.Kafka/Kafka/Configuration/KafkaPartitionExecutionMode.cs
+++ b/src/Pipelinez.Kafka/Kafka/Configuration/KafkaPartitionExecutionMode.cs
@@ -1,8 +1,22 @@
 namespace Pipelinez.Kafka.Configuration;
 
+/// <summary>
+/// Defines how a Kafka source is allowed to execute work across and within assigned partitions.
+/// </summary>
 public enum KafkaPartitionExecutionMode
 {
+    /// <summary>
+    /// Processes at most one record at a time per partition so partition ordering is preserved.
+    /// </summary>
     PreservePartitionOrder,
+
+    /// <summary>
+    /// Allows different partitions to execute concurrently while preserving ordering within each partition.
+    /// </summary>
     ParallelizeAcrossPartitions,
+
+    /// <summary>
+    /// Allows multiple records from the same partition to execute concurrently, which can relax ordering guarantees.
+    /// </summary>
     RelaxOrderingWithinPartition
 }

--- a/src/Pipelinez.Kafka/Kafka/Configuration/KafkaPartitionRebalanceMode.cs
+++ b/src/Pipelinez.Kafka/Kafka/Configuration/KafkaPartitionRebalanceMode.cs
@@ -1,7 +1,17 @@
 namespace Pipelinez.Kafka.Configuration;
 
+/// <summary>
+/// Defines how a Kafka source should behave when a partition rebalance revokes owned partitions.
+/// </summary>
 public enum KafkaPartitionRebalanceMode
 {
+    /// <summary>
+    /// Stops admitting new work for the partition and waits for in-flight records to drain before yielding ownership.
+    /// </summary>
     DrainAndYield,
+
+    /// <summary>
+    /// Stops admitting new work immediately and yields ownership as soon as active work is no longer accepted.
+    /// </summary>
     StopAcceptingNewWorkAndYield
 }

--- a/src/Pipelinez.Kafka/Kafka/Configuration/KafkaPartitionScalingOptions.cs
+++ b/src/Pipelinez.Kafka/Kafka/Configuration/KafkaPartitionScalingOptions.cs
@@ -2,20 +2,45 @@ using Ardalis.GuardClauses;
 
 namespace Pipelinez.Kafka.Configuration;
 
+/// <summary>
+/// Configures partition-aware scheduling and rebalance behavior for Kafka sources.
+/// </summary>
 public sealed class KafkaPartitionScalingOptions
 {
+    /// <summary>
+    /// Gets or sets how records may execute across and within assigned partitions.
+    /// </summary>
     public KafkaPartitionExecutionMode ExecutionMode { get; init; } =
         KafkaPartitionExecutionMode.PreservePartitionOrder;
 
+    /// <summary>
+    /// Gets or sets the maximum number of partitions that may have active in-flight work at one time.
+    /// </summary>
     public int MaxConcurrentPartitions { get; init; } = int.MaxValue;
 
+    /// <summary>
+    /// Gets or sets the maximum number of in-flight records allowed within a single partition.
+    /// </summary>
     public int MaxInFlightPerPartition { get; init; } = 1;
 
+    /// <summary>
+    /// Gets or sets how partition revocation should be coordinated during rebalances.
+    /// </summary>
     public KafkaPartitionRebalanceMode RebalanceMode { get; init; } =
         KafkaPartitionRebalanceMode.DrainAndYield;
 
+    /// <summary>
+    /// Gets or sets a value indicating whether partition execution lifecycle events should be raised.
+    /// </summary>
     public bool EmitPartitionExecutionEvents { get; init; } = true;
 
+    /// <summary>
+    /// Validates the configured scaling options and returns the same instance when they are valid.
+    /// </summary>
+    /// <returns>The validated options instance.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the execution mode requires ordered partition processing but <see cref="MaxInFlightPerPartition"/> allows more than one record.
+    /// </exception>
     public KafkaPartitionScalingOptions Validate()
     {
         Guard.Against.NegativeOrZero(MaxConcurrentPartitions, nameof(MaxConcurrentPartitions));

--- a/src/Pipelinez.Kafka/Kafka/Configuration/KafkaSchemaRegistryOptions.cs
+++ b/src/Pipelinez.Kafka/Kafka/Configuration/KafkaSchemaRegistryOptions.cs
@@ -1,13 +1,38 @@
 namespace Pipelinez.Kafka.Configuration;
 
+/// <summary>
+/// Configures Confluent Schema Registry connectivity and serializer selection for Kafka transports.
+/// </summary>
 public class KafkaSchemaRegistryOptions
 {
     private string _server = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Schema Registry username.
+    /// </summary>
     public string User { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Schema Registry password.
+    /// </summary>
     public string Password { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the configured key serializer name, such as <c>AVRO</c> or <c>JSON</c>.
+    /// </summary>
     public string KeySerializer { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the configured value serializer name, such as <c>AVRO</c> or <c>JSON</c>.
+    /// </summary>
     public string ValueSerializer { get; set; } = string.Empty;
-    
+
+    /// <summary>
+    /// Gets or sets the Schema Registry server address.
+    /// </summary>
+    /// <remarks>
+    /// When an <c>https://</c> prefix is not provided, one is added automatically when the value is read.
+    /// </remarks>
     public string Server
     {
         get => GetSchemaServer();

--- a/src/Pipelinez.Kafka/Kafka/Configuration/KafkaSourceOptions.cs
+++ b/src/Pipelinez.Kafka/Kafka/Configuration/KafkaSourceOptions.cs
@@ -5,10 +5,33 @@ namespace Pipelinez.Kafka.Configuration;
 /// </summary>
 public class KafkaSourceOptions : KafkaOptions
 {
+    /// <summary>
+    /// Gets or sets the Kafka topic to consume from.
+    /// </summary>
     public string TopicName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Kafka consumer group used by the source.
+    /// </summary>
     public string ConsumerGroup { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a brand new consumer group should begin from the start of the topic.
+    /// </summary>
     public bool StartOffsetFromBeginning { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the automatic offset commit interval in milliseconds when broker auto-commit is enabled.
+    /// </summary>
     public int? AutoCommitIntervalMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets optional schema registry configuration used by Kafka deserializers.
+    /// </summary>
     public KafkaSchemaRegistryOptions Schema { get; set; } = new KafkaSchemaRegistryOptions();
+
+    /// <summary>
+    /// Gets or sets partition-aware scaling options for distributed Kafka consumption.
+    /// </summary>
     public KafkaPartitionScalingOptions PartitionScaling { get; set; } = new KafkaPartitionScalingOptions();
 }

--- a/src/Pipelinez.Kafka/Kafka/Destination/KafkaDeadLetterDestination.cs
+++ b/src/Pipelinez.Kafka/Kafka/Destination/KafkaDeadLetterDestination.cs
@@ -11,6 +11,12 @@ using Pipelinez.Kafka.Record;
 
 namespace Pipelinez.Kafka.Destination;
 
+/// <summary>
+/// Writes Pipelinez dead-letter records to a Kafka topic.
+/// </summary>
+/// <typeparam name="T">The pipeline record type being dead-lettered.</typeparam>
+/// <typeparam name="TRecordKey">The Kafka message key type.</typeparam>
+/// <typeparam name="TRecordValue">The Kafka message value type.</typeparam>
 public sealed class KafkaDeadLetterDestination<T, TRecordKey, TRecordValue>
     : IPipelineDeadLetterDestination<T>
     where T : PipelineRecord
@@ -22,6 +28,12 @@ public sealed class KafkaDeadLetterDestination<T, TRecordKey, TRecordValue>
     private readonly ILogger<KafkaDeadLetterDestination<T, TRecordKey, TRecordValue>> _logger;
     private IKafkaProducer<TRecordKey, TRecordValue>? _producer;
 
+    /// <summary>
+    /// Initializes a new Kafka dead-letter destination for the specified pipeline.
+    /// </summary>
+    /// <param name="pipelineName">The owning pipeline name.</param>
+    /// <param name="config">The Kafka destination configuration.</param>
+    /// <param name="messageMapper">Maps a dead-letter record into the Kafka message to publish.</param>
     public KafkaDeadLetterDestination(
         string pipelineName,
         KafkaDestinationOptions config,
@@ -35,6 +47,7 @@ public sealed class KafkaDeadLetterDestination<T, TRecordKey, TRecordValue>
             _config);
     }
 
+    /// <inheritdoc />
     public async Task WriteAsync(
         PipelineDeadLetterRecord<T> deadLetterRecord,
         CancellationToken cancellationToken)

--- a/src/Pipelinez.Kafka/Kafka/Destination/KafkaPipelineDestination.cs
+++ b/src/Pipelinez.Kafka/Kafka/Destination/KafkaPipelineDestination.cs
@@ -10,6 +10,12 @@ using Pipelinez.Kafka.Record;
 
 namespace Pipelinez.Kafka.Destination;
 
+/// <summary>
+/// Publishes pipeline records to a Kafka topic.
+/// </summary>
+/// <typeparam name="T">The pipeline record type.</typeparam>
+/// <typeparam name="TRecordKey">The Kafka message key type.</typeparam>
+/// <typeparam name="TRecordValue">The Kafka message value type.</typeparam>
 public class KafkaPipelineDestination<T, TRecordKey, TRecordValue> : PipelineDestination<T> where T : PipelineRecord where TRecordKey : class where TRecordValue : class
 {
     private readonly string _pipelineName;
@@ -17,7 +23,13 @@ public class KafkaPipelineDestination<T, TRecordKey, TRecordValue> : PipelineDes
     private readonly Func<T, Message<TRecordKey, TRecordValue>> _messageMapper;
     private readonly ILogger<KafkaPipelineDestination<T, TRecordKey, TRecordValue>> _logger;
     private IKafkaProducer<TRecordKey, TRecordValue>? _producer;
-    
+
+    /// <summary>
+    /// Initializes a new Kafka pipeline destination for the specified pipeline.
+    /// </summary>
+    /// <param name="pipelineName">The owning pipeline name.</param>
+    /// <param name="config">The Kafka destination configuration.</param>
+    /// <param name="messageMapper">Maps a pipeline record to the Kafka message to publish.</param>
     public KafkaPipelineDestination(string pipelineName, KafkaDestinationOptions config, Func<T, Message<TRecordKey, TRecordValue>> messageMapper)
     {
         _logger = LoggingManager.Instance.CreateLogger<KafkaPipelineDestination<T, TRecordKey, TRecordValue>>();
@@ -26,6 +38,7 @@ public class KafkaPipelineDestination<T, TRecordKey, TRecordValue> : PipelineDes
         _messageMapper = messageMapper;
     }
 
+    /// <inheritdoc />
     protected override void Initialize()
     {
         _logger.LogInformation("Initializing KafkaPipelineDestination");
@@ -35,7 +48,8 @@ public class KafkaPipelineDestination<T, TRecordKey, TRecordValue> : PipelineDes
         // At this point we need a producer or we are dead
         Guard.Against.Null(_producer, nameof(_producer), "No Kafka Producer was created in the destination. Cannot proceed.");
     }
-    
+
+    /// <inheritdoc />
     protected override async Task ExecuteAsync(T record, CancellationToken cancellationToken)
     {
         _logger.LogTrace("Publishing: {S}", record.ToString());

--- a/src/Pipelinez.Kafka/Kafka/KafkaPipelineBuilderExtensions.cs
+++ b/src/Pipelinez.Kafka/Kafka/KafkaPipelineBuilderExtensions.cs
@@ -8,8 +8,21 @@ using Pipelinez.Kafka.Source;
 
 namespace Pipelinez.Kafka;
 
+/// <summary>
+/// Provides Kafka transport extension methods for <see cref="PipelineBuilder{T}" />.
+/// </summary>
 public static class KafkaPipelineBuilderExtensions
 {
+    /// <summary>
+    /// Configures the pipeline to consume records from Kafka.
+    /// </summary>
+    /// <typeparam name="T">The pipeline record type.</typeparam>
+    /// <typeparam name="TRecordKey">The Kafka key type.</typeparam>
+    /// <typeparam name="TRecordValue">The Kafka value type.</typeparam>
+    /// <param name="builder">The pipeline builder to configure.</param>
+    /// <param name="config">The Kafka source configuration.</param>
+    /// <param name="recordMapper">Maps the Kafka key and value into a pipeline record.</param>
+    /// <returns>The same builder for chaining.</returns>
     public static PipelineBuilder<T> WithKafkaSource<T, TRecordKey, TRecordValue>(
         this PipelineBuilder<T> builder,
         KafkaSourceOptions config,
@@ -26,6 +39,17 @@ public static class KafkaPipelineBuilderExtensions
             recordMapper));
     }
 
+    /// <summary>
+    /// Configures the pipeline to consume records from Kafka with explicit partition scaling behavior.
+    /// </summary>
+    /// <typeparam name="T">The pipeline record type.</typeparam>
+    /// <typeparam name="TRecordKey">The Kafka key type.</typeparam>
+    /// <typeparam name="TRecordValue">The Kafka value type.</typeparam>
+    /// <param name="builder">The pipeline builder to configure.</param>
+    /// <param name="config">The Kafka source configuration.</param>
+    /// <param name="recordMapper">Maps the Kafka key and value into a pipeline record.</param>
+    /// <param name="partitionScalingOptions">The partition-aware execution settings to apply.</param>
+    /// <returns>The same builder for chaining.</returns>
     public static PipelineBuilder<T> WithKafkaSource<T, TRecordKey, TRecordValue>(
         this PipelineBuilder<T> builder,
         KafkaSourceOptions config,
@@ -41,7 +65,17 @@ public static class KafkaPipelineBuilderExtensions
         config.PartitionScaling = partitionScalingOptions.Validate();
         return builder.WithKafkaSource<T, TRecordKey, TRecordValue>(config, recordMapper);
     }
-    
+
+    /// <summary>
+    /// Configures the pipeline to publish records to Kafka.
+    /// </summary>
+    /// <typeparam name="T">The pipeline record type.</typeparam>
+    /// <typeparam name="TRecordKey">The Kafka key type.</typeparam>
+    /// <typeparam name="TRecordValue">The Kafka value type.</typeparam>
+    /// <param name="builder">The pipeline builder to configure.</param>
+    /// <param name="config">The Kafka destination configuration.</param>
+    /// <param name="recordMapper">Maps a pipeline record to the Kafka message to publish.</param>
+    /// <returns>The same builder for chaining.</returns>
     public static PipelineBuilder<T> WithKafkaDestination<T, TRecordKey, TRecordValue>(
         this PipelineBuilder<T> builder,
         KafkaDestinationOptions config,
@@ -58,6 +92,16 @@ public static class KafkaPipelineBuilderExtensions
             recordMapper));
     }
 
+    /// <summary>
+    /// Configures the pipeline to write dead-letter records to Kafka.
+    /// </summary>
+    /// <typeparam name="T">The pipeline record type.</typeparam>
+    /// <typeparam name="TRecordKey">The Kafka key type.</typeparam>
+    /// <typeparam name="TRecordValue">The Kafka value type.</typeparam>
+    /// <param name="builder">The pipeline builder to configure.</param>
+    /// <param name="config">The Kafka destination configuration.</param>
+    /// <param name="recordMapper">Maps the dead-letter envelope into the Kafka message to publish.</param>
+    /// <returns>The same builder for chaining.</returns>
     public static PipelineBuilder<T> WithKafkaDeadLetterDestination<T, TRecordKey, TRecordValue>(
         this PipelineBuilder<T> builder,
         KafkaDestinationOptions config,

--- a/src/Pipelinez.Kafka/Kafka/Record/KafkaMetadataExtensions.cs
+++ b/src/Pipelinez.Kafka/Kafka/Record/KafkaMetadataExtensions.cs
@@ -5,6 +5,9 @@ using Pipelinez.Core.Record.Metadata;
 namespace Pipelinez.Kafka.Record;
 
 // Not sure this belongs here, but for now....
+/// <summary>
+/// Provides helper methods for converting Kafka transport metadata into Pipelinez metadata structures.
+/// </summary>
 public static class KafkaMetadataExtensions
 {
     /// <summary>
@@ -31,11 +34,23 @@ public static class KafkaMetadataExtensions
         return metadata;
     }
 
+    /// <summary>
+    /// Builds a stable partition key identifier for the specified Kafka topic and partition.
+    /// </summary>
+    /// <param name="topicName">The Kafka topic name.</param>
+    /// <param name="partitionId">The partition identifier.</param>
+    /// <returns>A stable partition key value.</returns>
     public static string BuildPartitionKey(string topicName, int partitionId)
     {
         return $"{topicName}:{partitionId}";
     }
 
+    /// <summary>
+    /// Builds a stable lease identifier for the specified Kafka topic and partition.
+    /// </summary>
+    /// <param name="topicName">The Kafka topic name.</param>
+    /// <param name="partitionId">The partition identifier.</param>
+    /// <returns>A stable lease identifier value.</returns>
     public static string BuildLeaseId(string topicName, int partitionId)
     {
         return $"kafka:{topicName}:{partitionId}";

--- a/src/Pipelinez.Kafka/Kafka/Record/KafkaMetadataKeys.cs
+++ b/src/Pipelinez.Kafka/Kafka/Record/KafkaMetadataKeys.cs
@@ -1,8 +1,22 @@
 namespace Pipelinez.Kafka.Record;
 
+/// <summary>
+/// Defines metadata keys used for Kafka source records.
+/// </summary>
 public static class KafkaMetadataKeys
 {
+    /// <summary>
+    /// Metadata key that stores the source Kafka topic name.
+    /// </summary>
     public static string SOURCE_TOPIC_NAME = "kafka.source.topic.name";
+
+    /// <summary>
+    /// Metadata key that stores the source Kafka offset.
+    /// </summary>
     public static string SOURCE_OFFSET = "kafka.source.offset";
+
+    /// <summary>
+    /// Metadata key that stores the source Kafka partition identifier.
+    /// </summary>
     public static string SOURCE_PARTITION = "kafka.source.partition";
 }

--- a/src/Pipelinez.Kafka/Kafka/Source/KafkaPipelineSource.cs
+++ b/src/Pipelinez.Kafka/Kafka/Source/KafkaPipelineSource.cs
@@ -13,6 +13,12 @@ using Pipelinez.Kafka.Record;
 
 namespace Pipelinez.Kafka.Source;
 
+/// <summary>
+/// Consumes records from Kafka and publishes them into a Pipelinez pipeline.
+/// </summary>
+/// <typeparam name="T">The pipeline record type.</typeparam>
+/// <typeparam name="TRecordKey">The Kafka key type.</typeparam>
+/// <typeparam name="TRecordValue">The Kafka value type.</typeparam>
 public class KafkaPipelineSource<T, TRecordKey, TRecordValue> : PipelineSourceBase<T>, IDistributedPipelineSource<T>
     where T : PipelineRecord
     where TRecordKey : class
@@ -42,6 +48,12 @@ public class KafkaPipelineSource<T, TRecordKey, TRecordValue> : PipelineSourceBa
     private long _offsetsStored;
     private readonly Dictionary<int, long> _offsetTracker = new();
 
+    /// <summary>
+    /// Initializes a new Kafka-backed pipeline source.
+    /// </summary>
+    /// <param name="pipelineName">The owning pipeline name.</param>
+    /// <param name="options">The Kafka source configuration.</param>
+    /// <param name="recordMapper">Maps Kafka key and value payloads into pipeline records.</param>
     public KafkaPipelineSource(
         string pipelineName,
         KafkaSourceOptions options,
@@ -54,6 +66,7 @@ public class KafkaPipelineSource<T, TRecordKey, TRecordValue> : PipelineSourceBa
         _recordMapper = recordMapper ?? throw new ArgumentNullException(nameof(recordMapper));
     }
 
+    /// <inheritdoc />
     protected override void Initialize()
     {
         _logger.LogInformation("Initializing KafkaPipelineSource");
@@ -62,6 +75,7 @@ public class KafkaPipelineSource<T, TRecordKey, TRecordValue> : PipelineSourceBa
         Consumer.PartitionsRevoked += HandlePartitionsRevoked;
     }
 
+    /// <inheritdoc />
     protected override async Task MainLoop(CancellationTokenSource cancellationToken)
     {
         _logger.LogInformation("Starting KafkaPipelineSource Consumer");
@@ -145,6 +159,7 @@ public class KafkaPipelineSource<T, TRecordKey, TRecordValue> : PipelineSourceBa
         }).ConfigureAwait(false);
     }
 
+    /// <inheritdoc />
     public override void OnPipelineContainerComplete(object sender, PipelineContainerCompletedEventHandlerArgs<PipelineContainer<T>> e)
     {
         var topicPartitionOffset = TryGetSourceTopicPartitionOffset(e.Container.Metadata);
@@ -174,10 +189,13 @@ public class KafkaPipelineSource<T, TRecordKey, TRecordValue> : PipelineSourceBa
     private IKafkaConsumer<TRecordKey, TRecordValue> Consumer =>
         _consumer ?? throw new InvalidOperationException("Kafka consumer has not been initialized.");
 
+    /// <inheritdoc />
     public bool SupportsDistributedExecution => true;
 
+    /// <inheritdoc />
     public string TransportName => "Kafka";
 
+    /// <inheritdoc />
     public IReadOnlyList<PipelinePartitionLease> GetOwnedPartitions()
     {
         lock (_stateLock)
@@ -186,6 +204,7 @@ public class KafkaPipelineSource<T, TRecordKey, TRecordValue> : PipelineSourceBa
         }
     }
 
+    /// <inheritdoc />
     public IReadOnlyList<PipelinePartitionExecutionState> GetPartitionExecutionStates()
     {
         lock (_stateLock)

--- a/src/Pipelinez/Core/DeadLettering/IPipelineDeadLetterDestination.cs
+++ b/src/Pipelinez/Core/DeadLettering/IPipelineDeadLetterDestination.cs
@@ -2,7 +2,16 @@ using Pipelinez.Core.Record;
 
 namespace Pipelinez.Core.DeadLettering;
 
+/// <summary>
+/// Defines a destination that can persist dead-letter records after terminal fault handling.
+/// </summary>
+/// <typeparam name="T">The pipeline record type contained in the dead-letter envelope.</typeparam>
 public interface IPipelineDeadLetterDestination<T> where T : PipelineRecord
 {
+    /// <summary>
+    /// Writes a dead-letter record to the configured store.
+    /// </summary>
+    /// <param name="deadLetterRecord">The dead-letter record to persist.</param>
+    /// <param name="cancellationToken">A token used to cancel the write operation.</param>
     Task WriteAsync(PipelineDeadLetterRecord<T> deadLetterRecord, CancellationToken cancellationToken);
 }

--- a/src/Pipelinez/Core/DeadLettering/InMemoryDeadLetterDestination.cs
+++ b/src/Pipelinez/Core/DeadLettering/InMemoryDeadLetterDestination.cs
@@ -3,13 +3,21 @@ using Pipelinez.Core.Record;
 
 namespace Pipelinez.Core.DeadLettering;
 
+/// <summary>
+/// Stores dead-letter records in memory for testing or simple host scenarios.
+/// </summary>
+/// <typeparam name="T">The pipeline record type stored in the dead-letter envelopes.</typeparam>
 public sealed class InMemoryDeadLetterDestination<T> : IPipelineDeadLetterDestination<T>
     where T : PipelineRecord
 {
     private readonly ConcurrentQueue<PipelineDeadLetterRecord<T>> _records = new();
 
+    /// <summary>
+    /// Gets the dead-letter records written to the in-memory destination.
+    /// </summary>
     public IReadOnlyList<PipelineDeadLetterRecord<T>> Records => _records.ToArray();
 
+    /// <inheritdoc />
     public Task WriteAsync(PipelineDeadLetterRecord<T> deadLetterRecord, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(deadLetterRecord);

--- a/src/Pipelinez/Core/DeadLettering/PipelineDeadLetterOptions.cs
+++ b/src/Pipelinez/Core/DeadLettering/PipelineDeadLetterOptions.cs
@@ -1,13 +1,29 @@
 namespace Pipelinez.Core.DeadLettering;
 
+/// <summary>
+/// Configures how the pipeline handles dead-letter writes and dead-letter events.
+/// </summary>
 public sealed class PipelineDeadLetterOptions
 {
+    /// <summary>
+    /// Gets a value indicating whether dead-letter success and failure events should be emitted.
+    /// </summary>
     public bool EmitDeadLetterEvents { get; init; } = true;
 
+    /// <summary>
+    /// Gets a value indicating whether a dead-letter write failure should fault the pipeline.
+    /// </summary>
     public bool TreatDeadLetterFailureAsPipelineFault { get; init; } = true;
 
+    /// <summary>
+    /// Gets a value indicating whether metadata should be cloned when dead-letter envelopes are created.
+    /// </summary>
     public bool CloneMetadata { get; init; } = true;
 
+    /// <summary>
+    /// Validates the configured options.
+    /// </summary>
+    /// <returns>The validated options instance.</returns>
     public PipelineDeadLetterOptions Validate()
     {
         return this;

--- a/src/Pipelinez/Core/DeadLettering/PipelineDeadLetterRecord.cs
+++ b/src/Pipelinez/Core/DeadLettering/PipelineDeadLetterRecord.cs
@@ -7,24 +7,55 @@ using Pipelinez.Core.Retry;
 
 namespace Pipelinez.Core.DeadLettering;
 
+/// <summary>
+/// Represents the full dead-letter envelope persisted for a terminally handled pipeline record.
+/// </summary>
+/// <typeparam name="T">The pipeline record type captured in the dead-letter envelope.</typeparam>
 public sealed class PipelineDeadLetterRecord<T> where T : PipelineRecord
 {
+    /// <summary>
+    /// Gets the original record that was dead-lettered.
+    /// </summary>
     public required T Record { get; init; }
 
+    /// <summary>
+    /// Gets the fault state that caused the record to be dead-lettered.
+    /// </summary>
     public required PipelineFaultState Fault { get; init; }
 
+    /// <summary>
+    /// Gets the metadata associated with the record at dead-letter time.
+    /// </summary>
     public required MetadataCollection Metadata { get; init; }
 
+    /// <summary>
+    /// Gets the execution history recorded for pipeline segments that processed the record.
+    /// </summary>
     public required IReadOnlyList<PipelineSegmentExecution> SegmentHistory { get; init; }
 
+    /// <summary>
+    /// Gets the retry history recorded for the record.
+    /// </summary>
     public required IReadOnlyList<PipelineRetryAttempt> RetryHistory { get; init; }
 
+    /// <summary>
+    /// Gets the timestamp when the container carrying the record was created.
+    /// </summary>
     public required DateTimeOffset CreatedAtUtc { get; init; }
 
+    /// <summary>
+    /// Gets the timestamp when the record was written to the dead-letter destination.
+    /// </summary>
     public required DateTimeOffset DeadLetteredAtUtc { get; init; }
 
+    /// <summary>
+    /// Gets the distributed execution context associated with the record.
+    /// </summary>
     public required PipelineRecordDistributionContext Distribution { get; init; }
 
+    /// <summary>
+    /// Validates that the dead-letter envelope contains the required values.
+    /// </summary>
     public void Validate()
     {
         Guard.Against.Null(Record, nameof(Record));

--- a/src/Pipelinez/Core/Destination/IBatchedPipelineDestination.cs
+++ b/src/Pipelinez/Core/Destination/IBatchedPipelineDestination.cs
@@ -2,9 +2,18 @@ using Pipelinez.Core.Record;
 
 namespace Pipelinez.Core.Destination;
 
+/// <summary>
+/// Defines a destination that can process groups of pipeline containers in a single batch operation.
+/// </summary>
+/// <typeparam name="T">The pipeline record type written by the destination.</typeparam>
 public interface IBatchedPipelineDestination<T> : IPipelineDestination<T>
     where T : PipelineRecord
 {
+    /// <summary>
+    /// Executes a batch of records as a single destination operation.
+    /// </summary>
+    /// <param name="batch">The batch of pipeline containers to process.</param>
+    /// <param name="cancellationToken">A token used to cancel the batch operation.</param>
     Task ExecuteBatchAsync(
         IReadOnlyList<PipelineContainer<T>> batch,
         CancellationToken cancellationToken);

--- a/src/Pipelinez/Core/Destination/IPipelineDestination.cs
+++ b/src/Pipelinez/Core/Destination/IPipelineDestination.cs
@@ -3,12 +3,26 @@ using Pipelinez.Core.Record;
 
 namespace Pipelinez.Core.Destination;
 
-
+/// <summary>
+/// Defines a pipeline destination that consumes terminal pipeline containers.
+/// </summary>
+/// <typeparam name="T">The pipeline record type written by the destination.</typeparam>
 public interface IPipelineDestination<T> : IFlowDestination<PipelineContainer<T>> where T : PipelineRecord
 {
+    /// <summary>
+    /// Starts the destination execution loop.
+    /// </summary>
+    /// <param name="cancellationToken">The runtime cancellation source used to stop the destination.</param>
     Task StartAsync(CancellationTokenSource cancellationToken);
-    
+
+    /// <summary>
+    /// Gets a task that completes when the destination has fully finished processing.
+    /// </summary>
     Task Completion { get; }
-    
+
+    /// <summary>
+    /// Initializes the destination with its parent pipeline.
+    /// </summary>
+    /// <param name="parentPipeline">The owning pipeline.</param>
     void Initialize(Pipeline<T> parentPipeline);
 }

--- a/src/Pipelinez/Core/Destination/InMemoryDestination.cs
+++ b/src/Pipelinez/Core/Destination/InMemoryDestination.cs
@@ -3,20 +3,27 @@ using Pipelinez.Core.Record;
 
 namespace Pipelinez.Core.Destination;
 
-
+/// <summary>
+/// Provides a minimal in-memory destination that simply logs received records.
+/// </summary>
 public class InMemoryPipelineDestination<T> : PipelineDestination<T> where T : PipelineRecord
 {
+    /// <summary>
+    /// Initializes a new in-memory destination.
+    /// </summary>
     public InMemoryPipelineDestination()
     {
         
     }
 
+    /// <inheritdoc />
     protected override Task ExecuteAsync(T record, CancellationToken cancellationToken)
     {
         Logger.LogTrace("Record received: {record}", record);
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     protected override void Initialize()
     {
         // No initialization needed

--- a/src/Pipelinez/Core/Destination/PipelineDestination.cs
+++ b/src/Pipelinez/Core/Destination/PipelineDestination.cs
@@ -14,6 +14,10 @@ using Pipelinez.Core.Retry;
 
 namespace Pipelinez.Core.Destination;
 
+/// <summary>
+/// Provides a base implementation for pipeline destinations backed by a Dataflow buffer.
+/// </summary>
+/// <typeparam name="T">The pipeline record type written by the destination.</typeparam>
 public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelineExecutionConfigurable, IPipelinePerformanceAware, IPipelineBatchingAware, IPipelineRetryConfigurable<T>, IPipelineFlowStatusProvider
     where T : PipelineRecord
 {
@@ -27,20 +31,29 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
     private IPipelinePerformanceCollector? _performanceCollector;
     private string _componentName = "Destination";
 
+    /// <summary>
+    /// Gets the logger used by the destination.
+    /// </summary>
     protected ILogger<PipelineDestination<T>> Logger { get; }
 
+    /// <summary>
+    /// Initializes a new destination base instance.
+    /// </summary>
     protected PipelineDestination()
     {
         Logger = LoggingManager.Instance.CreateLogger<PipelineDestination<T>>();
     }
 
+    /// <inheritdoc />
     public Task Completion => _completionSource.Task;
 
+    /// <inheritdoc />
     public ITargetBlock<PipelineContainer<T>> AsTargetBlock()
     {
         return MessageBuffer;
     }
 
+    /// <inheritdoc />
     public async Task StartAsync(CancellationTokenSource cancellationToken)
     {
         try
@@ -56,16 +69,26 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
         }
     }
 
+    /// <inheritdoc />
     public void Initialize(Pipeline<T> parentPipeline)
     {
         _parentPipeline = parentPipeline;
         Initialize();
     }
 
+    /// <summary>
+    /// Executes the destination logic for a successfully processed record.
+    /// </summary>
+    /// <param name="record">The record to write.</param>
+    /// <param name="cancellationToken">The cancellation token for the execution.</param>
     protected abstract Task ExecuteAsync(T record, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Provides an opportunity for the destination to initialize transport-specific state.
+    /// </summary>
     protected abstract void Initialize();
 
+    /// <inheritdoc />
     public void ConfigureExecutionOptions(PipelineExecutionOptions options)
     {
         var validated = Guard.Against.Null(options, nameof(options)).Validate();
@@ -73,17 +96,20 @@ public abstract class PipelineDestination<T> : IPipelineDestination<T>, IPipelin
         _executionOptions = validated;
     }
 
+    /// <inheritdoc />
     public PipelineExecutionOptions GetExecutionOptions()
     {
         return _executionOptions;
     }
 
+    /// <inheritdoc />
     public void ConfigureRetryPolicy(PipelineRetryPolicy<T>? retryPolicy)
     {
         EnsureExecutionOptionsCanBeChanged();
         _retryPolicy = retryPolicy;
     }
 
+    /// <inheritdoc />
     public PipelineRetryPolicy<T>? GetRetryPolicy()
     {
         return _retryPolicy;

--- a/src/Pipelinez/Core/Distributed/DistributedMetadataKeys.cs
+++ b/src/Pipelinez/Core/Distributed/DistributedMetadataKeys.cs
@@ -1,10 +1,28 @@
 namespace Pipelinez.Core.Distributed;
 
+/// <summary>
+/// Defines metadata keys used to store distributed execution information on pipeline containers.
+/// </summary>
 public static class DistributedMetadataKeys
 {
+    /// <summary>
+    /// The metadata key that stores the transport name.
+    /// </summary>
     public const string TransportName = "pipelinez.distribution.transport.name";
+    /// <summary>
+    /// The metadata key that stores the logical lease identifier.
+    /// </summary>
     public const string LeaseId = "pipelinez.distribution.lease.id";
+    /// <summary>
+    /// The metadata key that stores the logical partition key.
+    /// </summary>
     public const string PartitionKey = "pipelinez.distribution.partition.key";
+    /// <summary>
+    /// The metadata key that stores the numeric partition identifier.
+    /// </summary>
     public const string PartitionId = "pipelinez.distribution.partition.id";
+    /// <summary>
+    /// The metadata key that stores the transport offset.
+    /// </summary>
     public const string Offset = "pipelinez.distribution.offset";
 }

--- a/src/Pipelinez/Core/Distributed/PipelineDistributedStatus.cs
+++ b/src/Pipelinez/Core/Distributed/PipelineDistributedStatus.cs
@@ -2,8 +2,14 @@ using Ardalis.GuardClauses;
 
 namespace Pipelinez.Core.Distributed;
 
+/// <summary>
+/// Represents the distributed execution status exposed through pipeline status APIs.
+/// </summary>
 public sealed class PipelineDistributedStatus
 {
+    /// <summary>
+    /// Initializes a new distributed status snapshot.
+    /// </summary>
     public PipelineDistributedStatus(
         PipelineExecutionMode executionMode,
         string instanceId,
@@ -18,13 +24,28 @@ public sealed class PipelineDistributedStatus
         PartitionExecution = partitionExecution?.ToArray() ?? Array.Empty<PipelinePartitionExecutionState>();
     }
 
+    /// <summary>
+    /// Gets the execution mode currently used by the pipeline.
+    /// </summary>
     public PipelineExecutionMode ExecutionMode { get; }
 
+    /// <summary>
+    /// Gets the host instance identifier.
+    /// </summary>
     public string InstanceId { get; }
 
+    /// <summary>
+    /// Gets the worker identifier.
+    /// </summary>
     public string WorkerId { get; }
 
+    /// <summary>
+    /// Gets the partitions currently owned by the worker.
+    /// </summary>
     public IReadOnlyList<PipelinePartitionLease> OwnedPartitions { get; }
 
+    /// <summary>
+    /// Gets the current execution state of owned partitions.
+    /// </summary>
     public IReadOnlyList<PipelinePartitionExecutionState> PartitionExecution { get; }
 }

--- a/src/Pipelinez/Core/Distributed/PipelineExecutionMode.cs
+++ b/src/Pipelinez/Core/Distributed/PipelineExecutionMode.cs
@@ -1,7 +1,16 @@
 namespace Pipelinez.Core.Distributed;
 
+/// <summary>
+/// Represents the execution mode used by a pipeline host.
+/// </summary>
 public enum PipelineExecutionMode
 {
+    /// <summary>
+    /// Executes the pipeline within a single host process without transport ownership coordination.
+    /// </summary>
     SingleProcess,
+    /// <summary>
+    /// Executes the pipeline in distributed mode with transport-specific ownership coordination.
+    /// </summary>
     Distributed
 }

--- a/src/Pipelinez/Core/Distributed/PipelineHostOptions.cs
+++ b/src/Pipelinez/Core/Distributed/PipelineHostOptions.cs
@@ -1,12 +1,27 @@
 namespace Pipelinez.Core.Distributed;
 
+/// <summary>
+/// Configures host-level execution behavior for a pipeline.
+/// </summary>
 public sealed class PipelineHostOptions
 {
+    /// <summary>
+    /// Gets the execution mode used by the pipeline.
+    /// </summary>
     public PipelineExecutionMode ExecutionMode { get; init; } = PipelineExecutionMode.SingleProcess;
 
+    /// <summary>
+    /// Gets the host instance identifier reported in runtime and diagnostic data.
+    /// </summary>
     public string? InstanceId { get; init; }
 
+    /// <summary>
+    /// Gets the worker identifier reported in runtime and diagnostic data.
+    /// </summary>
     public string? WorkerId { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether distributed mode requires transport ownership support.
+    /// </summary>
     public bool RequireTransportOwnership { get; init; } = true;
 }

--- a/src/Pipelinez/Core/Distributed/PipelinePartitionExecutionState.cs
+++ b/src/Pipelinez/Core/Distributed/PipelinePartitionExecutionState.cs
@@ -2,8 +2,14 @@ using Ardalis.GuardClauses;
 
 namespace Pipelinez.Core.Distributed;
 
+/// <summary>
+/// Describes the current execution state of a single owned partition.
+/// </summary>
 public sealed class PipelinePartitionExecutionState
 {
+    /// <summary>
+    /// Initializes a new partition execution state snapshot.
+    /// </summary>
     public PipelinePartitionExecutionState(
         string leaseId,
         string partitionKey,
@@ -22,17 +28,38 @@ public sealed class PipelinePartitionExecutionState
         HighestCompletedOffset = highestCompletedOffset;
     }
 
+    /// <summary>
+    /// Gets the logical lease identifier.
+    /// </summary>
     public string LeaseId { get; }
 
+    /// <summary>
+    /// Gets the logical partition key.
+    /// </summary>
     public string PartitionKey { get; }
 
+    /// <summary>
+    /// Gets the numeric partition identifier, if one exists.
+    /// </summary>
     public int? PartitionId { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether the partition is currently assigned to this worker.
+    /// </summary>
     public bool IsAssigned { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether the partition is draining during rebalance or shutdown.
+    /// </summary>
     public bool IsDraining { get; }
 
+    /// <summary>
+    /// Gets the number of in-flight records for the partition.
+    /// </summary>
     public int InFlightCount { get; }
 
+    /// <summary>
+    /// Gets the highest completed offset observed for the partition, if one exists.
+    /// </summary>
     public long? HighestCompletedOffset { get; }
 }

--- a/src/Pipelinez/Core/Distributed/PipelinePartitionLease.cs
+++ b/src/Pipelinez/Core/Distributed/PipelinePartitionLease.cs
@@ -2,8 +2,20 @@ using Ardalis.GuardClauses;
 
 namespace Pipelinez.Core.Distributed;
 
+/// <summary>
+/// Represents transport-owned work currently assigned to a pipeline worker.
+/// </summary>
 public sealed class PipelinePartitionLease
 {
+    /// <summary>
+    /// Initializes a new partition lease description.
+    /// </summary>
+    /// <param name="leaseId">The logical lease identifier.</param>
+    /// <param name="transportName">The name of the transport that owns the partition.</param>
+    /// <param name="partitionKey">The logical partition key.</param>
+    /// <param name="instanceId">The host instance identifier.</param>
+    /// <param name="workerId">The worker identifier.</param>
+    /// <param name="partitionId">The numeric partition identifier, if one exists.</param>
     public PipelinePartitionLease(
         string leaseId,
         string transportName,
@@ -20,15 +32,33 @@ public sealed class PipelinePartitionLease
         PartitionId = partitionId;
     }
 
+    /// <summary>
+    /// Gets the logical lease identifier.
+    /// </summary>
     public string LeaseId { get; }
 
+    /// <summary>
+    /// Gets the transport name that owns the partition.
+    /// </summary>
     public string TransportName { get; }
 
+    /// <summary>
+    /// Gets the logical partition key.
+    /// </summary>
     public string PartitionKey { get; }
 
+    /// <summary>
+    /// Gets the instance identifier of the host that owns the partition.
+    /// </summary>
     public string InstanceId { get; }
 
+    /// <summary>
+    /// Gets the worker identifier that owns the partition.
+    /// </summary>
     public string WorkerId { get; }
 
+    /// <summary>
+    /// Gets the numeric partition identifier, if the transport exposes one.
+    /// </summary>
     public int? PartitionId { get; }
 }

--- a/src/Pipelinez/Core/Distributed/PipelineRecordDistributionContext.cs
+++ b/src/Pipelinez/Core/Distributed/PipelineRecordDistributionContext.cs
@@ -2,8 +2,14 @@ using Ardalis.GuardClauses;
 
 namespace Pipelinez.Core.Distributed;
 
+/// <summary>
+/// Captures the distributed execution context associated with a single record.
+/// </summary>
 public sealed class PipelineRecordDistributionContext
 {
+    /// <summary>
+    /// Initializes a new record distribution context.
+    /// </summary>
     public PipelineRecordDistributionContext(
         string instanceId,
         string workerId,
@@ -22,17 +28,38 @@ public sealed class PipelineRecordDistributionContext
         Offset = offset;
     }
 
+    /// <summary>
+    /// Gets the host instance identifier that processed the record.
+    /// </summary>
     public string InstanceId { get; }
 
+    /// <summary>
+    /// Gets the worker identifier that processed the record.
+    /// </summary>
     public string WorkerId { get; }
 
+    /// <summary>
+    /// Gets the transport name, if the source provided one.
+    /// </summary>
     public string? TransportName { get; }
 
+    /// <summary>
+    /// Gets the logical lease identifier, if the source provided one.
+    /// </summary>
     public string? LeaseId { get; }
 
+    /// <summary>
+    /// Gets the logical partition key, if the source provided one.
+    /// </summary>
     public string? PartitionKey { get; }
 
+    /// <summary>
+    /// Gets the numeric partition identifier, if the source provided one.
+    /// </summary>
     public int? PartitionId { get; }
 
+    /// <summary>
+    /// Gets the transport offset, if the source provided one.
+    /// </summary>
     public long? Offset { get; }
 }

--- a/src/Pipelinez/Core/Distributed/PipelineRuntimeContext.cs
+++ b/src/Pipelinez/Core/Distributed/PipelineRuntimeContext.cs
@@ -2,8 +2,14 @@ using Ardalis.GuardClauses;
 
 namespace Pipelinez.Core.Distributed;
 
+/// <summary>
+/// Describes the current runtime identity and owned work for a running pipeline.
+/// </summary>
 public sealed class PipelineRuntimeContext
 {
+    /// <summary>
+    /// Initializes a new runtime context snapshot.
+    /// </summary>
     public PipelineRuntimeContext(
         string pipelineName,
         PipelineExecutionMode executionMode,
@@ -20,15 +26,33 @@ public sealed class PipelineRuntimeContext
         PartitionExecution = partitionExecution?.ToArray() ?? Array.Empty<PipelinePartitionExecutionState>();
     }
 
+    /// <summary>
+    /// Gets the logical pipeline name.
+    /// </summary>
     public string PipelineName { get; }
 
+    /// <summary>
+    /// Gets the configured execution mode.
+    /// </summary>
     public PipelineExecutionMode ExecutionMode { get; }
 
+    /// <summary>
+    /// Gets the current host instance identifier.
+    /// </summary>
     public string InstanceId { get; }
 
+    /// <summary>
+    /// Gets the current worker identifier.
+    /// </summary>
     public string WorkerId { get; }
 
+    /// <summary>
+    /// Gets the partitions currently owned by the worker.
+    /// </summary>
     public IReadOnlyList<PipelinePartitionLease> OwnedPartitions { get; }
 
+    /// <summary>
+    /// Gets the current execution state of owned partitions.
+    /// </summary>
     public IReadOnlyList<PipelinePartitionExecutionState> PartitionExecution { get; }
 }

--- a/src/Pipelinez/Core/ErrorHandling/PipelineErrorAction.cs
+++ b/src/Pipelinez/Core/ErrorHandling/PipelineErrorAction.cs
@@ -1,9 +1,24 @@
 namespace Pipelinez.Core.ErrorHandling;
 
+/// <summary>
+/// Describes the terminal action a pipeline should take after retries are exhausted for a faulted record.
+/// </summary>
 public enum PipelineErrorAction
 {
+    /// <summary>
+    /// Fault the pipeline and stop processing.
+    /// </summary>
     StopPipeline,
+    /// <summary>
+    /// Skip the faulted record and continue processing later records.
+    /// </summary>
     SkipRecord,
+    /// <summary>
+    /// Rethrow the fault and fault the pipeline.
+    /// </summary>
     Rethrow,
+    /// <summary>
+    /// Dead-letter the record and continue processing when dead-lettering succeeds.
+    /// </summary>
     DeadLetter
 }

--- a/src/Pipelinez/Core/ErrorHandling/PipelineErrorContext.cs
+++ b/src/Pipelinez/Core/ErrorHandling/PipelineErrorContext.cs
@@ -5,8 +5,15 @@ using Pipelinez.Core.Retry;
 
 namespace Pipelinez.Core.ErrorHandling;
 
+/// <summary>
+/// Provides the context passed to a configured pipeline error handler.
+/// </summary>
+/// <typeparam name="T">The pipeline record type being handled.</typeparam>
 public sealed class PipelineErrorContext<T> where T : PipelineRecord
 {
+    /// <summary>
+    /// Initializes a new error handler context.
+    /// </summary>
     public PipelineErrorContext(
         Exception exception,
         PipelineContainer<T> container,
@@ -19,23 +26,53 @@ public sealed class PipelineErrorContext<T> where T : PipelineRecord
         CancellationToken = cancellationToken;
     }
 
+    /// <summary>
+    /// Gets the exception that triggered error handling.
+    /// </summary>
     public Exception Exception { get; }
 
+    /// <summary>
+    /// Gets the faulted pipeline container.
+    /// </summary>
     public PipelineContainer<T> Container { get; }
 
+    /// <summary>
+    /// Gets the faulted record.
+    /// </summary>
     public T Record => Container.Record;
 
+    /// <summary>
+    /// Gets the recorded fault state.
+    /// </summary>
     public PipelineFaultState Fault { get; }
 
+    /// <summary>
+    /// Gets the component name associated with the fault.
+    /// </summary>
     public string ComponentName => Fault.ComponentName;
 
+    /// <summary>
+    /// Gets the component kind associated with the fault.
+    /// </summary>
     public PipelineComponentKind ComponentKind => Fault.ComponentKind;
 
+    /// <summary>
+    /// Gets the runtime cancellation token associated with the pipeline.
+    /// </summary>
     public CancellationToken CancellationToken { get; }
 
+    /// <summary>
+    /// Gets the retry history recorded for the container.
+    /// </summary>
     public IReadOnlyList<PipelineRetryAttempt> RetryHistory => Container.RetryHistory.ToArray();
 
+    /// <summary>
+    /// Gets the number of recorded retry attempts.
+    /// </summary>
     public int RetryAttemptCount => Container.RetryHistory.Count;
 
+    /// <summary>
+    /// Gets a value indicating whether the record exhausted at least one retry attempt.
+    /// </summary>
     public bool RetryExhausted => RetryAttemptCount > 0;
 }

--- a/src/Pipelinez/Core/ErrorHandling/PipelineErrorHandler.cs
+++ b/src/Pipelinez/Core/ErrorHandling/PipelineErrorHandler.cs
@@ -2,5 +2,11 @@ using Pipelinez.Core.Record;
 
 namespace Pipelinez.Core.ErrorHandling;
 
+/// <summary>
+/// Represents asynchronous terminal fault policy logic for a faulted pipeline record.
+/// </summary>
+/// <typeparam name="T">The pipeline record type being handled.</typeparam>
+/// <param name="context">The fault context passed to the handler.</param>
+/// <returns>The error action the pipeline should take.</returns>
 public delegate Task<PipelineErrorAction> PipelineErrorHandler<T>(PipelineErrorContext<T> context)
     where T : PipelineRecord;

--- a/src/Pipelinez/Core/Eventing/Eventing.cs
+++ b/src/Pipelinez/Core/Eventing/Eventing.cs
@@ -8,6 +8,10 @@ using Pipelinez.Core.Record;
 namespace Pipelinez.Core.Eventing;
 
 
+/// <summary>
+/// Represents a handler for internal pipeline-container completion notifications.
+/// </summary>
+/// <typeparam name="T">The completed container type.</typeparam>
 public delegate void PipelineContainerCompletedEventHandler<T>(object sender,
     PipelineContainerCompletedEventHandlerArgs<T> args);
 
@@ -15,13 +19,20 @@ internal delegate void PipelineContainerFaultHandledEventHandler<T>(object sende
     PipelineContainerFaultHandledEventHandlerArgs<T> args);
 
 /// <summary>
-/// Contains data for the PipelineRecordCompleted event.
+/// Contains data for an internal pipeline-container completion notification.
 /// </summary>
-/// <typeparam name="T"></typeparam>
+/// <typeparam name="T">The completed container type.</typeparam>
 public sealed class PipelineContainerCompletedEventHandlerArgs<T>
 {
+    /// <summary>
+    /// Gets the completed container.
+    /// </summary>
     public T Container { get; }
-    
+
+    /// <summary>
+    /// Initializes a new container completion event payload.
+    /// </summary>
+    /// <param name="container">The completed container.</param>
     public PipelineContainerCompletedEventHandlerArgs(T container)
     {
         Container = container;
@@ -41,20 +52,39 @@ internal sealed class PipelineContainerFaultHandledEventHandlerArgs<T>
     public ErrorHandling.PipelineErrorAction Action { get; }
 }
 
+/// <summary>
+/// Represents a handler for record-completed notifications.
+/// </summary>
+/// <typeparam name="T">The completed record type.</typeparam>
 public delegate void PipelineRecordCompletedEventHandler<T>(object sender, PipelineRecordCompletedEventHandlerArgs<T> args);
 
 /// <summary>
-/// Contains data for the PipelineRecordCompleted event.
+/// Contains data for the record-completed event.
 /// </summary>
-/// <typeparam name="T"></typeparam>
+/// <typeparam name="T">The completed record type.</typeparam>
 public sealed class PipelineRecordCompletedEventHandlerArgs<T>
 {
+    /// <summary>
+    /// Gets the completed record.
+    /// </summary>
     public T Record { get; }
 
+    /// <summary>
+    /// Gets the distributed execution context for the record, if one exists.
+    /// </summary>
     public PipelineRecordDistributionContext? Distribution { get; }
 
+    /// <summary>
+    /// Gets the diagnostic context for the record, if one exists.
+    /// </summary>
     public PipelineRecordDiagnosticContext? Diagnostic { get; }
 
+    /// <summary>
+    /// Initializes a new record-completed event payload.
+    /// </summary>
+    /// <param name="record">The completed record.</param>
+    /// <param name="distribution">The distributed execution context, if one exists.</param>
+    /// <param name="diagnostic">The diagnostic context, if one exists.</param>
     public PipelineRecordCompletedEventHandlerArgs(
         T record,
         PipelineRecordDistributionContext? distribution = null,
@@ -66,32 +96,62 @@ public sealed class PipelineRecordCompletedEventHandlerArgs<T>
     }
 }
 
+/// <summary>
+/// Represents a handler for record-faulted notifications.
+/// </summary>
+/// <typeparam name="T">The faulted record type.</typeparam>
 public delegate void PipelineRecordFaultedEventHandler<T>(
     object sender,
     PipelineRecordFaultedEventArgs<T> args) where T : PipelineRecord;
 
+/// <summary>
+/// Represents a handler for record-retrying notifications.
+/// </summary>
+/// <typeparam name="T">The retried record type.</typeparam>
 public delegate void PipelineRecordRetryingEventHandler<T>(
     object sender,
     PipelineRecordRetryingEventArgs<T> args) where T : PipelineRecord;
 
+/// <summary>
+/// Represents a handler for saturation-state change notifications.
+/// </summary>
 public delegate void PipelineSaturationChangedEventHandler(
     object sender,
     PipelineSaturationChangedEventArgs args);
 
+/// <summary>
+/// Represents a handler for publish-rejected notifications.
+/// </summary>
+/// <typeparam name="T">The rejected record type.</typeparam>
 public delegate void PipelinePublishRejectedEventHandler<T>(
     object sender,
     PipelinePublishRejectedEventArgs<T> args) where T : PipelineRecord;
 
+/// <summary>
+/// Represents a handler for record dead-letter notifications.
+/// </summary>
+/// <typeparam name="T">The dead-lettered record type.</typeparam>
 public delegate void PipelineRecordDeadLetteredEventHandler<T>(
     object sender,
     PipelineRecordDeadLetteredEventArgs<T> args) where T : PipelineRecord;
 
+/// <summary>
+/// Represents a handler for dead-letter-write-failed notifications.
+/// </summary>
+/// <typeparam name="T">The record type associated with the failed dead-letter write.</typeparam>
 public delegate void PipelineDeadLetterWriteFailedEventHandler<T>(
     object sender,
     PipelineDeadLetterWriteFailedEventArgs<T> args) where T : PipelineRecord;
 
+/// <summary>
+/// Contains data for the record-faulted event.
+/// </summary>
+/// <typeparam name="T">The faulted record type.</typeparam>
 public sealed class PipelineRecordFaultedEventArgs<T> where T : PipelineRecord
 {
+    /// <summary>
+    /// Initializes a new record-faulted event payload.
+    /// </summary>
     public PipelineRecordFaultedEventArgs(
         T record,
         PipelineContainer<T> container,
@@ -106,19 +166,41 @@ public sealed class PipelineRecordFaultedEventArgs<T> where T : PipelineRecord
         Diagnostic = diagnostic;
     }
 
+    /// <summary>
+    /// Gets the faulted record.
+    /// </summary>
     public T Record { get; }
 
+    /// <summary>
+    /// Gets the faulted container.
+    /// </summary>
     public PipelineContainer<T> Container { get; }
 
+    /// <summary>
+    /// Gets the recorded fault state.
+    /// </summary>
     public PipelineFaultState Fault { get; }
 
+    /// <summary>
+    /// Gets the distributed execution context for the record, if one exists.
+    /// </summary>
     public PipelineRecordDistributionContext? Distribution { get; }
 
+    /// <summary>
+    /// Gets the diagnostic context for the record, if one exists.
+    /// </summary>
     public PipelineRecordDiagnosticContext? Diagnostic { get; }
 }
 
+/// <summary>
+/// Contains data for the record-retrying event.
+/// </summary>
+/// <typeparam name="T">The retried record type.</typeparam>
 public sealed class PipelineRecordRetryingEventArgs<T> where T : PipelineRecord
 {
+    /// <summary>
+    /// Initializes a new record-retrying event payload.
+    /// </summary>
     public PipelineRecordRetryingEventArgs(
         T record,
         PipelineContainer<T> container,
@@ -139,31 +221,70 @@ public sealed class PipelineRecordRetryingEventArgs<T> where T : PipelineRecord
         Diagnostic = diagnostic;
     }
 
+    /// <summary>
+    /// Gets the record being retried.
+    /// </summary>
     public T Record { get; }
 
+    /// <summary>
+    /// Gets the container associated with the retry.
+    /// </summary>
     public PipelineContainer<T> Container { get; }
 
+    /// <summary>
+    /// Gets the recorded fault state that triggered the retry.
+    /// </summary>
     public PipelineFaultState Fault { get; }
 
+    /// <summary>
+    /// Gets the current retry attempt number.
+    /// </summary>
     public int AttemptNumber { get; }
 
+    /// <summary>
+    /// Gets the maximum number of attempts allowed.
+    /// </summary>
     public int MaxAttempts { get; }
 
+    /// <summary>
+    /// Gets the delay scheduled before the next attempt.
+    /// </summary>
     public TimeSpan Delay { get; }
 
+    /// <summary>
+    /// Gets the distributed execution context for the record, if one exists.
+    /// </summary>
     public PipelineRecordDistributionContext? Distribution { get; }
 
+    /// <summary>
+    /// Gets the diagnostic context for the record, if one exists.
+    /// </summary>
     public PipelineRecordDiagnosticContext? Diagnostic { get; }
 
+    /// <summary>
+    /// Gets the component name associated with the retry.
+    /// </summary>
     public string ComponentName => Fault.ComponentName;
 
+    /// <summary>
+    /// Gets the component kind associated with the retry.
+    /// </summary>
     public PipelineComponentKind ComponentKind => Fault.ComponentKind;
 
+    /// <summary>
+    /// Gets the exception that triggered the retry.
+    /// </summary>
     public Exception Exception => Fault.Exception;
 }
 
+/// <summary>
+/// Contains data for saturation-state change notifications.
+/// </summary>
 public sealed class PipelineSaturationChangedEventArgs
 {
+    /// <summary>
+    /// Initializes a new saturation-change payload.
+    /// </summary>
     public PipelineSaturationChangedEventArgs(
         double saturationRatio,
         bool isSaturated,
@@ -174,15 +295,31 @@ public sealed class PipelineSaturationChangedEventArgs
         ObservedAtUtc = observedAtUtc;
     }
 
+    /// <summary>
+    /// Gets the observed saturation ratio.
+    /// </summary>
     public double SaturationRatio { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether the pipeline was saturated.
+    /// </summary>
     public bool IsSaturated { get; }
 
+    /// <summary>
+    /// Gets the time the saturation state was observed.
+    /// </summary>
     public DateTimeOffset ObservedAtUtc { get; }
 }
 
+/// <summary>
+/// Contains data for publish-rejected notifications.
+/// </summary>
+/// <typeparam name="T">The rejected record type.</typeparam>
 public sealed class PipelinePublishRejectedEventArgs<T> where T : PipelineRecord
 {
+    /// <summary>
+    /// Initializes a new publish-rejected payload.
+    /// </summary>
     public PipelinePublishRejectedEventArgs(
         T record,
         FlowControl.PipelinePublishResultReason reason,
@@ -195,17 +332,36 @@ public sealed class PipelinePublishRejectedEventArgs<T> where T : PipelineRecord
         Diagnostic = diagnostic;
     }
 
+    /// <summary>
+    /// Gets the rejected record.
+    /// </summary>
     public T Record { get; }
 
+    /// <summary>
+    /// Gets the rejection reason.
+    /// </summary>
     public FlowControl.PipelinePublishResultReason Reason { get; }
 
+    /// <summary>
+    /// Gets the time the rejection was observed.
+    /// </summary>
     public DateTimeOffset ObservedAtUtc { get; }
 
+    /// <summary>
+    /// Gets the diagnostic context for the record, if one exists.
+    /// </summary>
     public PipelineRecordDiagnosticContext? Diagnostic { get; }
 }
 
+/// <summary>
+/// Contains data for record-dead-lettered notifications.
+/// </summary>
+/// <typeparam name="T">The dead-lettered record type.</typeparam>
 public sealed class PipelineRecordDeadLetteredEventArgs<T> where T : PipelineRecord
 {
+    /// <summary>
+    /// Initializes a new record-dead-lettered payload.
+    /// </summary>
     public PipelineRecordDeadLetteredEventArgs(
         T record,
         PipelineDeadLetterRecord<T> deadLetterRecord,
@@ -216,15 +372,31 @@ public sealed class PipelineRecordDeadLetteredEventArgs<T> where T : PipelineRec
         Diagnostic = diagnostic;
     }
 
+    /// <summary>
+    /// Gets the dead-lettered record.
+    /// </summary>
     public T Record { get; }
 
+    /// <summary>
+    /// Gets the dead-letter envelope written for the record.
+    /// </summary>
     public PipelineDeadLetterRecord<T> DeadLetterRecord { get; }
 
+    /// <summary>
+    /// Gets the diagnostic context for the record, if one exists.
+    /// </summary>
     public PipelineRecordDiagnosticContext? Diagnostic { get; }
 }
 
+/// <summary>
+/// Contains data for dead-letter-write-failed notifications.
+/// </summary>
+/// <typeparam name="T">The record type associated with the failed dead-letter write.</typeparam>
 public sealed class PipelineDeadLetterWriteFailedEventArgs<T> where T : PipelineRecord
 {
+    /// <summary>
+    /// Initializes a new dead-letter-write-failed payload.
+    /// </summary>
     public PipelineDeadLetterWriteFailedEventArgs(
         T record,
         PipelineDeadLetterRecord<T> deadLetterRecord,
@@ -237,64 +409,133 @@ public sealed class PipelineDeadLetterWriteFailedEventArgs<T> where T : Pipeline
         Diagnostic = diagnostic;
     }
 
+    /// <summary>
+    /// Gets the record associated with the failed dead-letter write.
+    /// </summary>
     public T Record { get; }
 
+    /// <summary>
+    /// Gets the dead-letter envelope that failed to write.
+    /// </summary>
     public PipelineDeadLetterRecord<T> DeadLetterRecord { get; }
 
+    /// <summary>
+    /// Gets the exception raised by the dead-letter destination.
+    /// </summary>
     public Exception Exception { get; }
 
+    /// <summary>
+    /// Gets the diagnostic context for the record, if one exists.
+    /// </summary>
     public PipelineRecordDiagnosticContext? Diagnostic { get; }
 }
 
+/// <summary>
+/// Represents a handler for pipeline-faulted notifications.
+/// </summary>
 public delegate void PipelineFaultedEventHandler(object sender, PipelineFaultedEventArgs args);
 
+/// <summary>
+/// Contains data for pipeline-faulted notifications.
+/// </summary>
 public sealed class PipelineFaultedEventArgs
 {
+    /// <summary>
+    /// Initializes a new pipeline-faulted payload.
+    /// </summary>
     public PipelineFaultedEventArgs(string pipelineName, PipelineFaultState fault)
     {
         PipelineName = Guard.Against.NullOrWhiteSpace(pipelineName, nameof(pipelineName));
         Fault = Guard.Against.Null(fault, nameof(fault));
     }
 
+    /// <summary>
+    /// Gets the logical pipeline name.
+    /// </summary>
     public string PipelineName { get; }
 
+    /// <summary>
+    /// Gets the recorded pipeline fault.
+    /// </summary>
     public PipelineFaultState Fault { get; }
 
+    /// <summary>
+    /// Gets the underlying exception.
+    /// </summary>
     public Exception Exception => Fault.Exception;
 
+    /// <summary>
+    /// Gets the faulting component name.
+    /// </summary>
     public string ComponentName => Fault.ComponentName;
 
+    /// <summary>
+    /// Gets the kind of component that faulted.
+    /// </summary>
     public PipelineComponentKind ComponentKind => Fault.ComponentKind;
 }
 
+/// <summary>
+/// Represents a handler for worker-started notifications.
+/// </summary>
 public delegate void PipelineWorkerStartedEventHandler(object sender, PipelineWorkerStartedEventArgs args);
 
+/// <summary>
+/// Contains data for worker-started notifications.
+/// </summary>
 public sealed class PipelineWorkerStartedEventArgs
 {
+    /// <summary>
+    /// Initializes a new worker-started payload.
+    /// </summary>
     public PipelineWorkerStartedEventArgs(PipelineRuntimeContext runtimeContext)
     {
         RuntimeContext = Guard.Against.Null(runtimeContext, nameof(runtimeContext));
     }
 
+    /// <summary>
+    /// Gets the current runtime context.
+    /// </summary>
     public PipelineRuntimeContext RuntimeContext { get; }
 }
 
+/// <summary>
+/// Represents a handler for worker-stopping notifications.
+/// </summary>
 public delegate void PipelineWorkerStoppingEventHandler(object sender, PipelineWorkerStoppingEventArgs args);
 
+/// <summary>
+/// Contains data for worker-stopping notifications.
+/// </summary>
 public sealed class PipelineWorkerStoppingEventArgs
 {
+    /// <summary>
+    /// Initializes a new worker-stopping payload.
+    /// </summary>
     public PipelineWorkerStoppingEventArgs(PipelineRuntimeContext runtimeContext)
     {
         RuntimeContext = Guard.Against.Null(runtimeContext, nameof(runtimeContext));
     }
 
+    /// <summary>
+    /// Gets the current runtime context.
+    /// </summary>
     public PipelineRuntimeContext RuntimeContext { get; }
 }
 
+/// <summary>
+/// Represents a handler for partition-assigned notifications.
+/// </summary>
 public delegate void PipelinePartitionsAssignedEventHandler(object sender, PipelinePartitionsAssignedEventArgs args);
 
+/// <summary>
+/// Contains data for partition-assigned notifications.
+/// </summary>
 public sealed class PipelinePartitionsAssignedEventArgs
 {
+    /// <summary>
+    /// Initializes a new partition-assigned payload.
+    /// </summary>
     public PipelinePartitionsAssignedEventArgs(
         PipelineRuntimeContext runtimeContext,
         IReadOnlyList<PipelinePartitionLease> partitions)
@@ -303,20 +544,47 @@ public sealed class PipelinePartitionsAssignedEventArgs
         Partitions = Guard.Against.Null(partitions, nameof(partitions)).ToArray();
     }
 
+    /// <summary>
+    /// Gets the current runtime context.
+    /// </summary>
     public PipelineRuntimeContext RuntimeContext { get; }
 
+    /// <summary>
+    /// Gets the current worker identifier.
+    /// </summary>
     public string WorkerId => RuntimeContext.WorkerId;
 
+    /// <summary>
+    /// Gets the partitions assigned to the worker.
+    /// </summary>
     public IReadOnlyList<PipelinePartitionLease> Partitions { get; }
 }
 
+/// <summary>
+/// Represents a handler for partition-revoked notifications.
+/// </summary>
 public delegate void PipelinePartitionsRevokedEventHandler(object sender, PipelinePartitionsRevokedEventArgs args);
+/// <summary>
+/// Represents a handler for partition-draining notifications.
+/// </summary>
 public delegate void PipelinePartitionDrainingEventHandler(object sender, PipelinePartitionDrainingEventArgs args);
+/// <summary>
+/// Represents a handler for partition-drained notifications.
+/// </summary>
 public delegate void PipelinePartitionDrainedEventHandler(object sender, PipelinePartitionDrainedEventArgs args);
+/// <summary>
+/// Represents a handler for partition-execution-state-changed notifications.
+/// </summary>
 public delegate void PipelinePartitionExecutionStateChangedEventHandler(object sender, PipelinePartitionExecutionStateChangedEventArgs args);
 
+/// <summary>
+/// Contains data for partition-revoked notifications.
+/// </summary>
 public sealed class PipelinePartitionsRevokedEventArgs
 {
+    /// <summary>
+    /// Initializes a new partition-revoked payload.
+    /// </summary>
     public PipelinePartitionsRevokedEventArgs(
         PipelineRuntimeContext runtimeContext,
         IReadOnlyList<PipelinePartitionLease> partitions)
@@ -325,15 +593,30 @@ public sealed class PipelinePartitionsRevokedEventArgs
         Partitions = Guard.Against.Null(partitions, nameof(partitions)).ToArray();
     }
 
+    /// <summary>
+    /// Gets the current runtime context.
+    /// </summary>
     public PipelineRuntimeContext RuntimeContext { get; }
 
+    /// <summary>
+    /// Gets the current worker identifier.
+    /// </summary>
     public string WorkerId => RuntimeContext.WorkerId;
 
+    /// <summary>
+    /// Gets the partitions revoked from the worker.
+    /// </summary>
     public IReadOnlyList<PipelinePartitionLease> Partitions { get; }
 }
 
+/// <summary>
+/// Contains data for partition-draining notifications.
+/// </summary>
 public sealed class PipelinePartitionDrainingEventArgs
 {
+    /// <summary>
+    /// Initializes a new partition-draining payload.
+    /// </summary>
     public PipelinePartitionDrainingEventArgs(
         PipelineRuntimeContext runtimeContext,
         PipelinePartitionLease partition)
@@ -342,13 +625,25 @@ public sealed class PipelinePartitionDrainingEventArgs
         Partition = Guard.Against.Null(partition, nameof(partition));
     }
 
+    /// <summary>
+    /// Gets the current runtime context.
+    /// </summary>
     public PipelineRuntimeContext RuntimeContext { get; }
 
+    /// <summary>
+    /// Gets the partition that is draining.
+    /// </summary>
     public PipelinePartitionLease Partition { get; }
 }
 
+/// <summary>
+/// Contains data for partition-drained notifications.
+/// </summary>
 public sealed class PipelinePartitionDrainedEventArgs
 {
+    /// <summary>
+    /// Initializes a new partition-drained payload.
+    /// </summary>
     public PipelinePartitionDrainedEventArgs(
         PipelineRuntimeContext runtimeContext,
         PipelinePartitionLease partition)
@@ -357,13 +652,25 @@ public sealed class PipelinePartitionDrainedEventArgs
         Partition = Guard.Against.Null(partition, nameof(partition));
     }
 
+    /// <summary>
+    /// Gets the current runtime context.
+    /// </summary>
     public PipelineRuntimeContext RuntimeContext { get; }
 
+    /// <summary>
+    /// Gets the partition that finished draining.
+    /// </summary>
     public PipelinePartitionLease Partition { get; }
 }
 
+/// <summary>
+/// Contains data for partition-execution-state-changed notifications.
+/// </summary>
 public sealed class PipelinePartitionExecutionStateChangedEventArgs
 {
+    /// <summary>
+    /// Initializes a new partition-execution-state-changed payload.
+    /// </summary>
     public PipelinePartitionExecutionStateChangedEventArgs(
         PipelineRuntimeContext runtimeContext,
         Distributed.PipelinePartitionExecutionState state)
@@ -372,7 +679,13 @@ public sealed class PipelinePartitionExecutionStateChangedEventArgs
         State = Guard.Against.Null(state, nameof(state));
     }
 
+    /// <summary>
+    /// Gets the current runtime context.
+    /// </summary>
     public PipelineRuntimeContext RuntimeContext { get; }
 
+    /// <summary>
+    /// Gets the updated partition execution state.
+    /// </summary>
     public Distributed.PipelinePartitionExecutionState State { get; }
 }

--- a/src/Pipelinez/Core/FaultHandling/PipelineComponentKind.cs
+++ b/src/Pipelinez/Core/FaultHandling/PipelineComponentKind.cs
@@ -1,9 +1,24 @@
 namespace Pipelinez.Core.FaultHandling;
 
+/// <summary>
+/// Identifies the pipeline component that originated a fault.
+/// </summary>
 public enum PipelineComponentKind
 {
+    /// <summary>
+    /// The fault originated in the source component.
+    /// </summary>
     Source,
+    /// <summary>
+    /// The fault originated in a segment component.
+    /// </summary>
     Segment,
+    /// <summary>
+    /// The fault originated in the destination component.
+    /// </summary>
     Destination,
+    /// <summary>
+    /// The fault originated in pipeline orchestration code.
+    /// </summary>
     Pipeline
 }

--- a/src/Pipelinez/Core/FaultHandling/PipelineFaultState.cs
+++ b/src/Pipelinez/Core/FaultHandling/PipelineFaultState.cs
@@ -2,8 +2,14 @@ using Ardalis.GuardClauses;
 
 namespace Pipelinez.Core.FaultHandling;
 
+/// <summary>
+/// Represents a fault captured by Pipelinez for a record or the pipeline runtime.
+/// </summary>
 public sealed class PipelineFaultState
 {
+    /// <summary>
+    /// Initializes a new fault state instance.
+    /// </summary>
     public PipelineFaultState(
         Exception exception,
         string componentName,
@@ -18,13 +24,28 @@ public sealed class PipelineFaultState
         Message = message;
     }
 
+    /// <summary>
+    /// Gets the underlying exception that caused the fault.
+    /// </summary>
     public Exception Exception { get; }
 
+    /// <summary>
+    /// Gets the logical component name that produced the fault.
+    /// </summary>
     public string ComponentName { get; }
 
+    /// <summary>
+    /// Gets the kind of component that produced the fault.
+    /// </summary>
     public PipelineComponentKind ComponentKind { get; }
 
+    /// <summary>
+    /// Gets the time the fault occurred.
+    /// </summary>
     public DateTimeOffset OccurredAtUtc { get; }
 
+    /// <summary>
+    /// Gets the consumer-facing message associated with the fault.
+    /// </summary>
     public string? Message { get; }
 }

--- a/src/Pipelinez/Core/FaultHandling/PipelineSegmentExecution.cs
+++ b/src/Pipelinez/Core/FaultHandling/PipelineSegmentExecution.cs
@@ -2,8 +2,14 @@ using Ardalis.GuardClauses;
 
 namespace Pipelinez.Core.FaultHandling;
 
+/// <summary>
+/// Records the execution outcome for a pipeline segment.
+/// </summary>
 public sealed class PipelineSegmentExecution
 {
+    /// <summary>
+    /// Initializes a new segment execution record.
+    /// </summary>
     public PipelineSegmentExecution(
         string segmentName,
         DateTimeOffset startedAtUtc,
@@ -18,15 +24,33 @@ public sealed class PipelineSegmentExecution
         FailureMessage = failureMessage;
     }
 
+    /// <summary>
+    /// Gets the segment name.
+    /// </summary>
     public string SegmentName { get; }
 
+    /// <summary>
+    /// Gets the time segment execution started.
+    /// </summary>
     public DateTimeOffset StartedAtUtc { get; }
 
+    /// <summary>
+    /// Gets the time segment execution completed.
+    /// </summary>
     public DateTimeOffset CompletedAtUtc { get; }
 
+    /// <summary>
+    /// Gets the total execution duration for the segment.
+    /// </summary>
     public TimeSpan Duration => CompletedAtUtc - StartedAtUtc;
 
+    /// <summary>
+    /// Gets a value indicating whether the segment completed successfully.
+    /// </summary>
     public bool Succeeded { get; }
 
+    /// <summary>
+    /// Gets the failure message recorded for the segment, if execution failed.
+    /// </summary>
     public string? FailureMessage { get; }
 }

--- a/src/Pipelinez/Core/Flow/IFlowDestination.cs
+++ b/src/Pipelinez/Core/Flow/IFlowDestination.cs
@@ -3,10 +3,14 @@ using System.Threading.Tasks.Dataflow;
 namespace Pipelinez.Core.Flow;
 
 /// <summary>
-/// Defines an interface that would be implemented by a target for a pipeline flow
+/// Defines a destination that can accept input from an upstream flow source.
 /// </summary>
-/// <typeparam name="TInput">Type this flow will accept</typeparam>
+/// <typeparam name="TInput">The type of messages accepted by the destination.</typeparam>
 public interface IFlowDestination<TInput>
 {
+    /// <summary>
+    /// Gets the underlying Dataflow target block used to receive messages.
+    /// </summary>
+    /// <returns>The target block that should receive linked input.</returns>
     ITargetBlock<TInput> AsTargetBlock();
 }

--- a/src/Pipelinez/Core/Flow/IFlowSource.cs
+++ b/src/Pipelinez/Core/Flow/IFlowSource.cs
@@ -3,11 +3,16 @@ using System.Threading.Tasks.Dataflow;
 namespace Pipelinez.Core.Flow;
 
 /// <summary>
-/// Defines a source for a pipeline flow
+/// Defines a source that can connect its output to a downstream flow destination.
 /// </summary>
-/// <typeparam name="TOutput">Type this flow will publish</typeparam>
+/// <typeparam name="TOutput">The type of messages produced by the source.</typeparam>
 public interface IFlowSource<TOutput>
 {
+    /// <summary>
+    /// Connects the source to a downstream destination.
+    /// </summary>
+    /// <param name="target">The destination that should receive published output.</param>
+    /// <param name="options">Optional Dataflow link options applied to the connection.</param>
+    /// <returns>A disposable link handle that can be used to disconnect the source from the destination.</returns>
     IDisposable ConnectTo(IFlowDestination<TOutput> target, DataflowLinkOptions? options = null);
-    
 }

--- a/src/Pipelinez/Core/FlowControl/PipelineComponentFlowStatus.cs
+++ b/src/Pipelinez/Core/FlowControl/PipelineComponentFlowStatus.cs
@@ -1,7 +1,13 @@
 namespace Pipelinez.Core.FlowControl;
 
+/// <summary>
+/// Describes the flow-control state of a single pipeline component.
+/// </summary>
 public sealed class PipelineComponentFlowStatus
 {
+    /// <summary>
+    /// Initializes a new component flow-control snapshot.
+    /// </summary>
     public PipelineComponentFlowStatus(
         string name,
         int approximateQueueDepth,
@@ -12,14 +18,29 @@ public sealed class PipelineComponentFlowStatus
         BoundedCapacity = boundedCapacity;
     }
 
+    /// <summary>
+    /// Gets the component name.
+    /// </summary>
     public string Name { get; }
 
+    /// <summary>
+    /// Gets the approximate number of buffered items for the component.
+    /// </summary>
     public int ApproximateQueueDepth { get; }
 
+    /// <summary>
+    /// Gets the component's bounded capacity, if one is configured.
+    /// </summary>
     public int? BoundedCapacity { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether the component is currently saturated.
+    /// </summary>
     public bool IsSaturated => BoundedCapacity.HasValue && ApproximateQueueDepth >= BoundedCapacity.Value;
 
+    /// <summary>
+    /// Gets the saturation ratio for the component when a bounded capacity exists.
+    /// </summary>
     public double SaturationRatio => BoundedCapacity.HasValue && BoundedCapacity.Value > 0
         ? Math.Min(1d, (double)ApproximateQueueDepth / BoundedCapacity.Value)
         : 0d;

--- a/src/Pipelinez/Core/FlowControl/PipelineFlowControlOptions.cs
+++ b/src/Pipelinez/Core/FlowControl/PipelineFlowControlOptions.cs
@@ -2,16 +2,35 @@ using Ardalis.GuardClauses;
 
 namespace Pipelinez.Core.FlowControl;
 
+/// <summary>
+/// Configures pipeline-wide flow-control behavior.
+/// </summary>
 public sealed class PipelineFlowControlOptions
 {
+    /// <summary>
+    /// Gets the default overflow policy used when publication encounters saturation.
+    /// </summary>
     public PipelineOverflowPolicy OverflowPolicy { get; init; } = PipelineOverflowPolicy.Wait;
 
+    /// <summary>
+    /// Gets the default timeout used while waiting for capacity.
+    /// </summary>
     public TimeSpan? PublishTimeout { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether saturation change events should be emitted.
+    /// </summary>
     public bool EmitSaturationEvents { get; init; } = true;
 
+    /// <summary>
+    /// Gets the saturation ratio threshold that should be treated as a warning level.
+    /// </summary>
     public double SaturationWarningThreshold { get; init; } = 0.80d;
 
+    /// <summary>
+    /// Validates the configured options.
+    /// </summary>
+    /// <returns>The validated options instance.</returns>
     public PipelineFlowControlOptions Validate()
     {
         if (PublishTimeout.HasValue && PublishTimeout.Value <= TimeSpan.Zero)

--- a/src/Pipelinez/Core/FlowControl/PipelineFlowControlStatus.cs
+++ b/src/Pipelinez/Core/FlowControl/PipelineFlowControlStatus.cs
@@ -1,7 +1,13 @@
 namespace Pipelinez.Core.FlowControl;
 
+/// <summary>
+/// Represents the current flow-control state of the pipeline as a whole.
+/// </summary>
 public sealed class PipelineFlowControlStatus
 {
+    /// <summary>
+    /// Initializes a new flow-control snapshot.
+    /// </summary>
     public PipelineFlowControlStatus(
         PipelineOverflowPolicy overflowPolicy,
         bool isSaturated,
@@ -18,15 +24,33 @@ public sealed class PipelineFlowControlStatus
         Components = components;
     }
 
+    /// <summary>
+    /// Gets the default overflow policy applied by the pipeline.
+    /// </summary>
     public PipelineOverflowPolicy OverflowPolicy { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether any component is currently saturated.
+    /// </summary>
     public bool IsSaturated { get; }
 
+    /// <summary>
+    /// Gets the overall saturation ratio across bounded components.
+    /// </summary>
     public double SaturationRatio { get; }
 
+    /// <summary>
+    /// Gets the total buffered record count across observed components.
+    /// </summary>
     public int TotalBufferedCount { get; }
 
+    /// <summary>
+    /// Gets the total bounded capacity across observed components, if one exists.
+    /// </summary>
     public int? TotalCapacity { get; }
 
+    /// <summary>
+    /// Gets the component-level flow snapshots.
+    /// </summary>
     public IReadOnlyList<PipelineComponentFlowStatus> Components { get; }
 }

--- a/src/Pipelinez/Core/FlowControl/PipelineOverflowPolicy.cs
+++ b/src/Pipelinez/Core/FlowControl/PipelineOverflowPolicy.cs
@@ -1,8 +1,20 @@
 namespace Pipelinez.Core.FlowControl;
 
+/// <summary>
+/// Determines how publication behaves when the pipeline is saturated.
+/// </summary>
 public enum PipelineOverflowPolicy
 {
+    /// <summary>
+    /// Wait for capacity to become available.
+    /// </summary>
     Wait,
+    /// <summary>
+    /// Reject the publish request immediately.
+    /// </summary>
     Reject,
+    /// <summary>
+    /// Cancel the publish request if it would need to wait for capacity.
+    /// </summary>
     Cancel
 }

--- a/src/Pipelinez/Core/FlowControl/PipelinePublishOptions.cs
+++ b/src/Pipelinez/Core/FlowControl/PipelinePublishOptions.cs
@@ -1,13 +1,29 @@
 namespace Pipelinez.Core.FlowControl;
 
+/// <summary>
+/// Specifies per-call flow-control behavior for a publish request.
+/// </summary>
 public sealed class PipelinePublishOptions
 {
+    /// <summary>
+    /// Gets the maximum time to wait for capacity before the publish attempt times out.
+    /// </summary>
     public TimeSpan? Timeout { get; init; }
 
+    /// <summary>
+    /// Gets the cancellation token used to cancel the publish request while waiting for capacity.
+    /// </summary>
     public CancellationToken CancellationToken { get; init; } = CancellationToken.None;
 
+    /// <summary>
+    /// Gets the overflow policy override applied to this publish request.
+    /// </summary>
     public PipelineOverflowPolicy? OverflowPolicyOverride { get; init; }
 
+    /// <summary>
+    /// Validates the configured options.
+    /// </summary>
+    /// <returns>The validated options instance.</returns>
     public PipelinePublishOptions Validate()
     {
         if (Timeout.HasValue && Timeout.Value <= TimeSpan.Zero)

--- a/src/Pipelinez/Core/FlowControl/PipelinePublishResult.cs
+++ b/src/Pipelinez/Core/FlowControl/PipelinePublishResult.cs
@@ -2,6 +2,9 @@ using System.Runtime.ExceptionServices;
 
 namespace Pipelinez.Core.FlowControl;
 
+/// <summary>
+/// Represents the result of attempting to publish a record into the pipeline.
+/// </summary>
 public sealed class PipelinePublishResult
 {
     private PipelinePublishResult(
@@ -14,17 +17,37 @@ public sealed class PipelinePublishResult
         WaitDuration = waitDuration;
     }
 
+    /// <summary>
+    /// Gets a value indicating whether the record was accepted by the pipeline.
+    /// </summary>
     public bool Accepted { get; }
 
+    /// <summary>
+    /// Gets the reason associated with the publish outcome.
+    /// </summary>
     public PipelinePublishResultReason Reason { get; }
 
+    /// <summary>
+    /// Gets the amount of time spent waiting for capacity before the outcome was produced.
+    /// </summary>
     public TimeSpan WaitDuration { get; }
 
+    /// <summary>
+    /// Creates a successful publish result.
+    /// </summary>
+    /// <param name="waitDuration">The time spent waiting for capacity.</param>
+    /// <returns>A successful publish result.</returns>
     public static PipelinePublishResult AcceptedResult(TimeSpan waitDuration)
     {
         return new PipelinePublishResult(true, PipelinePublishResultReason.Accepted, waitDuration);
     }
 
+    /// <summary>
+    /// Creates a rejected publish result.
+    /// </summary>
+    /// <param name="reason">The rejection reason.</param>
+    /// <param name="waitDuration">The time spent waiting before rejection.</param>
+    /// <returns>A rejected publish result.</returns>
     public static PipelinePublishResult Rejected(PipelinePublishResultReason reason, TimeSpan waitDuration)
     {
         if (reason == PipelinePublishResultReason.Accepted)
@@ -35,6 +58,9 @@ public sealed class PipelinePublishResult
         return new PipelinePublishResult(false, reason, waitDuration);
     }
 
+    /// <summary>
+    /// Throws an exception when the publish attempt was not accepted.
+    /// </summary>
     public void ThrowIfNotAccepted()
     {
         if (Accepted)

--- a/src/Pipelinez/Core/FlowControl/PipelinePublishResultReason.cs
+++ b/src/Pipelinez/Core/FlowControl/PipelinePublishResultReason.cs
@@ -1,9 +1,24 @@
 namespace Pipelinez.Core.FlowControl;
 
+/// <summary>
+/// Describes the outcome of a publish attempt.
+/// </summary>
 public enum PipelinePublishResultReason
 {
+    /// <summary>
+    /// The record was accepted by the pipeline.
+    /// </summary>
     Accepted,
+    /// <summary>
+    /// The record was rejected because the configured overflow policy refused publication.
+    /// </summary>
     RejectedByOverflowPolicy,
+    /// <summary>
+    /// The publish request timed out before capacity became available.
+    /// </summary>
     TimedOut,
+    /// <summary>
+    /// The publish request was canceled before capacity became available.
+    /// </summary>
     Canceled
 }

--- a/src/Pipelinez/Core/IPipeline.cs
+++ b/src/Pipelinez/Core/IPipeline.cs
@@ -9,43 +9,71 @@ using Pipelinez.Core.Status;
 
 namespace Pipelinez.Core;
 
+/// <summary>
+/// Represents a running pipeline that can accept, process, and complete records.
+/// </summary>
+/// <typeparam name="T">The pipeline record type processed by the pipeline.</typeparam>
 public interface IPipeline<T> where T : PipelineRecord
 {
     /// <summary>
-    /// Starts up the pipeline
+    /// Starts the pipeline runtime.
     /// </summary>
-    /// <param name="cancellationToken">A token allowing the cancellation of the pipeline</param>
-    /// <returns></returns>
+    /// <param name="cancellationToken">A token used to cancel startup or runtime execution.</param>
+    /// <returns>A task that completes once startup has finished.</returns>
     Task StartPipelineAsync(CancellationToken cancellationToken = default);
     
     /// <summary>
-    /// Publishes a record into the pipeline. Acts as a manual source for the pipeline.
+    /// Publishes a record into the pipeline using the default flow-control behavior.
     /// </summary>
-    /// <returns></returns>
+    /// <param name="record">The record to publish.</param>
     Task PublishAsync(T record);
 
     /// <summary>
     /// Publishes a record into the pipeline with explicit flow-control behavior.
     /// </summary>
+    /// <param name="record">The record to publish.</param>
+    /// <param name="options">The publish options to apply.</param>
+    /// <returns>The publish result.</returns>
     Task<PipelinePublishResult> PublishAsync(T record, PipelinePublishOptions options);
 
     /// <summary>
     /// Completes and shuts down the pipeline.
     /// </summary>
+    /// <returns>A task that completes once the pipeline has fully shut down.</returns>
     Task CompleteAsync();
 
     /// <summary>Gets a <see cref="T:System.Threading.Tasks.Task" /> that represents the asynchronous operation and completion of the pipeline.</summary>
     /// <returns>The task.</returns>
     Task Completion { get; }
 
+    /// <summary>
+    /// Gets the current runtime status snapshot for the pipeline.
+    /// </summary>
+    /// <returns>The current pipeline status.</returns>
     PipelineStatus GetStatus();
 
+    /// <summary>
+    /// Gets the current distributed runtime context for the pipeline.
+    /// </summary>
+    /// <returns>The current runtime context.</returns>
     PipelineRuntimeContext GetRuntimeContext();
 
+    /// <summary>
+    /// Gets the current performance snapshot for the pipeline.
+    /// </summary>
+    /// <returns>The current performance snapshot.</returns>
     PipelinePerformanceSnapshot GetPerformanceSnapshot();
 
+    /// <summary>
+    /// Gets the current health snapshot for the pipeline.
+    /// </summary>
+    /// <returns>The current health snapshot.</returns>
     PipelineHealthStatus GetHealthStatus();
 
+    /// <summary>
+    /// Gets the current operational snapshot for the pipeline.
+    /// </summary>
+    /// <returns>The current operational snapshot.</returns>
     PipelineOperationalSnapshot GetOperationalSnapshot();
     
     #region Eventing

--- a/src/Pipelinez/Core/Operational/PipelineHealthCheck.cs
+++ b/src/Pipelinez/Core/Operational/PipelineHealthCheck.cs
@@ -3,18 +3,30 @@ using Pipelinez.Core.Record;
 
 namespace Pipelinez.Core.Operational;
 
+/// <summary>
+/// Adapts a Pipelinez pipeline into a standard ASP.NET Core health check.
+/// </summary>
+/// <typeparam name="T">The pipeline record type handled by the pipeline.</typeparam>
 public sealed class PipelineHealthCheck<T> : IHealthCheck
     where T : PipelineRecord
 {
     private readonly IPipeline<T> _pipeline;
     private readonly bool _includeComponentDiagnostics;
 
+    /// <summary>
+    /// Initializes a new pipeline health check.
+    /// </summary>
+    /// <param name="pipeline">The pipeline to inspect.</param>
+    /// <param name="includeComponentDiagnostics">
+    /// A value indicating whether component status information should be included in the health-check payload.
+    /// </param>
     public PipelineHealthCheck(IPipeline<T> pipeline, bool includeComponentDiagnostics = true)
     {
         _pipeline = pipeline ?? throw new ArgumentNullException(nameof(pipeline));
         _includeComponentDiagnostics = includeComponentDiagnostics;
     }
 
+    /// <inheritdoc />
     public Task<HealthCheckResult> CheckHealthAsync(
         HealthCheckContext context,
         CancellationToken cancellationToken = default)

--- a/src/Pipelinez/Core/Operational/PipelineHealthState.cs
+++ b/src/Pipelinez/Core/Operational/PipelineHealthState.cs
@@ -1,10 +1,28 @@
 namespace Pipelinez.Core.Operational;
 
+/// <summary>
+/// Represents the current health state of a pipeline.
+/// </summary>
 public enum PipelineHealthState
 {
+    /// <summary>
+    /// The pipeline is starting up and has not yet reached steady-state execution.
+    /// </summary>
     Starting = 0,
+    /// <summary>
+    /// The pipeline is operating normally.
+    /// </summary>
     Healthy = 1,
+    /// <summary>
+    /// The pipeline is operating but has exceeded one or more degraded thresholds.
+    /// </summary>
     Degraded = 2,
+    /// <summary>
+    /// The pipeline is unhealthy or faulted.
+    /// </summary>
     Unhealthy = 3,
+    /// <summary>
+    /// The pipeline completed successfully.
+    /// </summary>
     Completed = 4
 }

--- a/src/Pipelinez/Core/Operational/PipelineHealthStatus.cs
+++ b/src/Pipelinez/Core/Operational/PipelineHealthStatus.cs
@@ -5,8 +5,14 @@ using Pipelinez.Core.Status;
 
 namespace Pipelinez.Core.Operational;
 
+/// <summary>
+/// Represents a health snapshot for a pipeline.
+/// </summary>
 public sealed class PipelineHealthStatus
 {
+    /// <summary>
+    /// Initializes a new health status snapshot.
+    /// </summary>
     public PipelineHealthStatus(
         string pipelineName,
         PipelineHealthState state,
@@ -25,19 +31,43 @@ public sealed class PipelineHealthStatus
         LastPipelineFault = lastPipelineFault;
     }
 
+    /// <summary>
+    /// Gets the pipeline name.
+    /// </summary>
     public string PipelineName { get; }
 
+    /// <summary>
+    /// Gets the current health state.
+    /// </summary>
     public PipelineHealthState State { get; }
 
+    /// <summary>
+    /// Gets the list of reasons contributing to the health state.
+    /// </summary>
     public IReadOnlyList<string> Reasons { get; }
 
+    /// <summary>
+    /// Gets a single formatted health reason string, when available.
+    /// </summary>
     public string? Reason => Reasons.Count == 0 ? null : string.Join("; ", Reasons);
 
+    /// <summary>
+    /// Gets the time the health snapshot was observed.
+    /// </summary>
     public DateTimeOffset ObservedAtUtc { get; }
 
+    /// <summary>
+    /// Gets the runtime status snapshot used to evaluate health.
+    /// </summary>
     public PipelineStatus RuntimeStatus { get; }
 
+    /// <summary>
+    /// Gets the performance snapshot used to evaluate health.
+    /// </summary>
     public PipelinePerformanceSnapshot Performance { get; }
 
+    /// <summary>
+    /// Gets the last pipeline-level fault, if one has occurred.
+    /// </summary>
     public PipelineFaultState? LastPipelineFault { get; }
 }

--- a/src/Pipelinez/Core/Operational/PipelineOperationalMetadataKeys.cs
+++ b/src/Pipelinez/Core/Operational/PipelineOperationalMetadataKeys.cs
@@ -1,6 +1,12 @@
 namespace Pipelinez.Core.Operational;
 
+/// <summary>
+/// Defines metadata keys used by Pipelinez operational tooling.
+/// </summary>
 public static class PipelineOperationalMetadataKeys
 {
+    /// <summary>
+    /// The metadata key that stores the record correlation identifier.
+    /// </summary>
     public const string CorrelationId = "pipelinez.correlation.id";
 }

--- a/src/Pipelinez/Core/Operational/PipelineOperationalOptions.cs
+++ b/src/Pipelinez/Core/Operational/PipelineOperationalOptions.cs
@@ -2,26 +2,60 @@ using Ardalis.GuardClauses;
 
 namespace Pipelinez.Core.Operational;
 
+/// <summary>
+/// Configures health, diagnostics, and metrics behavior for the pipeline runtime.
+/// </summary>
 public sealed class PipelineOperationalOptions
 {
+    /// <summary>
+    /// Gets a value indicating whether health checks are enabled.
+    /// </summary>
     public bool EnableHealthChecks { get; init; } = true;
 
+    /// <summary>
+    /// Gets a value indicating whether metrics emission is enabled.
+    /// </summary>
     public bool EnableMetrics { get; init; } = true;
 
+    /// <summary>
+    /// Gets a value indicating whether correlation identifiers should be added to records.
+    /// </summary>
     public bool EnableCorrelationIds { get; init; } = true;
 
+    /// <summary>
+    /// Gets a value indicating whether component details should be included in health-check results.
+    /// </summary>
     public bool IncludeComponentDiagnosticsInHealthResults { get; init; } = true;
 
+    /// <summary>
+    /// Gets the saturation ratio at which the pipeline should be considered degraded.
+    /// </summary>
     public double SaturationDegradedThreshold { get; init; } = 0.90d;
 
+    /// <summary>
+    /// Gets the retry exhaustion count at which the pipeline should be considered degraded.
+    /// </summary>
     public long RetryExhaustionDegradedThreshold { get; init; } = 1;
 
+    /// <summary>
+    /// Gets the dead-letter count at which the pipeline should be considered degraded.
+    /// </summary>
     public long DeadLetterDegradedThreshold { get; init; } = 1;
 
+    /// <summary>
+    /// Gets the publish rejection count at which the pipeline should be considered degraded.
+    /// </summary>
     public long PublishRejectionDegradedThreshold { get; init; } = 1;
 
+    /// <summary>
+    /// Gets the number of draining partitions at which the pipeline should be considered degraded.
+    /// </summary>
     public int DrainingPartitionDegradedThreshold { get; init; } = 1;
 
+    /// <summary>
+    /// Validates the configured options.
+    /// </summary>
+    /// <returns>The validated options instance.</returns>
     public PipelineOperationalOptions Validate()
     {
         Guard.Against.OutOfRange(SaturationDegradedThreshold, nameof(SaturationDegradedThreshold), 0d, 1d);

--- a/src/Pipelinez/Core/Operational/PipelineOperationalSnapshot.cs
+++ b/src/Pipelinez/Core/Operational/PipelineOperationalSnapshot.cs
@@ -5,8 +5,14 @@ using Pipelinez.Core.Status;
 
 namespace Pipelinez.Core.Operational;
 
+/// <summary>
+/// Represents an operator-focused runtime snapshot for a pipeline.
+/// </summary>
 public sealed class PipelineOperationalSnapshot
 {
+    /// <summary>
+    /// Initializes a new operational snapshot.
+    /// </summary>
     public PipelineOperationalSnapshot(
         PipelineStatus status,
         PipelinePerformanceSnapshot performance,
@@ -25,17 +31,38 @@ public sealed class PipelineOperationalSnapshot
         LastDeadLetteredAtUtc = lastDeadLetteredAtUtc;
     }
 
+    /// <summary>
+    /// Gets the runtime status snapshot.
+    /// </summary>
     public PipelineStatus Status { get; }
 
+    /// <summary>
+    /// Gets the performance snapshot.
+    /// </summary>
     public PipelinePerformanceSnapshot Performance { get; }
 
+    /// <summary>
+    /// Gets the health snapshot.
+    /// </summary>
     public PipelineHealthStatus Health { get; }
 
+    /// <summary>
+    /// Gets the time the snapshot was observed.
+    /// </summary>
     public DateTimeOffset ObservedAtUtc { get; }
 
+    /// <summary>
+    /// Gets the last pipeline-level fault, if one exists.
+    /// </summary>
     public PipelineFaultState? LastPipelineFault { get; }
 
+    /// <summary>
+    /// Gets the last successful record completion time, if one exists.
+    /// </summary>
     public DateTimeOffset? LastRecordCompletedAtUtc { get; }
 
+    /// <summary>
+    /// Gets the last dead-lettered record time, if one exists.
+    /// </summary>
     public DateTimeOffset? LastDeadLetteredAtUtc { get; }
 }

--- a/src/Pipelinez/Core/Operational/PipelineRecordDiagnosticContext.cs
+++ b/src/Pipelinez/Core/Operational/PipelineRecordDiagnosticContext.cs
@@ -2,8 +2,14 @@ using Ardalis.GuardClauses;
 
 namespace Pipelinez.Core.Operational;
 
+/// <summary>
+/// Captures diagnostic identifiers associated with a record as it moves through the pipeline.
+/// </summary>
 public sealed class PipelineRecordDiagnosticContext
 {
+    /// <summary>
+    /// Initializes a new record diagnostic context.
+    /// </summary>
     public PipelineRecordDiagnosticContext(
         string correlationId,
         string pipelineName,
@@ -18,13 +24,28 @@ public sealed class PipelineRecordDiagnosticContext
         ComponentName = componentName;
     }
 
+    /// <summary>
+    /// Gets the record correlation identifier.
+    /// </summary>
     public string CorrelationId { get; }
 
+    /// <summary>
+    /// Gets the pipeline name.
+    /// </summary>
     public string PipelineName { get; }
 
+    /// <summary>
+    /// Gets the host instance identifier.
+    /// </summary>
     public string InstanceId { get; }
 
+    /// <summary>
+    /// Gets the worker identifier.
+    /// </summary>
     public string WorkerId { get; }
 
+    /// <summary>
+    /// Gets the component name associated with the current diagnostic event, if one exists.
+    /// </summary>
     public string? ComponentName { get; }
 }

--- a/src/Pipelinez/Core/Performance/IPipelineExecutionConfigurable.cs
+++ b/src/Pipelinez/Core/Performance/IPipelineExecutionConfigurable.cs
@@ -1,8 +1,19 @@
 namespace Pipelinez.Core.Performance;
 
+/// <summary>
+/// Defines a component whose execution behavior can be tuned with Pipelinez execution options.
+/// </summary>
 public interface IPipelineExecutionConfigurable
 {
+    /// <summary>
+    /// Applies execution options to the component before it begins processing.
+    /// </summary>
+    /// <param name="options">The execution options to apply.</param>
     void ConfigureExecutionOptions(PipelineExecutionOptions options);
 
+    /// <summary>
+    /// Gets the execution options currently configured for the component.
+    /// </summary>
+    /// <returns>The active execution options.</returns>
     PipelineExecutionOptions GetExecutionOptions();
 }

--- a/src/Pipelinez/Core/Performance/PipelineBatchingOptions.cs
+++ b/src/Pipelinez/Core/Performance/PipelineBatchingOptions.cs
@@ -2,12 +2,25 @@ using Ardalis.GuardClauses;
 
 namespace Pipelinez.Core.Performance;
 
+/// <summary>
+/// Configures batch execution behavior for destinations that support batching.
+/// </summary>
 public sealed class PipelineBatchingOptions
 {
+    /// <summary>
+    /// Gets the maximum number of records included in a batch.
+    /// </summary>
     public int BatchSize { get; init; } = 100;
 
+    /// <summary>
+    /// Gets the maximum amount of time to wait before flushing a partial batch.
+    /// </summary>
     public TimeSpan MaxBatchDelay { get; init; } = TimeSpan.FromMilliseconds(100);
 
+    /// <summary>
+    /// Validates the configured options.
+    /// </summary>
+    /// <returns>The validated options instance.</returns>
     public PipelineBatchingOptions Validate()
     {
         Guard.Against.NegativeOrZero(BatchSize, nameof(BatchSize));

--- a/src/Pipelinez/Core/Performance/PipelineComponentPerformanceSnapshot.cs
+++ b/src/Pipelinez/Core/Performance/PipelineComponentPerformanceSnapshot.cs
@@ -1,7 +1,13 @@
 namespace Pipelinez.Core.Performance;
 
+/// <summary>
+/// Represents performance statistics for a single pipeline component.
+/// </summary>
 public sealed class PipelineComponentPerformanceSnapshot
 {
+    /// <summary>
+    /// Initializes a new component performance snapshot.
+    /// </summary>
     public PipelineComponentPerformanceSnapshot(
         string componentName,
         long processedCount,
@@ -18,15 +24,33 @@ public sealed class PipelineComponentPerformanceSnapshot
         QueueDepth = queueDepth;
     }
 
+    /// <summary>
+    /// Gets the component name.
+    /// </summary>
     public string ComponentName { get; }
 
+    /// <summary>
+    /// Gets the number of records processed successfully by the component.
+    /// </summary>
     public long ProcessedCount { get; }
 
+    /// <summary>
+    /// Gets the number of faulted executions observed for the component.
+    /// </summary>
     public long FaultedCount { get; }
 
+    /// <summary>
+    /// Gets the current calculated records-per-second rate for the component.
+    /// </summary>
     public double RecordsPerSecond { get; }
 
+    /// <summary>
+    /// Gets the average execution latency for the component.
+    /// </summary>
     public TimeSpan AverageExecutionLatency { get; }
 
+    /// <summary>
+    /// Gets the current queue depth, if available.
+    /// </summary>
     public int? QueueDepth { get; }
 }

--- a/src/Pipelinez/Core/Performance/PipelineExecutionOptions.cs
+++ b/src/Pipelinez/Core/Performance/PipelineExecutionOptions.cs
@@ -3,8 +3,15 @@ using Ardalis.GuardClauses;
 
 namespace Pipelinez.Core.Performance;
 
+/// <summary>
+/// Configures execution behavior for a source, segment, or destination.
+/// </summary>
 public sealed class PipelineExecutionOptions
 {
+    /// <summary>
+    /// Creates the default execution options used for sources.
+    /// </summary>
+    /// <returns>The default source execution options.</returns>
     public static PipelineExecutionOptions CreateDefaultSourceOptions()
     {
         return new PipelineExecutionOptions
@@ -15,6 +22,10 @@ public sealed class PipelineExecutionOptions
         };
     }
 
+    /// <summary>
+    /// Creates the default execution options used for segments.
+    /// </summary>
+    /// <returns>The default segment execution options.</returns>
     public static PipelineExecutionOptions CreateDefaultSegmentOptions()
     {
         return new PipelineExecutionOptions
@@ -25,6 +36,10 @@ public sealed class PipelineExecutionOptions
         };
     }
 
+    /// <summary>
+    /// Creates the default execution options used for destinations.
+    /// </summary>
+    /// <returns>The default destination execution options.</returns>
     public static PipelineExecutionOptions CreateDefaultDestinationOptions()
     {
         return new PipelineExecutionOptions
@@ -35,12 +50,25 @@ public sealed class PipelineExecutionOptions
         };
     }
 
+    /// <summary>
+    /// Gets the bounded capacity used by the underlying Dataflow block.
+    /// </summary>
     public int BoundedCapacity { get; init; } = DataflowBlockOptions.Unbounded;
 
+    /// <summary>
+    /// Gets the maximum degree of parallelism used by the component.
+    /// </summary>
     public int DegreeOfParallelism { get; init; } = 1;
 
+    /// <summary>
+    /// Gets a value indicating whether record ordering should be preserved.
+    /// </summary>
     public bool EnsureOrdered { get; init; } = true;
 
+    /// <summary>
+    /// Validates the configured options.
+    /// </summary>
+    /// <returns>The validated options instance.</returns>
     public PipelineExecutionOptions Validate()
     {
         if (BoundedCapacity != DataflowBlockOptions.Unbounded && BoundedCapacity <= 0)
@@ -55,6 +83,11 @@ public sealed class PipelineExecutionOptions
         return this;
     }
 
+    /// <summary>
+    /// Determines whether these options match another execution options instance.
+    /// </summary>
+    /// <param name="other">The options to compare.</param>
+    /// <returns><see langword="true" /> when the options are equivalent; otherwise, <see langword="false" />.</returns>
     public bool Matches(PipelineExecutionOptions? other)
     {
         return other is not null &&

--- a/src/Pipelinez/Core/Performance/PipelineMetricsOptions.cs
+++ b/src/Pipelinez/Core/Performance/PipelineMetricsOptions.cs
@@ -1,8 +1,17 @@
 namespace Pipelinez.Core.Performance;
 
+/// <summary>
+/// Configures which runtime metrics are emitted by the pipeline performance collector.
+/// </summary>
 public sealed class PipelineMetricsOptions
 {
+    /// <summary>
+    /// Gets a value indicating whether aggregate runtime metrics should be emitted.
+    /// </summary>
     public bool EnableRuntimeMetrics { get; init; } = true;
 
+    /// <summary>
+    /// Gets a value indicating whether per-component timing metrics should be emitted.
+    /// </summary>
     public bool EnablePerComponentTiming { get; init; } = true;
 }

--- a/src/Pipelinez/Core/Performance/PipelinePerformanceOptions.cs
+++ b/src/Pipelinez/Core/Performance/PipelinePerformanceOptions.cs
@@ -1,20 +1,42 @@
 namespace Pipelinez.Core.Performance;
 
+/// <summary>
+/// Configures performance-related execution settings for the pipeline.
+/// </summary>
 public sealed class PipelinePerformanceOptions
 {
+    /// <summary>
+    /// Gets the execution options applied to the source.
+    /// </summary>
     public PipelineExecutionOptions SourceExecution { get; init; } =
         PipelineExecutionOptions.CreateDefaultSourceOptions();
 
+    /// <summary>
+    /// Gets the default execution options applied to segments.
+    /// </summary>
     public PipelineExecutionOptions DefaultSegmentExecution { get; init; } =
         PipelineExecutionOptions.CreateDefaultSegmentOptions();
 
+    /// <summary>
+    /// Gets the execution options applied to the destination.
+    /// </summary>
     public PipelineExecutionOptions DestinationExecution { get; init; } =
         PipelineExecutionOptions.CreateDefaultDestinationOptions();
 
+    /// <summary>
+    /// Gets the batching options applied to the destination when it supports batching.
+    /// </summary>
     public PipelineBatchingOptions? DestinationBatching { get; init; }
 
+    /// <summary>
+    /// Gets the metrics collection options for performance instrumentation.
+    /// </summary>
     public PipelineMetricsOptions Metrics { get; init; } = new();
 
+    /// <summary>
+    /// Validates the configured options.
+    /// </summary>
+    /// <returns>The validated options instance.</returns>
     public PipelinePerformanceOptions Validate()
     {
         SourceExecution.Validate();

--- a/src/Pipelinez/Core/Performance/PipelinePerformanceSnapshot.cs
+++ b/src/Pipelinez/Core/Performance/PipelinePerformanceSnapshot.cs
@@ -1,7 +1,13 @@
 namespace Pipelinez.Core.Performance;
 
+/// <summary>
+/// Represents an aggregated performance snapshot for a running pipeline.
+/// </summary>
 public sealed class PipelinePerformanceSnapshot
 {
+    /// <summary>
+    /// Initializes a new pipeline performance snapshot.
+    /// </summary>
     public PipelinePerformanceSnapshot(
         DateTimeOffset startedAtUtc,
         TimeSpan elapsed,
@@ -40,37 +46,88 @@ public sealed class PipelinePerformanceSnapshot
         Components = components;
     }
 
+    /// <summary>
+    /// Gets the time performance collection started.
+    /// </summary>
     public DateTimeOffset StartedAtUtc { get; }
 
+    /// <summary>
+    /// Gets the elapsed time covered by the snapshot.
+    /// </summary>
     public TimeSpan Elapsed { get; }
 
+    /// <summary>
+    /// Gets the total number of records published into the pipeline.
+    /// </summary>
     public long TotalRecordsPublished { get; }
 
+    /// <summary>
+    /// Gets the total number of records completed successfully.
+    /// </summary>
     public long TotalRecordsCompleted { get; }
 
+    /// <summary>
+    /// Gets the total number of faulted records observed by the pipeline.
+    /// </summary>
     public long TotalRecordsFaulted { get; }
 
+    /// <summary>
+    /// Gets the total number of retry attempts performed.
+    /// </summary>
     public long TotalRetryCount { get; }
 
+    /// <summary>
+    /// Gets the number of times retry recovered a record successfully.
+    /// </summary>
     public long SuccessfulRetryRecoveries { get; }
 
+    /// <summary>
+    /// Gets the number of times retries were exhausted.
+    /// </summary>
     public long RetryExhaustions { get; }
 
+    /// <summary>
+    /// Gets the total number of dead-lettered records.
+    /// </summary>
     public long TotalDeadLetteredCount { get; }
 
+    /// <summary>
+    /// Gets the total number of dead-letter write failures.
+    /// </summary>
     public long TotalDeadLetterFailureCount { get; }
 
+    /// <summary>
+    /// Gets the total number of publish calls that waited for capacity.
+    /// </summary>
     public long TotalPublishWaitCount { get; }
 
+    /// <summary>
+    /// Gets the average duration spent waiting for capacity during publish.
+    /// </summary>
     public TimeSpan AveragePublishWaitDuration { get; }
 
+    /// <summary>
+    /// Gets the total number of rejected publish calls.
+    /// </summary>
     public long TotalPublishRejectedCount { get; }
 
+    /// <summary>
+    /// Gets the peak buffered record count observed across the pipeline.
+    /// </summary>
     public int PeakBufferedCount { get; }
 
+    /// <summary>
+    /// Gets the current calculated records-per-second rate for the pipeline.
+    /// </summary>
     public double RecordsPerSecond { get; }
 
+    /// <summary>
+    /// Gets the average end-to-end latency for completed records.
+    /// </summary>
     public TimeSpan AverageEndToEndLatency { get; }
 
+    /// <summary>
+    /// Gets the component-level performance snapshots.
+    /// </summary>
     public IReadOnlyList<PipelineComponentPerformanceSnapshot> Components { get; }
 }

--- a/src/Pipelinez/Core/Pipeline.cs
+++ b/src/Pipelinez/Core/Pipeline.cs
@@ -20,6 +20,10 @@ using Pipelinez.Core.Status;
 
 namespace Pipelinez.Core;
 
+/// <summary>
+/// Implements the Pipelinez runtime for a specific record type.
+/// </summary>
+/// <typeparam name="TPipelineRecord">The pipeline record type processed by the runtime.</typeparam>
 public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipelineRecord : PipelineRecord
 {
     private enum PipelineRuntimeState
@@ -35,10 +39,10 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     #region Builder
     
     /// <summary>
-    /// Initiates the build of a new pipeline with the specified PipelineRecord type
+    /// Creates a builder for a new pipeline with the specified name.
     /// </summary>
-    /// <param name="pipelineName">Name of the pipeline</param>
-    /// <returns></returns>
+    /// <param name="pipelineName">The logical name of the pipeline.</param>
+    /// <returns>A pipeline builder for the specified record type.</returns>
     public static PipelineBuilder<TPipelineRecord> New(string pipelineName)
     {
         return new PipelineBuilder<TPipelineRecord>(pipelineName);
@@ -84,6 +88,9 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     
     #region Logging
     
+    /// <summary>
+    /// Gets the logger used by the pipeline runtime.
+    /// </summary>
     protected ILogger<Pipeline<TPipelineRecord>> Logger { get; }
     
     #endregion
@@ -98,63 +105,45 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
     
     #region Eventing
 
-    /// <summary>
-    /// Occurs when a record in the pipeline has completed traversing the pipeline
-    /// </summary>
+    /// <inheritdoc />
     public event PipelineRecordCompletedEventHandler<TPipelineRecord>? OnPipelineRecordCompleted;
 
-    /// <summary>
-    /// Occurs when a record in the pipeline faults.
-    /// </summary>
+    /// <inheritdoc />
     public event PipelineRecordFaultedEventHandler<TPipelineRecord>? OnPipelineRecordFaulted;
 
-    /// <summary>
-    /// Occurs when a record is about to be retried after a transient failure.
-    /// </summary>
+    /// <inheritdoc />
     public event PipelineRecordRetryingEventHandler<TPipelineRecord>? OnPipelineRecordRetrying;
+    /// <inheritdoc />
     public event PipelineRecordDeadLetteredEventHandler<TPipelineRecord>? OnPipelineRecordDeadLettered;
+    /// <inheritdoc />
     public event PipelineDeadLetterWriteFailedEventHandler<TPipelineRecord>? OnPipelineDeadLetterWriteFailed;
+    /// <inheritdoc />
     public event PipelineSaturationChangedEventHandler? OnSaturationChanged;
+    /// <inheritdoc />
     public event PipelinePublishRejectedEventHandler<TPipelineRecord>? OnPublishRejected;
 
-    /// <summary>
-    /// Occurs when the pipeline transitions into a faulted state.
-    /// </summary>
+    /// <inheritdoc />
     public event PipelineFaultedEventHandler? OnPipelineFaulted;
 
-    /// <summary>
-    /// Occurs when the distributed worker starts.
-    /// </summary>
+    /// <inheritdoc />
     public event PipelineWorkerStartedEventHandler? OnWorkerStarted;
 
-    /// <summary>
-    /// Occurs when partitions are assigned to the current distributed worker.
-    /// </summary>
+    /// <inheritdoc />
     public event PipelinePartitionsAssignedEventHandler? OnPartitionsAssigned;
 
-    /// <summary>
-    /// Occurs when partitions are revoked from the current distributed worker.
-    /// </summary>
+    /// <inheritdoc />
     public event PipelinePartitionsRevokedEventHandler? OnPartitionsRevoked;
 
-    /// <summary>
-    /// Occurs when a partition begins draining.
-    /// </summary>
+    /// <inheritdoc />
     public event PipelinePartitionDrainingEventHandler? OnPartitionDraining;
 
-    /// <summary>
-    /// Occurs when a partition has drained.
-    /// </summary>
+    /// <inheritdoc />
     public event PipelinePartitionDrainedEventHandler? OnPartitionDrained;
 
-    /// <summary>
-    /// Occurs when partition execution state changes.
-    /// </summary>
+    /// <inheritdoc />
     public event PipelinePartitionExecutionStateChangedEventHandler? OnPartitionExecutionStateChanged;
 
-    /// <summary>
-    /// Occurs when the distributed worker begins stopping.
-    /// </summary>
+    /// <inheritdoc />
     public event PipelineWorkerStoppingEventHandler? OnWorkerStopping;
 
     /// <summary>
@@ -352,7 +341,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
 
     #endregion
     
-    // Initiates the pipeline
+    /// <inheritdoc />
     public Task StartPipelineAsync(CancellationToken cancellationToken = default)
     {
         CancellationTokenSource runtimeCancellationTokenSource;
@@ -400,12 +389,14 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public async Task PublishAsync(TPipelineRecord record)
     {
         var publishResult = await PublishAsync(record, new PipelinePublishOptions()).ConfigureAwait(false);
         publishResult.ThrowIfNotAccepted();
     }
 
+    /// <inheritdoc />
     public async Task<PipelinePublishResult> PublishAsync(
         TPipelineRecord record,
         PipelinePublishOptions options)
@@ -416,6 +407,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         return await _source.PublishAsync(record, Guard.Against.Null(options, nameof(options)).Validate()).ConfigureAwait(false);
     }
 
+    /// <inheritdoc />
     public async Task CompleteAsync()
     {
         Task completionTask = Completion;
@@ -476,10 +468,10 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         }
     }
     
-    /// <summary>Gets a <see cref="T:System.Threading.Tasks.Task" /> that represents the asynchronous operation and completion of the pipeline.</summary>
-    /// <returns>The task.</returns>
+    /// <inheritdoc />
     public Task Completion => _completionSource.Task;
 
+    /// <inheritdoc />
     public PipelineStatus GetStatus()
     {
         var flowControlStatus = GetFlowControlStatus();
@@ -505,6 +497,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
             flowControlStatus);
     }
 
+    /// <inheritdoc />
     public PipelineRuntimeContext GetRuntimeContext()
     {
         lock (_distributionLock)
@@ -519,11 +512,13 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
         }
     }
 
+    /// <inheritdoc />
     public PipelinePerformanceSnapshot GetPerformanceSnapshot()
     {
         return _performanceCollector.CreateSnapshot();
     }
 
+    /// <inheritdoc />
     public PipelineHealthStatus GetHealthStatus()
     {
         var status = GetStatus();
@@ -541,6 +536,7 @@ public class Pipeline<TPipelineRecord> : IPipeline<TPipelineRecord> where TPipel
             _pipelineFault);
     }
 
+    /// <inheritdoc />
     public PipelineOperationalSnapshot GetOperationalSnapshot()
     {
         var status = GetStatus();

--- a/src/Pipelinez/Core/PipelineBuilder.cs
+++ b/src/Pipelinez/Core/PipelineBuilder.cs
@@ -15,6 +15,10 @@ using Pipelinez.Core.Source;
 
 namespace Pipelinez.Core;
 
+/// <summary>
+/// Builds a Pipelinez pipeline by composing a source, zero or more segments, and a destination.
+/// </summary>
+/// <typeparam name="T">The pipeline record type processed by the pipeline.</typeparam>
 public class PipelineBuilder<T>(string pipelineName)
     where T : PipelineRecord
 {
@@ -23,6 +27,9 @@ public class PipelineBuilder<T>(string pipelineName)
         PipelineExecutionOptions? ExecutionOptions,
         PipelineRetryPolicy<T>? RetryPolicy);
 
+    /// <summary>
+    /// Gets the logical name of the pipeline being built.
+    /// </summary>
     public string PipelineName { get; } = Guard.Against.NullOrWhiteSpace(pipelineName, nameof(pipelineName));
 
     #region Pipeline Components
@@ -46,6 +53,11 @@ public class PipelineBuilder<T>(string pipelineName)
 
     #region Sources
 
+    /// <summary>
+    /// Configures the pipeline source.
+    /// </summary>
+    /// <param name="source">The source to use.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> WithSource(IPipelineSource<T> source)
     {
         _source = Guard.Against.Null(source, nameof(source));
@@ -53,6 +65,12 @@ public class PipelineBuilder<T>(string pipelineName)
         return this;
     }
 
+    /// <summary>
+    /// Configures the pipeline source with explicit execution options.
+    /// </summary>
+    /// <param name="source">The source to use.</param>
+    /// <param name="executionOptions">The execution options to apply to the source.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> WithSource(IPipelineSource<T> source, PipelineExecutionOptions executionOptions)
     {
         _source = Guard.Against.Null(source, nameof(source));
@@ -60,6 +78,11 @@ public class PipelineBuilder<T>(string pipelineName)
         return this;
     }
 
+    /// <summary>
+    /// Configures the built-in in-memory source.
+    /// </summary>
+    /// <param name="config">Reserved source configuration input.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> WithInMemorySource(object config)
     {
         return WithSource(new InMemoryPipelineSource<T>());
@@ -69,6 +92,12 @@ public class PipelineBuilder<T>(string pipelineName)
 
     #region Segments
 
+    /// <summary>
+    /// Adds a segment to the pipeline.
+    /// </summary>
+    /// <param name="segment">The segment to add.</param>
+    /// <param name="config">Reserved segment configuration input.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> AddSegment(IPipelineSegment<T> segment, object config)
     {
         _segments.Add(new PipelineSegmentRegistration(
@@ -78,6 +107,13 @@ public class PipelineBuilder<T>(string pipelineName)
         return this;
     }
 
+    /// <summary>
+    /// Adds a segment to the pipeline with explicit execution options.
+    /// </summary>
+    /// <param name="segment">The segment to add.</param>
+    /// <param name="config">Reserved segment configuration input.</param>
+    /// <param name="executionOptions">The execution options to apply to the segment.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> AddSegment(
         IPipelineSegment<T> segment,
         object config,
@@ -90,6 +126,13 @@ public class PipelineBuilder<T>(string pipelineName)
         return this;
     }
 
+    /// <summary>
+    /// Adds a segment to the pipeline with an explicit retry policy.
+    /// </summary>
+    /// <param name="segment">The segment to add.</param>
+    /// <param name="config">Reserved segment configuration input.</param>
+    /// <param name="retryPolicy">The retry policy to apply to the segment.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> AddSegment(
         IPipelineSegment<T> segment,
         object config,
@@ -102,6 +145,14 @@ public class PipelineBuilder<T>(string pipelineName)
         return this;
     }
 
+    /// <summary>
+    /// Adds a segment to the pipeline with explicit execution options and retry policy.
+    /// </summary>
+    /// <param name="segment">The segment to add.</param>
+    /// <param name="config">Reserved segment configuration input.</param>
+    /// <param name="executionOptions">The execution options to apply to the segment.</param>
+    /// <param name="retryPolicy">The retry policy to apply to the segment.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> AddSegment(
         IPipelineSegment<T> segment,
         object config,
@@ -119,6 +170,11 @@ public class PipelineBuilder<T>(string pipelineName)
 
     #region Destinations
 
+    /// <summary>
+    /// Configures the pipeline destination.
+    /// </summary>
+    /// <param name="destination">The destination to use.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> WithDestination(IPipelineDestination<T> destination)
     {
         _destination = Guard.Against.Null(destination, nameof(destination));
@@ -127,6 +183,12 @@ public class PipelineBuilder<T>(string pipelineName)
         return this;
     }
 
+    /// <summary>
+    /// Configures the pipeline destination with explicit execution options.
+    /// </summary>
+    /// <param name="destination">The destination to use.</param>
+    /// <param name="executionOptions">The execution options to apply to the destination.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> WithDestination(IPipelineDestination<T> destination, PipelineExecutionOptions executionOptions)
     {
         _destination = Guard.Against.Null(destination, nameof(destination));
@@ -135,6 +197,12 @@ public class PipelineBuilder<T>(string pipelineName)
         return this;
     }
 
+    /// <summary>
+    /// Configures the pipeline destination with an explicit retry policy.
+    /// </summary>
+    /// <param name="destination">The destination to use.</param>
+    /// <param name="retryPolicy">The retry policy to apply to the destination.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> WithDestination(IPipelineDestination<T> destination, PipelineRetryPolicy<T> retryPolicy)
     {
         _destination = Guard.Against.Null(destination, nameof(destination));
@@ -143,6 +211,13 @@ public class PipelineBuilder<T>(string pipelineName)
         return this;
     }
 
+    /// <summary>
+    /// Configures the pipeline destination with explicit execution options and retry policy.
+    /// </summary>
+    /// <param name="destination">The destination to use.</param>
+    /// <param name="executionOptions">The execution options to apply to the destination.</param>
+    /// <param name="retryPolicy">The retry policy to apply to the destination.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> WithDestination(
         IPipelineDestination<T> destination,
         PipelineExecutionOptions executionOptions,
@@ -154,11 +229,21 @@ public class PipelineBuilder<T>(string pipelineName)
         return this;
     }
 
+    /// <summary>
+    /// Configures the built-in in-memory destination.
+    /// </summary>
+    /// <param name="config">Reserved destination configuration input.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> WithInMemoryDestination(string config)
     {
         return WithDestination(new InMemoryPipelineDestination<T>());
     }
 
+    /// <summary>
+    /// Configures the dead-letter destination used for terminally handled faults.
+    /// </summary>
+    /// <param name="deadLetterDestination">The dead-letter destination to use.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> WithDeadLetterDestination(IPipelineDeadLetterDestination<T> deadLetterDestination)
     {
         _deadLetterDestination = Guard.Against.Null(deadLetterDestination, nameof(deadLetterDestination));
@@ -169,6 +254,11 @@ public class PipelineBuilder<T>(string pipelineName)
 
     #region Logging
 
+    /// <summary>
+    /// Configures the logger factory used by pipeline components.
+    /// </summary>
+    /// <param name="logFactory">The logger factory to use.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> UseLogger(ILoggerFactory logFactory)
     {
         LoggingManager.Instance.AssignLogFactory(logFactory);
@@ -179,12 +269,22 @@ public class PipelineBuilder<T>(string pipelineName)
 
     #region Hosting
 
+    /// <summary>
+    /// Configures dead-letter behavior for the pipeline.
+    /// </summary>
+    /// <param name="options">The dead-letter options to apply.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> UseDeadLetterOptions(PipelineDeadLetterOptions options)
     {
         _deadLetterOptions = Guard.Against.Null(options, nameof(options)).Validate();
         return this;
     }
 
+    /// <summary>
+    /// Configures host-level execution options.
+    /// </summary>
+    /// <param name="options">The host options to apply.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> UseHostOptions(PipelineHostOptions options)
     {
         _hostOptions = Guard.Against.Null(options, nameof(options));
@@ -195,12 +295,22 @@ public class PipelineBuilder<T>(string pipelineName)
 
     #region Flow Control
 
+    /// <summary>
+    /// Configures operational tooling behavior for the pipeline.
+    /// </summary>
+    /// <param name="options">The operational options to apply.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> UseOperationalOptions(PipelineOperationalOptions options)
     {
         _operationalOptions = Guard.Against.Null(options, nameof(options)).Validate();
         return this;
     }
 
+    /// <summary>
+    /// Configures pipeline-wide flow-control behavior.
+    /// </summary>
+    /// <param name="options">The flow-control options to apply.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> UseFlowControlOptions(PipelineFlowControlOptions options)
     {
         _flowControlOptions = Guard.Against.Null(options, nameof(options)).Validate();
@@ -211,6 +321,11 @@ public class PipelineBuilder<T>(string pipelineName)
 
     #region Performance
 
+    /// <summary>
+    /// Configures performance and execution-tuning options for the pipeline.
+    /// </summary>
+    /// <param name="options">The performance options to apply.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> UsePerformanceOptions(PipelinePerformanceOptions options)
     {
         _performanceOptions = Guard.Against.Null(options, nameof(options)).Validate();
@@ -221,6 +336,11 @@ public class PipelineBuilder<T>(string pipelineName)
 
     #region Retry
 
+    /// <summary>
+    /// Configures default retry behavior for segments and destinations.
+    /// </summary>
+    /// <param name="options">The retry options to apply.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> UseRetryOptions(PipelineRetryOptions<T> options)
     {
         _retryOptions = Guard.Against.Null(options, nameof(options));
@@ -231,12 +351,22 @@ public class PipelineBuilder<T>(string pipelineName)
 
     #region Error Handling
 
+    /// <summary>
+    /// Configures the asynchronous error handler used after retries are exhausted.
+    /// </summary>
+    /// <param name="errorHandler">The error handler to use.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> WithErrorHandler(PipelineErrorHandler<T> errorHandler)
     {
         _errorHandler = Guard.Against.Null(errorHandler, nameof(errorHandler));
         return this;
     }
 
+    /// <summary>
+    /// Configures the synchronous error handler used after retries are exhausted.
+    /// </summary>
+    /// <param name="errorHandler">The error handler to use.</param>
+    /// <returns>The builder instance.</returns>
     public PipelineBuilder<T> WithErrorHandler(Func<PipelineErrorContext<T>, PipelineErrorAction> errorHandler)
     {
         Guard.Against.Null(errorHandler, nameof(errorHandler));
@@ -248,6 +378,10 @@ public class PipelineBuilder<T>(string pipelineName)
 
     #region Build
 
+    /// <summary>
+    /// Builds the pipeline using the configured components and options.
+    /// </summary>
+    /// <returns>The built pipeline instance.</returns>
     public IPipeline<T> Build()
     {
         Guard.Against.Null(_source, message: "Pipeline must have a source defined before it is built");

--- a/src/Pipelinez/Core/Record/Metadata/MetadataCollection.cs
+++ b/src/Pipelinez/Core/Record/Metadata/MetadataCollection.cs
@@ -2,75 +2,103 @@ using System.Collections;
 
 namespace Pipelinez.Core.Record.Metadata;
 
+/// <summary>
+/// Represents a mutable collection of metadata records attached to a pipeline container.
+/// </summary>
 public class MetadataCollection : IList<MetadataRecord>
 {
     private readonly IList<MetadataRecord> _internalList;
     
+    /// <summary>
+    /// Initializes a new empty metadata collection.
+    /// </summary>
     public MetadataCollection()
     {
         _internalList = new List<MetadataRecord>();
     }
-    
+
+    /// <inheritdoc />
     public IEnumerator<MetadataRecord> GetEnumerator()
     {
         return _internalList.GetEnumerator();
     }
 
+    /// <inheritdoc />
     IEnumerator IEnumerable.GetEnumerator()
     {
         return GetEnumerator();
     }
 
+    /// <inheritdoc />
     public void Add(MetadataRecord item)
     {
         // TODO: throw if adding a duplicate key
         _internalList.Add(item);
     }
 
+    /// <inheritdoc />
     public void Clear()
     {
         _internalList.Clear();
     }
 
+    /// <inheritdoc />
     public bool Contains(MetadataRecord item)
     {
         return _internalList.Contains(item);
     }
 
+    /// <inheritdoc />
     public void CopyTo(MetadataRecord[] array, int arrayIndex)
     {
         _internalList.CopyTo(array, arrayIndex);
     }
 
+    /// <inheritdoc />
     public bool Remove(MetadataRecord item)
     {
         return _internalList.Remove(item);
     }
 
+    /// <inheritdoc />
     public int Count => _internalList.Count;
 
+    /// <inheritdoc />
     public bool IsReadOnly => _internalList.IsReadOnly;
 
+    /// <inheritdoc />
     public int IndexOf(MetadataRecord item)
     {
         return _internalList.IndexOf(item);
     }
 
+    /// <inheritdoc />
     public void Insert(int index, MetadataRecord item)
     {
         _internalList.Insert(index, item);
     }
 
+    /// <inheritdoc />
     public void RemoveAt(int index)
     {
         _internalList.RemoveAt(index);
     }
 
+    /// <summary>
+    /// Determines whether the collection contains a metadata record with the specified key.
+    /// </summary>
+    /// <param name="key">The metadata key to look for.</param>
+    /// <returns><see langword="true" /> if the key exists; otherwise, <see langword="false" />.</returns>
     public bool HasKey(string key)
     {
         return _internalList.Any(m => m.Key.Equals(key, StringComparison.InvariantCultureIgnoreCase));
     }
 
+    /// <summary>
+    /// Gets the first metadata record that matches the specified key.
+    /// </summary>
+    /// <param name="key">The metadata key to retrieve.</param>
+    /// <returns>The matching metadata record, or <see langword="null" /> when no match exists.</returns>
     public MetadataRecord? GetByKey(string key)
     {
         if (HasKey(key))
@@ -81,11 +109,21 @@ public class MetadataCollection : IList<MetadataRecord>
         return null;
     }
 
+    /// <summary>
+    /// Gets the value associated with the specified metadata key.
+    /// </summary>
+    /// <param name="key">The metadata key to retrieve.</param>
+    /// <returns>The metadata value, or <see langword="null" /> when no match exists.</returns>
     public string? GetValue(string key)
     {
         return GetByKey(key)?.Value;
     }
 
+    /// <summary>
+    /// Adds or updates a metadata value for the specified key.
+    /// </summary>
+    /// <param name="key">The metadata key.</param>
+    /// <param name="value">The metadata value.</param>
     public void Set(string key, string value)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
@@ -101,6 +139,10 @@ public class MetadataCollection : IList<MetadataRecord>
         Add(new MetadataRecord(key, value));
     }
 
+    /// <summary>
+    /// Creates a deep copy of the metadata collection.
+    /// </summary>
+    /// <returns>A cloned metadata collection.</returns>
     public MetadataCollection Clone()
     {
         var clone = new MetadataCollection();
@@ -113,6 +155,7 @@ public class MetadataCollection : IList<MetadataRecord>
         return clone;
     }
 
+    /// <inheritdoc />
     public MetadataRecord this[int index]
     {
         get => _internalList[index];

--- a/src/Pipelinez/Core/Record/Metadata/MetadataRecord.cs
+++ b/src/Pipelinez/Core/Record/Metadata/MetadataRecord.cs
@@ -1,10 +1,25 @@
 namespace Pipelinez.Core.Record.Metadata;
 
+/// <summary>
+/// Represents a metadata key/value pair associated with a pipeline container.
+/// </summary>
 public class MetadataRecord
 {
+    /// <summary>
+    /// Gets or sets the metadata key.
+    /// </summary>
     public string Key { get; set; }
+
+    /// <summary>
+    /// Gets or sets the metadata value.
+    /// </summary>
     public string Value { get; set; }
 
+    /// <summary>
+    /// Initializes a new metadata record.
+    /// </summary>
+    /// <param name="key">The metadata key.</param>
+    /// <param name="value">The metadata value.</param>
     public MetadataRecord(string key, string value)
     {
         Key = key;

--- a/src/Pipelinez/Core/Record/PipelineContainer.cs
+++ b/src/Pipelinez/Core/Record/PipelineContainer.cs
@@ -5,12 +5,25 @@ using Pipelinez.Core.Retry;
 
 namespace Pipelinez.Core.Record;
 
+/// <summary>
+/// Wraps a pipeline record with metadata, fault state, and execution history while it moves through the pipeline.
+/// </summary>
+/// <typeparam name="T">The pipeline record type carried by the container.</typeparam>
 public sealed class PipelineContainer<T> where T : PipelineRecord
 {
+    /// <summary>
+    /// Initializes a new container for the supplied record with an empty metadata collection.
+    /// </summary>
+    /// <param name="record">The record to wrap.</param>
     public PipelineContainer(T record) : this(record, new MetadataCollection())
     {
     }
 
+    /// <summary>
+    /// Initializes a new container for the supplied record and metadata.
+    /// </summary>
+    /// <param name="record">The record to wrap.</param>
+    /// <param name="metadata">The metadata associated with the record.</param>
     public PipelineContainer(T record, MetadataCollection metadata)
     {
         Record = Guard.Against.Null(record, nameof(record));
@@ -19,32 +32,62 @@ public sealed class PipelineContainer<T> where T : PipelineRecord
     }
     
     /// <summary>
-    /// Contains metadata relating to the record.
+    /// Gets the metadata associated with the record.
     /// </summary>
     public MetadataCollection Metadata { get; }
 
+    /// <summary>
+    /// Gets the time the container was created.
+    /// </summary>
     public DateTimeOffset CreatedAtUtc { get; }
-    
+
+    /// <summary>
+    /// Gets or sets the record carried by the container.
+    /// </summary>
     public T Record { get; set; }
 
+    /// <summary>
+    /// Gets the fault state recorded for the container, if any.
+    /// </summary>
     public PipelineFaultState? Fault { get; private set; }
 
+    /// <summary>
+    /// Gets a value indicating whether the container has faulted.
+    /// </summary>
     public bool HasFault => Fault is not null;
 
+    /// <summary>
+    /// Gets the ordered execution history recorded for pipeline segments.
+    /// </summary>
     public IList<PipelineSegmentExecution> SegmentHistory { get; } = new List<PipelineSegmentExecution>();
 
+    /// <summary>
+    /// Gets the ordered retry history recorded for the container.
+    /// </summary>
     public IList<PipelineRetryAttempt> RetryHistory { get; } = new List<PipelineRetryAttempt>();
 
+    /// <summary>
+    /// Marks the container as faulted.
+    /// </summary>
+    /// <param name="fault">The fault state to record.</param>
     public void MarkFaulted(PipelineFaultState fault)
     {
         Fault ??= Guard.Against.Null(fault, nameof(fault));
     }
 
+    /// <summary>
+    /// Adds a segment execution entry to the container history.
+    /// </summary>
+    /// <param name="segmentExecution">The execution record to add.</param>
     public void AddSegmentExecution(PipelineSegmentExecution segmentExecution)
     {
         SegmentHistory.Add(Guard.Against.Null(segmentExecution, nameof(segmentExecution)));
     }
 
+    /// <summary>
+    /// Adds a retry attempt entry to the container history.
+    /// </summary>
+    /// <param name="retryAttempt">The retry attempt to add.</param>
     public void AddRetryAttempt(PipelineRetryAttempt retryAttempt)
     {
         RetryHistory.Add(Guard.Against.Null(retryAttempt, nameof(retryAttempt)));

--- a/src/Pipelinez/Core/Record/PipelineRecord.cs
+++ b/src/Pipelinez/Core/Record/PipelineRecord.cs
@@ -3,12 +3,12 @@ namespace Pipelinez.Core.Record;
 
 
 /// <summary>
-/// Base class for any data structure that needs to flow through a pipeline
+/// Base class for records that flow through a Pipelinez pipeline.
 /// </summary>
 public abstract class PipelineRecord
 {
     /// <summary>
-    /// Headers associated to the record
+    /// Gets the headers associated with the record.
     /// </summary>
     public IList<PipelineRecordHeader> Headers { get; } = new List<PipelineRecordHeader>();
 }

--- a/src/Pipelinez/Core/Record/PipelineRecordHeader.cs
+++ b/src/Pipelinez/Core/Record/PipelineRecordHeader.cs
@@ -1,10 +1,17 @@
 namespace Pipelinez.Core.Record;
 
 /// <summary>
-/// A string key/value pair of data that represents a header record part of a PipelineRecord 
+/// Represents a string key/value header attached to a <see cref="PipelineRecord" />.
 /// </summary>
 public class PipelineRecordHeader
 {
+    /// <summary>
+    /// Gets or sets the header key.
+    /// </summary>
     public string Key { get; set; } = String.Empty;
+
+    /// <summary>
+    /// Gets or sets the header value.
+    /// </summary>
     public string Value { get; set; } = String.Empty;
 }

--- a/src/Pipelinez/Core/Retry/IPipelineRetryConfigurable.cs
+++ b/src/Pipelinez/Core/Retry/IPipelineRetryConfigurable.cs
@@ -2,9 +2,21 @@ using Pipelinez.Core.Record;
 
 namespace Pipelinez.Core.Retry;
 
+/// <summary>
+/// Defines a component that can be configured with a retry policy.
+/// </summary>
+/// <typeparam name="T">The pipeline record type handled by the component.</typeparam>
 public interface IPipelineRetryConfigurable<T> where T : PipelineRecord
 {
+    /// <summary>
+    /// Applies the retry policy that should be used for transient failures.
+    /// </summary>
+    /// <param name="retryPolicy">The retry policy to use, or <see langword="null" /> to disable retries.</param>
     void ConfigureRetryPolicy(PipelineRetryPolicy<T>? retryPolicy);
 
+    /// <summary>
+    /// Gets the retry policy currently configured for the component.
+    /// </summary>
+    /// <returns>The configured retry policy, or <see langword="null" /> when retries are disabled.</returns>
     PipelineRetryPolicy<T>? GetRetryPolicy();
 }

--- a/src/Pipelinez/Core/Retry/PipelineRetryAttempt.cs
+++ b/src/Pipelinez/Core/Retry/PipelineRetryAttempt.cs
@@ -3,8 +3,14 @@ using Pipelinez.Core.FaultHandling;
 
 namespace Pipelinez.Core.Retry;
 
+/// <summary>
+/// Describes a single retry attempt performed for a transient failure.
+/// </summary>
 public sealed class PipelineRetryAttempt
 {
+    /// <summary>
+    /// Initializes a new retry attempt record.
+    /// </summary>
     public PipelineRetryAttempt(
         int attemptNumber,
         string componentName,
@@ -27,21 +33,48 @@ public sealed class PipelineRetryAttempt
         Message = Guard.Against.NullOrWhiteSpace(message, nameof(message));
     }
 
+    /// <summary>
+    /// Gets the retry attempt number, starting at one.
+    /// </summary>
     public int AttemptNumber { get; }
 
+    /// <summary>
+    /// Gets the component name associated with the retry.
+    /// </summary>
     public string ComponentName { get; }
 
+    /// <summary>
+    /// Gets the component kind associated with the retry.
+    /// </summary>
     public PipelineComponentKind ComponentKind { get; }
 
+    /// <summary>
+    /// Gets the time the attempt started.
+    /// </summary>
     public DateTimeOffset StartedAtUtc { get; }
 
+    /// <summary>
+    /// Gets the time the attempt completed.
+    /// </summary>
     public DateTimeOffset CompletedAtUtc { get; }
 
+    /// <summary>
+    /// Gets the duration of the attempt.
+    /// </summary>
     public TimeSpan Duration { get; }
 
+    /// <summary>
+    /// Gets the configured delay before the next retry attempt.
+    /// </summary>
     public TimeSpan DelayBeforeNextAttempt { get; }
 
+    /// <summary>
+    /// Gets the exception type name captured for the attempt.
+    /// </summary>
     public string ExceptionType { get; }
 
+    /// <summary>
+    /// Gets the exception message captured for the attempt.
+    /// </summary>
     public string Message { get; }
 }

--- a/src/Pipelinez/Core/Retry/PipelineRetryContext.cs
+++ b/src/Pipelinez/Core/Retry/PipelineRetryContext.cs
@@ -4,8 +4,15 @@ using Pipelinez.Core.Record;
 
 namespace Pipelinez.Core.Retry;
 
+/// <summary>
+/// Provides context for retry policy evaluation.
+/// </summary>
+/// <typeparam name="T">The pipeline record type being retried.</typeparam>
 public sealed class PipelineRetryContext<T> where T : PipelineRecord
 {
+    /// <summary>
+    /// Initializes a new retry context.
+    /// </summary>
     public PipelineRetryContext(
         Exception exception,
         PipelineContainer<T> container,
@@ -24,19 +31,43 @@ public sealed class PipelineRetryContext<T> where T : PipelineRecord
         CancellationToken = cancellationToken;
     }
 
+    /// <summary>
+    /// Gets the exception that triggered the retry evaluation.
+    /// </summary>
     public Exception Exception { get; }
 
+    /// <summary>
+    /// Gets the pipeline container being retried.
+    /// </summary>
     public PipelineContainer<T> Container { get; }
 
+    /// <summary>
+    /// Gets the record being retried.
+    /// </summary>
     public T Record => Container.Record;
 
+    /// <summary>
+    /// Gets the component name associated with the retry.
+    /// </summary>
     public string ComponentName { get; }
 
+    /// <summary>
+    /// Gets the component kind associated with the retry.
+    /// </summary>
     public PipelineComponentKind ComponentKind { get; }
 
+    /// <summary>
+    /// Gets the current attempt number, starting at one.
+    /// </summary>
     public int AttemptNumber { get; }
 
+    /// <summary>
+    /// Gets the maximum number of attempts allowed by the retry policy.
+    /// </summary>
     public int MaxAttempts { get; }
 
+    /// <summary>
+    /// Gets the cancellation token associated with the retry operation.
+    /// </summary>
     public CancellationToken CancellationToken { get; }
 }

--- a/src/Pipelinez/Core/Retry/PipelineRetryOptions.cs
+++ b/src/Pipelinez/Core/Retry/PipelineRetryOptions.cs
@@ -2,11 +2,24 @@ using Pipelinez.Core.Record;
 
 namespace Pipelinez.Core.Retry;
 
+/// <summary>
+/// Configures default retry behavior for pipeline segments and destinations.
+/// </summary>
+/// <typeparam name="T">The pipeline record type processed by the retry policies.</typeparam>
 public sealed class PipelineRetryOptions<T> where T : PipelineRecord
 {
+    /// <summary>
+    /// Gets the default retry policy applied to segments when no per-segment override is configured.
+    /// </summary>
     public PipelineRetryPolicy<T>? DefaultSegmentPolicy { get; init; }
 
+    /// <summary>
+    /// Gets the retry policy applied to the destination when no destination override is configured.
+    /// </summary>
     public PipelineRetryPolicy<T>? DestinationPolicy { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether retry events should be emitted.
+    /// </summary>
     public bool EmitRetryEvents { get; init; } = true;
 }

--- a/src/Pipelinez/Core/Retry/PipelineRetryPolicy.cs
+++ b/src/Pipelinez/Core/Retry/PipelineRetryPolicy.cs
@@ -3,6 +3,10 @@ using Pipelinez.Core.Record;
 
 namespace Pipelinez.Core.Retry;
 
+/// <summary>
+/// Defines retry behavior for transient failures in segments or destinations.
+/// </summary>
+/// <typeparam name="T">The pipeline record type processed by the policy.</typeparam>
 public sealed class PipelineRetryPolicy<T> where T : PipelineRecord
 {
     private readonly IReadOnlyList<Func<PipelineRetryContext<T>, bool>> _filters;
@@ -17,10 +21,20 @@ public sealed class PipelineRetryPolicy<T> where T : PipelineRecord
         _filters = Guard.Against.Null(filters, nameof(filters));
     }
 
+    /// <summary>
+    /// Gets the maximum number of attempts allowed by the policy.
+    /// </summary>
     public int MaxAttempts { get; }
 
+    /// <summary>
+    /// Gets the delegate used to calculate delay before the next attempt.
+    /// </summary>
     public Func<PipelineRetryContext<T>, TimeSpan> DelayProvider { get; }
 
+    /// <summary>
+    /// Creates a policy that performs no retries beyond the initial attempt.
+    /// </summary>
+    /// <returns>A retry policy with no retry behavior.</returns>
     public static PipelineRetryPolicy<T> None()
     {
         return new PipelineRetryPolicy<T>(
@@ -29,6 +43,12 @@ public sealed class PipelineRetryPolicy<T> where T : PipelineRecord
             Array.Empty<Func<PipelineRetryContext<T>, bool>>());
     }
 
+    /// <summary>
+    /// Creates a fixed-delay retry policy.
+    /// </summary>
+    /// <param name="maxAttempts">The total number of attempts, including the initial attempt.</param>
+    /// <param name="delay">The delay applied between attempts.</param>
+    /// <returns>A fixed-delay retry policy.</returns>
     public static PipelineRetryPolicy<T> FixedDelay(int maxAttempts, TimeSpan delay)
     {
         if (delay < TimeSpan.Zero)
@@ -42,6 +62,14 @@ public sealed class PipelineRetryPolicy<T> where T : PipelineRecord
             Array.Empty<Func<PipelineRetryContext<T>, bool>>());
     }
 
+    /// <summary>
+    /// Creates an exponential backoff retry policy.
+    /// </summary>
+    /// <param name="maxAttempts">The total number of attempts, including the initial attempt.</param>
+    /// <param name="initialDelay">The delay used before the first retry attempt.</param>
+    /// <param name="maxDelay">The maximum delay allowed between attempts.</param>
+    /// <param name="useJitter">A value indicating whether randomized jitter should be applied.</param>
+    /// <returns>An exponential backoff retry policy.</returns>
     public static PipelineRetryPolicy<T> ExponentialBackoff(
         int maxAttempts,
         TimeSpan initialDelay,
@@ -90,11 +118,21 @@ public sealed class PipelineRetryPolicy<T> where T : PipelineRecord
             Array.Empty<Func<PipelineRetryContext<T>, bool>>());
     }
 
+    /// <summary>
+    /// Restricts retries to exceptions of the specified type.
+    /// </summary>
+    /// <typeparam name="TException">The exception type that should be retried.</typeparam>
+    /// <returns>A new retry policy with the additional filter applied.</returns>
     public PipelineRetryPolicy<T> Handle<TException>() where TException : Exception
     {
         return Handle(context => context.Exception is TException);
     }
 
+    /// <summary>
+    /// Restricts retries using a custom predicate.
+    /// </summary>
+    /// <param name="predicate">The predicate used to determine whether a retry is allowed.</param>
+    /// <returns>A new retry policy with the additional filter applied.</returns>
     public PipelineRetryPolicy<T> Handle(Func<PipelineRetryContext<T>, bool> predicate)
     {
         Guard.Against.Null(predicate, nameof(predicate));

--- a/src/Pipelinez/Core/Segment/IPipelineSegment.cs
+++ b/src/Pipelinez/Core/Segment/IPipelineSegment.cs
@@ -3,7 +3,14 @@ using Pipelinez.Core.Record;
 
 namespace Pipelinez.Core.Segment;
 
+/// <summary>
+/// Defines a pipeline segment that transforms records between the source and destination.
+/// </summary>
+/// <typeparam name="T">The pipeline record type processed by the segment.</typeparam>
 public interface IPipelineSegment<T> : IFlowSource<PipelineContainer<T>>, IFlowDestination<PipelineContainer<T>> where T : PipelineRecord
 {
+    /// <summary>
+    /// Gets a task that completes when the segment has finished processing.
+    /// </summary>
     Task Completion { get; }
 }

--- a/src/Pipelinez/Core/Segment/PipelineSegment.cs
+++ b/src/Pipelinez/Core/Segment/PipelineSegment.cs
@@ -12,6 +12,10 @@ using Pipelinez.Core.Retry;
 
 namespace Pipelinez.Core.Segment;
 
+/// <summary>
+/// Provides a base implementation for pipeline segments backed by a Dataflow transform block.
+/// </summary>
+/// <typeparam name="T">The pipeline record type processed by the segment.</typeparam>
 public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecutionConfigurable, IPipelinePerformanceAware, IPipelineRetryConfigurable<T>, IPipelineFlowStatusProvider where T : PipelineRecord
 {
     private TransformBlock<PipelineContainer<T>, PipelineContainer<T>>? _transformBlock;
@@ -22,10 +26,13 @@ public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecuti
     private string _componentName = "Segment";
 
     /// <summary>
-    /// Logger for the segment
+    /// Gets the logger used by the segment.
     /// </summary>
     protected ILogger<PipelineSegment<T>> Logger { get; }
 
+    /// <summary>
+    /// Initializes a new segment base instance.
+    /// </summary>
     public PipelineSegment()
     {
         Logger = LoggingManager.Instance.CreateLogger<PipelineSegment<T>>();
@@ -56,18 +63,14 @@ public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecuti
     
     #region IPipelineSegment
 
-    /// <summary>
-    /// Connect this source to the next segment in the pipeline
-    /// </summary>
-    /// <param name="target">IFlowDestination to connect to</param>
-    /// <param name="options"></param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public IDisposable ConnectTo(IFlowDestination<PipelineContainer<T>> target, DataflowLinkOptions? options = null)
     {
         options ??= new DataflowLinkOptions() { MaxMessages = DataflowBlockOptions.Unbounded };
         return TransformBlock.LinkTo(target.AsTargetBlock(), options);
     }
 
+    /// <inheritdoc />
     public ITargetBlock<PipelineContainer<T>> AsTargetBlock()
     {
         return TransformBlock;
@@ -164,16 +167,18 @@ public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecuti
     #region Required Implementations
     
     /// <summary>
-    /// This method should contain the logic for the pipeline segment.
+    /// Executes the transformation performed by the segment.
     /// </summary>
-    /// <param name="arg"></param>
-    /// <returns></returns>
+    /// <param name="arg">The record to transform.</param>
+    /// <returns>The transformed record.</returns>
     public abstract Task<T> ExecuteAsync(T arg);
     
     #endregion
 
+    /// <inheritdoc />
     public Task Completion => TransformBlock.Completion;
 
+    /// <inheritdoc />
     public void ConfigureExecutionOptions(PipelineExecutionOptions options)
     {
         var validated = Guard.Against.Null(options, nameof(options)).Validate();
@@ -181,17 +186,20 @@ public abstract class PipelineSegment<T> : IPipelineSegment<T>, IPipelineExecuti
         _executionOptions = validated;
     }
 
+    /// <inheritdoc />
     public PipelineExecutionOptions GetExecutionOptions()
     {
         return _executionOptions;
     }
 
+    /// <inheritdoc />
     public void ConfigureRetryPolicy(PipelineRetryPolicy<T>? retryPolicy)
     {
         EnsureExecutionOptionsCanBeChanged();
         _retryPolicy = retryPolicy;
     }
 
+    /// <inheritdoc />
     public PipelineRetryPolicy<T>? GetRetryPolicy()
     {
         return _retryPolicy;

--- a/src/Pipelinez/Core/Source/IDistributedPipelineSource.cs
+++ b/src/Pipelinez/Core/Source/IDistributedPipelineSource.cs
@@ -3,13 +3,31 @@ using Pipelinez.Core.Record;
 
 namespace Pipelinez.Core.Source;
 
+/// <summary>
+/// Defines a source that can report distributed ownership and partition execution state.
+/// </summary>
+/// <typeparam name="T">The pipeline record type produced by the source.</typeparam>
 public interface IDistributedPipelineSource<T> : IPipelineSource<T> where T : PipelineRecord
 {
+    /// <summary>
+    /// Gets a value indicating whether the source supports distributed execution.
+    /// </summary>
     bool SupportsDistributedExecution { get; }
 
+    /// <summary>
+    /// Gets the transport name reported in distributed metadata.
+    /// </summary>
     string TransportName { get; }
 
+    /// <summary>
+    /// Gets the partitions currently owned by the source.
+    /// </summary>
+    /// <returns>The owned partition leases.</returns>
     IReadOnlyList<PipelinePartitionLease> GetOwnedPartitions();
 
+    /// <summary>
+    /// Gets the current execution state for owned partitions.
+    /// </summary>
+    /// <returns>The partition execution state snapshots.</returns>
     IReadOnlyList<PipelinePartitionExecutionState> GetPartitionExecutionStates();
 }

--- a/src/Pipelinez/Core/Source/IPipelineSource.cs
+++ b/src/Pipelinez/Core/Source/IPipelineSource.cs
@@ -6,25 +6,68 @@ using Pipelinez.Core.Record.Metadata;
 
 namespace Pipelinez.Core.Source;
 
+/// <summary>
+/// Defines a pipeline source that can publish records into the pipeline runtime.
+/// </summary>
+/// <typeparam name="T">The pipeline record type produced by the source.</typeparam>
 public interface IPipelineSource<T> : IFlowSource<PipelineContainer<T>> where T : PipelineRecord
 {
+    /// <summary>
+    /// Starts the source execution loop.
+    /// </summary>
+    /// <param name="cancellationToken">The runtime cancellation source used to stop the source.</param>
     Task StartAsync(CancellationTokenSource cancellationToken);
-    
+
+    /// <summary>
+    /// Publishes a record using the pipeline's default flow-control behavior.
+    /// </summary>
+    /// <param name="record">The record to publish.</param>
     Task PublishAsync(T record);
 
+    /// <summary>
+    /// Publishes a record using explicit publish options.
+    /// </summary>
+    /// <param name="record">The record to publish.</param>
+    /// <param name="options">The publish options to apply.</param>
+    /// <returns>The publish result.</returns>
     Task<PipelinePublishResult> PublishAsync(T record, PipelinePublishOptions options);
 
+    /// <summary>
+    /// Publishes a record with explicit metadata using the pipeline's default flow-control behavior.
+    /// </summary>
+    /// <param name="record">The record to publish.</param>
+    /// <param name="metadata">The metadata to attach to the record.</param>
     Task PublishAsync(T record, MetadataCollection metadata);
 
+    /// <summary>
+    /// Publishes a record with explicit metadata and publish options.
+    /// </summary>
+    /// <param name="record">The record to publish.</param>
+    /// <param name="metadata">The metadata to attach to the record.</param>
+    /// <param name="options">The publish options to apply.</param>
+    /// <returns>The publish result.</returns>
     Task<PipelinePublishResult> PublishAsync(T record, MetadataCollection metadata, PipelinePublishOptions options);
 
-    void Complete();
-    Task Completion { get; }
-    
-    void Initialize(Pipeline<T> parentPipeline);
-    
     /// <summary>
-    /// Occurs when the record (internally the container) has completed traversing the pipeline
+    /// Marks the source as complete so no additional records will be published.
     /// </summary>
+    void Complete();
+
+    /// <summary>
+    /// Gets a task that completes when the source has finished publishing records.
+    /// </summary>
+    Task Completion { get; }
+
+    /// <summary>
+    /// Initializes the source with its parent pipeline.
+    /// </summary>
+    /// <param name="parentPipeline">The owning pipeline.</param>
+    void Initialize(Pipeline<T> parentPipeline);
+
+    /// <summary>
+    /// Handles notification that a published container completed successfully.
+    /// </summary>
+    /// <param name="sender">The event sender.</param>
+    /// <param name="e">The completed container event arguments.</param>
     void OnPipelineContainerComplete(object sender, PipelineContainerCompletedEventHandlerArgs<PipelineContainer<T>> e);
 }

--- a/src/Pipelinez/Core/Source/InMemorySource.cs
+++ b/src/Pipelinez/Core/Source/InMemorySource.cs
@@ -2,9 +2,12 @@ using Pipelinez.Core.Record;
 
 namespace Pipelinez.Core.Source;
 
-
+/// <summary>
+/// Provides a minimal in-memory source for tests and simple manual publication scenarios.
+/// </summary>
 public class InMemoryPipelineSource<T> : PipelineSourceBase<T> where T : PipelineRecord
 {
+    /// <inheritdoc />
     protected override async Task MainLoop(CancellationTokenSource cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)
@@ -13,6 +16,7 @@ public class InMemoryPipelineSource<T> : PipelineSourceBase<T> where T : Pipelin
         }
     }
 
+    /// <inheritdoc />
     protected override void Initialize()
     {
         // nothing to initialize

--- a/src/Pipelinez/Core/Source/PipelineSource.cs
+++ b/src/Pipelinez/Core/Source/PipelineSource.cs
@@ -12,6 +12,10 @@ using Pipelinez.Core.Record.Metadata;
 
 namespace Pipelinez.Core.Source;
 
+/// <summary>
+/// Provides a base implementation for pipeline sources backed by a Dataflow buffer.
+/// </summary>
+/// <typeparam name="T">The pipeline record type produced by the source.</typeparam>
 public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecutionConfigurable, IPipelinePerformanceAware, IPipelineFlowStatusProvider where T : PipelineRecord
 {
     private BufferBlock<PipelineContainer<T>>? _messageBuffer;
@@ -20,8 +24,14 @@ public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecu
     private IPipelinePerformanceCollector? _performanceCollector;
     private string _componentName = "Source";
 
+    /// <summary>
+    /// Gets the logger used by the source.
+    /// </summary>
     protected ILogger<PipelineSourceBase<T>> Logger { get; }
 
+    /// <summary>
+    /// Initializes a new source base instance.
+    /// </summary>
     public PipelineSourceBase()
     {
         Logger = LoggingManager.Instance.CreateLogger<PipelineSourceBase<T>>();
@@ -29,16 +39,14 @@ public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecu
     
     #region IPipelineSource
     
-    /// <summary>
-    /// Connect this source to the next segment in the pipeline
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public IDisposable ConnectTo(IFlowDestination<PipelineContainer<T>> target, DataflowLinkOptions? options = null)
     {
         options ??= new DataflowLinkOptions() { MaxMessages = DataflowBlockOptions.Unbounded };
         return MessageBuffer.LinkTo(target.AsTargetBlock(), options);
     }
     
+    /// <inheritdoc />
     public async Task StartAsync(CancellationTokenSource cancellationToken)
     {
         try
@@ -54,23 +62,27 @@ public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecu
         }
     }
 
+    /// <inheritdoc />
     public async Task PublishAsync(T record)
     {
         var publishResult = await PublishAsync(record, new PipelinePublishOptions()).ConfigureAwait(false);
         HandleUnacceptedPublishResult(publishResult);
     }
 
+    /// <inheritdoc />
     public Task<PipelinePublishResult> PublishAsync(T record, PipelinePublishOptions options)
     {
         return PublishAsync(record, new MetadataCollection(), options);
     }
 
+    /// <inheritdoc />
     public async Task PublishAsync(T record, MetadataCollection metadata)
     {
         var publishResult = await PublishAsync(record, metadata, new PipelinePublishOptions()).ConfigureAwait(false);
         HandleUnacceptedPublishResult(publishResult);
     }
 
+    /// <inheritdoc />
     public async Task<PipelinePublishResult> PublishAsync(T record, MetadataCollection metadata, PipelinePublishOptions options)
     {
         EnsureCorrelationId(metadata);
@@ -98,15 +110,18 @@ public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecu
         return publishResult;
     }
 
+    /// <inheritdoc />
     public void Complete()
     {
         Logger.LogInformation("Completing pipeline source");
         MessageBuffer.Complete();
     }
 
+    /// <inheritdoc />
     public Task Completion => MessageBuffer.Completion;
 
 
+    /// <inheritdoc />
     public void Initialize(Pipeline<T> parentPipeline)
     {
         _parentPipeline = parentPipeline;
@@ -117,6 +132,7 @@ public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecu
         Initialize();
     }
 
+    /// <inheritdoc />
     public virtual void OnPipelineContainerComplete(object sender,
         PipelineContainerCompletedEventHandlerArgs<PipelineContainer<T>> e)
     {
@@ -134,6 +150,7 @@ public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecu
 
     #region Performance
 
+    /// <inheritdoc />
     public void ConfigureExecutionOptions(PipelineExecutionOptions options)
     {
         var validated = Guard.Against.Null(options, nameof(options)).Validate();
@@ -141,6 +158,7 @@ public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecu
         _executionOptions = validated;
     }
 
+    /// <inheritdoc />
     public PipelineExecutionOptions GetExecutionOptions()
     {
         return _executionOptions;
@@ -159,18 +177,21 @@ public abstract class PipelineSourceBase<T> : IPipelineSource<T>, IPipelineExecu
     #region Required Implementation
     
     /// <summary>
-    /// This method should contain the logic for the pipeline source.
-    /// Source method is async and should contain the complete application loop for the source
+    /// Executes the main source loop.
     /// </summary>
-    /// <returns></returns>
+    /// <param name="cancellationToken">The runtime cancellation source used to stop the source.</param>
+    /// <returns>A task that completes when the source loop exits.</returns>
     protected abstract Task MainLoop(CancellationTokenSource cancellationToken);
     /// <summary>
-    /// Method to provide an opportunity for the source to initialize
+    /// Provides an opportunity for the source to initialize transport-specific state.
     /// </summary>
     protected abstract void Initialize();
     
     #endregion
 
+    /// <summary>
+    /// Gets the parent pipeline.
+    /// </summary>
     protected Pipeline<T> ParentPipeline =>
         _parentPipeline ?? throw new InvalidOperationException("Pipeline source has not been initialized.");
 

--- a/src/Pipelinez/Core/Status/Constants.cs
+++ b/src/Pipelinez/Core/Status/Constants.cs
@@ -1,9 +1,24 @@
 namespace Pipelinez.Core.Status;
 
+/// <summary>
+/// Represents high-level execution states reported for pipeline components and runtimes.
+/// </summary>
 public enum PipelineExecutionStatus
 {
+    /// <summary>
+    /// Indicates the component or runtime is operating normally.
+    /// </summary>
     Healthy,
+    /// <summary>
+    /// Indicates the component or runtime has completed successfully.
+    /// </summary>
     Completed,
+    /// <summary>
+    /// Indicates the component or runtime has faulted.
+    /// </summary>
     Faulted,
+    /// <summary>
+    /// Indicates Pipelinez could not determine a single status from the available information.
+    /// </summary>
     Unknown
 }

--- a/src/Pipelinez/Core/Status/PipelineComponentStatus.cs
+++ b/src/Pipelinez/Core/Status/PipelineComponentStatus.cs
@@ -2,8 +2,17 @@ using Pipelinez.Core.FlowControl;
 
 namespace Pipelinez.Core.Status;
 
+/// <summary>
+/// Describes the current status of a single pipeline component.
+/// </summary>
 public class PipelineComponentStatus
 {
+    /// <summary>
+    /// Initializes a new component status snapshot.
+    /// </summary>
+    /// <param name="name">The logical component name.</param>
+    /// <param name="status">The component execution status.</param>
+    /// <param name="flow">Optional flow-control information for the component.</param>
     public PipelineComponentStatus(
         string name,
         PipelineExecutionStatus status,
@@ -14,7 +23,16 @@ public class PipelineComponentStatus
         Flow = flow;
     }
 
+    /// <summary>
+    /// Gets the component name.
+    /// </summary>
     public string Name { get; }
+    /// <summary>
+    /// Gets the current execution status of the component.
+    /// </summary>
     public PipelineExecutionStatus Status { get; }
+    /// <summary>
+    /// Gets the current flow-control information for the component, if available.
+    /// </summary>
     public PipelineComponentFlowStatus? Flow { get; }
 }

--- a/src/Pipelinez/Core/Status/PipelineStatus.cs
+++ b/src/Pipelinez/Core/Status/PipelineStatus.cs
@@ -3,8 +3,18 @@ using Pipelinez.Core.FlowControl;
 
 namespace Pipelinez.Core.Status;
 
+/// <summary>
+/// Represents the current observable runtime status of a pipeline.
+/// </summary>
 public class PipelineStatus
 {
+    /// <summary>
+    /// Initializes a new pipeline status snapshot.
+    /// </summary>
+    /// <param name="components">The component-level status entries.</param>
+    /// <param name="runtimeStatus">The explicit runtime status, if one is available.</param>
+    /// <param name="distributedStatus">The distributed execution status, if applicable.</param>
+    /// <param name="flowControlStatus">The flow-control status, if applicable.</param>
     public PipelineStatus(
         IList<PipelineComponentStatus> components,
         PipelineExecutionStatus? runtimeStatus = null,
@@ -17,10 +27,25 @@ public class PipelineStatus
         FlowControlStatus = flowControlStatus;
     }
     
+    /// <summary>
+    /// Gets the overall pipeline status derived from the runtime status and component states.
+    /// </summary>
     public PipelineExecutionStatus Status => GetStatus();
+    /// <summary>
+    /// Gets the component-level status entries.
+    /// </summary>
     public IList<PipelineComponentStatus> Components { get; }
+    /// <summary>
+    /// Gets the explicit runtime status, if one is available.
+    /// </summary>
     public PipelineExecutionStatus? RuntimeStatus { get; }
+    /// <summary>
+    /// Gets distributed runtime information, if the pipeline is running in distributed mode.
+    /// </summary>
     public PipelineDistributedStatus? DistributedStatus { get; }
+    /// <summary>
+    /// Gets flow-control information for the pipeline, if available.
+    /// </summary>
     public PipelineFlowControlStatus? FlowControlStatus { get; }
     
     private PipelineExecutionStatus GetStatus()


### PR DESCRIPTION
## Summary

- Added comprehensive XML documentation across the public API surface of `Pipelinez`
- Added comprehensive XML documentation across the public API surface of `Pipelinez.Kafka`
- Enabled compiler enforcement so missing XML docs on public APIs fail package builds through `CS1591`
- Updated contributor and API stability guidance to make public API documentation a required part of public-surface changes
- Marked the public API code documentation roadmap item as implemented

## Validation

- [x] `dotnet build src/Pipelinez.sln --configuration Release`
- [x] `dotnet test src/Pipelinez.sln --configuration Release --no-build --logger "console;verbosity=minimal"`

Notes:

- Full solution build passed with `0 Warning(s)` and `0 Error(s)`
- Full test suite passed with `68/68` tests green

## Release Impact

- [x] Patch
- [ ] Minor
- [ ] Major
- [ ] No release impact

Notes:

- This change improves package quality, IntelliSense, and contributor guardrails without changing the public API surface itself

## Public API

- [x] No public API changes
- [ ] Public API changes were intentional and the approved baselines were updated
- [ ] New unstable public APIs are marked preview
- [ ] Obsoletions include a migration path

## Documentation

- [ ] No documentation updates were needed
- [x] Consumer-facing docs were updated for behavior or API changes

Docs updated in this PR include:
- `CONTRIBUTING.md`
- `docs/ApiStability.md`
- `README.md`
- `docs/README.md`
- XML documentation comments across public APIs in `src/Pipelinez`
- XML documentation comments across public APIs in `src/Pipelinez.Kafka`