### PR TITLE
Adding PostgreSql Destination

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -45,6 +45,9 @@ jobs:
       - name: Pack Pipelinez.Kafka
         run: dotnet pack src/Pipelinez.Kafka/Pipelinez.Kafka.csproj --configuration Release --no-build -o artifacts/packages -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
 
+      - name: Pack Pipelinez.PostgreSql
+        run: dotnet pack src/Pipelinez.PostgreSql/Pipelinez.PostgreSql.csproj --configuration Release --no-build -o artifacts/packages -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+
       - name: Validate Packages
         shell: pwsh
         run: ./scripts/Validate-Packages.ps1 -PackageDirectory artifacts/packages

--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -48,6 +48,9 @@ jobs:
       - name: Pack Pipelinez.Kafka
         run: dotnet pack src/Pipelinez.Kafka/Pipelinez.Kafka.csproj --configuration Release --no-build -o artifacts/packages -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
 
+      - name: Pack Pipelinez.PostgreSql
+        run: dotnet pack src/Pipelinez.PostgreSql/Pipelinez.PostgreSql.csproj --configuration Release --no-build -o artifacts/packages -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+
       - name: Validate Packages
         shell: pwsh
         run: ./scripts/Validate-Packages.ps1 -PackageDirectory artifacts/packages

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,6 +77,9 @@ jobs:
       - name: Pack Pipelinez.Kafka
         run: dotnet pack src/Pipelinez.Kafka/Pipelinez.Kafka.csproj --configuration Release --no-build -o artifacts/packages -p:Version=${{ steps.version.outputs.package_version }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
 
+      - name: Pack Pipelinez.PostgreSql
+        run: dotnet pack src/Pipelinez.PostgreSql/Pipelinez.PostgreSql.csproj --configuration Release --no-build -o artifacts/packages -p:Version=${{ steps.version.outputs.package_version }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+
       - name: Validate Packages
         shell: pwsh
         run: ./scripts/Validate-Packages.ps1 -PackageDirectory artifacts/packages -PackageVersion ${{ steps.version.outputs.package_version }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'Pipelinez' Or '$(MSBuildProjectName)' == 'Pipelinez.Kafka'">
+  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'Pipelinez' Or '$(MSBuildProjectName)' == 'Pipelinez.Kafka' Or '$(MSBuildProjectName)' == 'Pipelinez.PostgreSql'">
     <VersionPrefix Condition="'$(VersionPrefix)' == ''">1.0.0</VersionPrefix>
     <Version Condition="'$(Version)' == '' And '$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
     <Version Condition="'$(Version)' == '' And '$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
@@ -18,7 +18,7 @@
     <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(MSBuildProjectName)' == 'Pipelinez' Or '$(MSBuildProjectName)' == 'Pipelinez.Kafka'">
+  <ItemGroup Condition="'$(MSBuildProjectName)' == 'Pipelinez' Or '$(MSBuildProjectName)' == 'Pipelinez.Kafka' Or '$(MSBuildProjectName)' == 'Pipelinez.PostgreSql'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ dotnet add package Pipelinez.Kafka
 
 `Pipelinez.Kafka` depends on `Pipelinez`, so Kafka consumers do not need to add both explicitly unless they want to.
 
+The repository also contains `Pipelinez.PostgreSql`, a PostgreSQL destination and dead-letter transport extension that is currently available in-source and participates in the same pack and validation flow.
+
 Public package publishing is configured through GitHub tag releases and NuGet Trusted Publishing.
 
 The published packages include XML IntelliSense documentation, so the public API descriptions are available directly in editors like Visual Studio and Rider.
@@ -118,6 +120,7 @@ That container model is what allows Pipelinez to keep runtime behavior explicit 
 - explicit flow control, saturation visibility, and publish results
 - performance tuning, batching, and runtime performance snapshots
 - distributed execution and partition-aware Kafka scaling
+- PostgreSQL destination and dead-letter transport support
 - health checks, metrics, correlation IDs, and runtime events
 
 ## Kafka Support
@@ -171,10 +174,41 @@ For a full walkthrough, see:
 - [`src/examples/Example.Kafka.DataGen`](src/examples/Example.Kafka.DataGen)
 - [`src/tests/Pipelinez.Kafka.Tests`](src/tests/Pipelinez.Kafka.Tests)
 
+## PostgreSQL Support
+
+PostgreSQL support lives in the separate `Pipelinez.PostgreSql` package in this repository and currently focuses on:
+
+- PostgreSQL destination writes
+- PostgreSQL dead-letter writes
+- consumer-owned schema and table mapping
+- custom parameterized SQL through Dapper-backed execution
+
+Example shape:
+
+```csharp
+using Pipelinez.Core;
+using Pipelinez.PostgreSql;
+using Pipelinez.PostgreSql.Configuration;
+using Pipelinez.PostgreSql.Mapping;
+
+var pipeline = Pipeline<MyRecord>.New("postgres-pipeline")
+    .WithInMemorySource(new object())
+    .WithPostgreSqlDestination(
+        new PostgreSqlDestinationOptions
+        {
+            ConnectionString = "Host=localhost;Database=pipelinez;Username=postgres;Password=postgres"
+        },
+        PostgreSqlTableMap<MyRecord>.ForTable("app", "processed_records")
+            .Map("record_id", record => record.Id)
+            .MapJson("payload", record => record))
+    .Build();
+```
+
 ## Learn More
 
 - New to Pipelinez: [`docs/getting-started/in-memory.md`](docs/getting-started/in-memory.md)
 - Using Kafka: [`docs/getting-started/kafka.md`](docs/getting-started/kafka.md)
+- Using PostgreSQL destinations: [`docs/getting-started/postgresql-destination.md`](docs/getting-started/postgresql-destination.md)
 - Architecture overview: [`docs/Overview.md`](docs/Overview.md)
 - Runtime and transport internals: [`docs/README.md`](docs/README.md)
 - API compatibility policy: [`docs/ApiStability.md`](docs/ApiStability.md)
@@ -196,10 +230,14 @@ Feature-specific guides:
   core runtime
 - [`src/Pipelinez.Kafka`](src/Pipelinez.Kafka)
   Kafka transport extension
+- [`src/Pipelinez.PostgreSql`](src/Pipelinez.PostgreSql)
+  PostgreSQL destination and dead-letter transport extension
 - [`src/tests/Pipelinez.Tests`](src/tests/Pipelinez.Tests)
   core tests
 - [`src/tests/Pipelinez.Kafka.Tests`](src/tests/Pipelinez.Kafka.Tests)
   Kafka integration tests
+- [`src/tests/Pipelinez.PostgreSql.Tests`](src/tests/Pipelinez.PostgreSql.Tests)
+  PostgreSQL integration and approval tests
 - [`src/benchmarks/Pipelinez.Benchmarks`](src/benchmarks/Pipelinez.Benchmarks)
   BenchmarkDotNet-based performance benchmarks
 
@@ -250,6 +288,7 @@ Current implemented capabilities include:
 - performance tuning, batching, and runtime performance snapshots
 - operational health snapshots, health checks, metrics, and correlation IDs
 - Docker-backed Kafka integration coverage
+- Docker-backed PostgreSQL destination and dead-letter integration coverage
 - public API approval tests and repository-level API stability guidance
 
 ## API Stability

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -27,10 +27,14 @@ Each record flows through the runtime inside a `PipelineContainer<T>`, which let
   the transport-agnostic pipeline runtime
 - `src/Pipelinez.Kafka`
   the Kafka transport extension assembly
+- `src/Pipelinez.PostgreSql`
+  the PostgreSQL destination and dead-letter transport extension assembly
 - `src/tests/Pipelinez.Tests`
   unit and runtime tests for core pipeline behavior
 - `src/tests/Pipelinez.Kafka.Tests`
   Docker-backed Kafka integration tests using Testcontainers
+- `src/tests/Pipelinez.PostgreSql.Tests`
+  Docker-backed PostgreSQL destination and dead-letter integration tests using Testcontainers
 - `src/benchmarks/Pipelinez.Benchmarks`
   BenchmarkDotNet project for repeatable in-memory performance measurements
 - `src/examples/Example.Kafka`
@@ -48,6 +52,7 @@ The public packages are available on NuGet.org:
 - [`Pipelinez.Kafka`](https://www.nuget.org/packages/Pipelinez.Kafka)
 
 The repository remains configured for package metadata, XML docs, Source Link, symbol packages, and CI pack validation.
+The repository also contains `Pipelinez.PostgreSql`, which follows the same packaging model and local package validation flow.
 Public release automation is configured through tag-based GitHub Actions and NuGet Trusted Publishing.
 
 Versioning rules:
@@ -85,6 +90,11 @@ Kafka integrates through extension methods in `Pipelinez.Kafka`, not through par
 - `WithKafkaSource(...)`
 - `WithKafkaDestination(...)`
 - `WithKafkaDeadLetterDestination(...)`
+
+PostgreSQL also integrates through extension methods in `Pipelinez.PostgreSql`. The PostgreSQL assembly adds:
+
+- `WithPostgreSqlDestination(...)`
+- `WithPostgreSqlDeadLetterDestination(...)`
 
 `Build()` validates that a source and destination exist, creates a `Pipeline<T>`, links all blocks, and initializes the source and destination.
 If distributed execution is requested, `Build()` also validates that the configured source implements the distributed source contract.
@@ -750,6 +760,50 @@ The Kafka config path now supports both:
 
 Schema-registry-backed JSON and Avro serializer/deserializer configuration remains part of the public Kafka surface.
 
+## PostgreSQL Integration
+
+PostgreSQL support lives in the separate `Pipelinez.PostgreSql` assembly under `src/Pipelinez.PostgreSql`.
+
+### Builder Surface
+
+PostgreSQL extends the builder through `PostgreSqlPipelineBuilderExtensions`:
+
+- `WithPostgreSqlDestination(...)`
+- `WithPostgreSqlDeadLetterDestination(...)`
+
+This keeps `PipelineBuilder<T>` transport-agnostic while still exposing PostgreSQL-specific construction behavior where it belongs.
+
+### PostgreSQL Destination
+
+The PostgreSQL destination:
+
+- maps a pipeline record either through `PostgreSqlTableMap<T>` or a custom `PostgreSqlCommandDefinition`
+- generates parameterized `INSERT` statements for table-map-backed writes
+- executes commands through Dapper on top of `Npgsql`
+- only completes the record after PostgreSQL acknowledges the write
+
+The transport is intentionally schema-agnostic. Consumers choose the schema, table, and column names that make sense for their system.
+
+### PostgreSQL Dead-Letter Destination
+
+The PostgreSQL dead-letter destination supports two shapes:
+
+- `PostgreSqlTableMap<PipelineDeadLetterRecord<T>>`
+- `Func<PipelineDeadLetterRecord<T>, PostgreSqlCommandDefinition>`
+
+That allows consumers to use either a simple mapped dead-letter table or a fully custom SQL write for audit/compliance scenarios.
+
+### Configuration
+
+PostgreSQL configuration supports:
+
+- `ConnectionString`
+- `ConfigureConnectionString`
+- `ConfigureDataSource`
+- externally supplied `NpgsqlDataSource`
+
+This gives consumers full control over pooling and driver configuration while keeping Pipelinez responsible only for command execution.
+
 ## Examples
 
 ### `Example.Kafka`
@@ -808,6 +862,17 @@ The solution now includes two test layers.
 - partition-local ordering by default and opt-in out-of-order completion when within-partition concurrency is enabled
 - partition execution-state visibility in runtime context and distributed status
 
+### PostgreSQL Integration Tests
+
+`src/tests/Pipelinez.PostgreSql.Tests` uses Docker and `Testcontainers.PostgreSql` to validate:
+
+- direct record-to-table mapping into consumer-owned schemas and tables
+- custom parameterized SQL execution
+- dead-letter table mapping
+- dead-letter custom SQL execution
+- option validation and generated SQL safety
+- public API approval coverage for the PostgreSQL package
+
 At the time of this overview update, `dotnet test src\\Pipelinez.sln` passes with both the core and Kafka integration suites green.
 
 ## Current State
@@ -827,6 +892,7 @@ The major architectural work called out in the earlier planning docs has been im
 - explicit performance tuning controls, built-in performance snapshots, destination batching, and a benchmark project
 - explicit retry policies with retry history, retry events, and retry-aware performance counters
 - explicit dead-letter flows with in-memory and Kafka dead-letter destinations
+- explicit PostgreSQL destination and dead-letter transport support
 - explicit flow-control policies with publish results, saturation status, and pressure metrics
 - explicit operational tooling with health snapshots, health checks, meter metrics, and correlation-aware diagnostics
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ This folder contains the main documentation set for Pipelinez.
   first end-to-end pipeline without external infrastructure
 - [Kafka Pipeline](getting-started/kafka.md)
   first Kafka-backed pipeline using the example Docker workflow
+- [PostgreSQL Destination](getting-started/postgresql-destination.md)
+  first PostgreSQL-backed destination and dead-letter pipeline shape
 
 ## Guides
 
@@ -30,6 +32,7 @@ This folder contains the main documentation set for Pipelinez.
 ## Transport Docs
 
 - [Kafka](transports/kafka.md)
+- [PostgreSQL](transports/postgresql.md)
 
 ## Operations
 
@@ -39,6 +42,7 @@ This folder contains the main documentation set for Pipelinez.
 
 - [Runtime](architecture/runtime.md)
 - [Kafka Internals](architecture/kafka.md)
+- [PostgreSQL Internals](architecture/postgresql.md)
 - [Testing](architecture/testing.md)
 
 ## Installation Note
@@ -56,5 +60,7 @@ dotnet add package Pipelinez.Kafka
 ```
 
 Public releases are configured through tag-based GitHub Actions and NuGet Trusted Publishing.
+
+The repository also contains `Pipelinez.PostgreSql`, which is packable in-source and follows the same packaging and validation flow.
 
 Both public packages also ship XML IntelliSense documentation so API descriptions show up directly in supported IDEs.

--- a/docs/architecture/postgresql.md
+++ b/docs/architecture/postgresql.md
@@ -1,0 +1,97 @@
+# PostgreSQL Internals
+
+Audience: contributors and maintainers working on the PostgreSQL transport.
+
+## What This Covers
+
+- destination responsibilities
+- dead-letter responsibilities
+- mapping and SQL generation
+- connection ownership rules
+
+## Transport Scope
+
+The current PostgreSQL transport is destination-only.
+
+That means the transport does not participate in:
+
+- record sourcing
+- source ownership
+- replay detection
+- polling loops
+
+Instead, it integrates with the destination and dead-letter extension points already provided by the core runtime.
+
+## Destination Responsibilities
+
+`PostgreSqlPipelineDestination<TRecord>` is responsible for:
+
+- receiving successfully processed records from the pipeline destination base
+- translating each record into either:
+  - a generated insert command from `PostgreSqlTableMap<T>`
+  - a consumer-provided `PostgreSqlCommandDefinition`
+- executing the final command through Dapper
+- only completing the record after PostgreSQL acknowledges the write
+
+## Dead-Letter Responsibilities
+
+`PostgreSqlDeadLetterDestination<TRecord>` is responsible for:
+
+- receiving `PipelineDeadLetterRecord<TRecord>` envelopes
+- translating each dead-letter record into either:
+  - a generated insert command from `PostgreSqlTableMap<PipelineDeadLetterRecord<T>>`
+  - a consumer-provided `PostgreSqlCommandDefinition`
+- executing the final command through Dapper
+
+## Mapping Model
+
+`PostgreSqlTableMap<T>` is the generated-command path.
+
+It captures:
+
+- schema name
+- table name
+- ordered column mappings
+- whether each mapping is scalar or JSON
+
+The internal command factory then turns that into a parameterized `INSERT`.
+
+For JSON mappings, the generated SQL uses `::jsonb` casts so structured values can be serialized and inserted safely.
+
+## SQL Safety
+
+The transport never interpolates record values into SQL text.
+
+Safety rules:
+
+- table-map values become parameters
+- custom SQL values are expected to be parameterized through `PostgreSqlCommandDefinition.Parameters`
+- schema, table, and column identifiers are validated and quoted through the internal identifier helper
+
+## Connection Ownership
+
+The connection factory supports two modes:
+
+- externally supplied `NpgsqlDataSource`
+- internally built `NpgsqlDataSource`
+
+Rules:
+
+- externally supplied data sources are consumer-owned
+- internally built data sources are created from the configured connection string and builder hooks
+- connection-string and data-source customization hooks are only applied when Pipelinez builds the data source itself
+
+## Runtime Integration
+
+The PostgreSQL destination inherits the core destination runtime behavior, so PostgreSQL writes automatically participate in:
+
+- retry handling
+- flow control
+- destination performance metrics
+- operational health and diagnostics
+- dead-letter policy routing
+
+## Related Docs
+
+- [PostgreSQL](../transports/postgresql.md)
+- [Architecture: Runtime](runtime.md)

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -5,7 +5,7 @@ Audience: contributors and maintainers extending the test suite.
 ## What This Covers
 
 - the current test layers
-- what belongs in core tests versus Kafka integration tests
+- what belongs in core tests versus transport integration tests
 - API approval testing
 
 ## Test Layers
@@ -36,12 +36,25 @@ This suite validates:
 - distributed worker ownership and rebalance
 - partition-aware execution
 
+### PostgreSQL Integration Tests
+
+`src/tests/Pipelinez.PostgreSql.Tests` covers real PostgreSQL behavior using Docker/Testcontainers.
+
+This suite validates:
+
+- direct destination writes through generated table maps
+- custom SQL destination writes
+- dead-letter table mapping
+- dead-letter custom SQL writes
+- connection-configuration validation and API approval coverage
+
 ## API Approval Tests
 
 The repository now also includes public API approval tests for:
 
 - `Pipelinez`
 - `Pipelinez.Kafka`
+- `Pipelinez.PostgreSql`
 
 Those tests compare the compiled public surface to checked-in approved baselines.
 
@@ -51,6 +64,7 @@ Baseline refresh workflow:
 $env:PIPELINEZ_UPDATE_API_BASELINES='1'
 dotnet test src/tests/Pipelinez.Tests/Pipelinez.Tests.csproj --filter ApiApprovalTests
 dotnet test src/tests/Pipelinez.Kafka.Tests/Pipelinez.Kafka.Tests.csproj --filter ApiApprovalTests
+dotnet test src/tests/Pipelinez.PostgreSql.Tests/Pipelinez.PostgreSql.Tests.csproj --filter ApiApprovalTests
 ```
 
 Then run:
@@ -70,6 +84,11 @@ Use Kafka integration tests when:
 
 - the behavior depends on a real broker
 - the scenario depends on Kafka offsets, partitions, rebalance, or headers
+
+Use PostgreSQL integration tests when:
+
+- the behavior depends on real PostgreSQL execution
+- the scenario validates generated SQL, custom SQL, or dead-letter table writes
 
 ## Related Docs
 

--- a/docs/getting-started/postgresql-destination.md
+++ b/docs/getting-started/postgresql-destination.md
@@ -1,0 +1,120 @@
+# PostgreSQL Destination
+
+Audience: application developers who want to write pipeline output or dead-letter records into PostgreSQL.
+
+## What This Covers
+
+This guide shows the shape of the PostgreSQL transport as it exists today:
+
+- PostgreSQL destination writes
+- PostgreSQL dead-letter writes
+- consumer-owned schema and table mapping
+- custom SQL through Dapper-backed execution
+
+## Current Scope
+
+The first PostgreSQL transport implementation is destination-only.
+
+It supports:
+
+- `WithPostgreSqlDestination(...)`
+- `WithPostgreSqlDeadLetterDestination(...)`
+
+It does not currently support a PostgreSQL source.
+
+## Package
+
+The PostgreSQL transport lives in:
+
+- `src/Pipelinez.PostgreSql`
+
+If you are working from source, reference that project directly or pack it locally with the repository packaging workflow.
+
+## Minimal Destination Example
+
+```csharp
+using Pipelinez.Core;
+using Pipelinez.Core.Record;
+using Pipelinez.PostgreSql;
+using Pipelinez.PostgreSql.Configuration;
+using Pipelinez.PostgreSql.Mapping;
+
+var pipeline = Pipeline<OrderRecord>.New("orders")
+    .WithInMemorySource(new object())
+    .WithPostgreSqlDestination(
+        new PostgreSqlDestinationOptions
+        {
+            ConnectionString = "Host=localhost;Database=pipelinez;Username=postgres;Password=postgres"
+        },
+        PostgreSqlTableMap<OrderRecord>.ForTable("app", "processed_orders")
+            .Map("order_id", record => record.Id)
+            .MapJson("payload", record => record)
+            .Map("processed_at_utc", _ => DateTimeOffset.UtcNow))
+    .Build();
+
+public sealed class OrderRecord : PipelineRecord
+{
+    public required string Id { get; init; }
+}
+```
+
+## Custom SQL Example
+
+```csharp
+var pipeline = Pipeline<OrderRecord>.New("orders")
+    .WithInMemorySource(new object())
+    .WithPostgreSqlDestination(
+        new PostgreSqlDestinationOptions
+        {
+            ConnectionString = "Host=localhost;Database=pipelinez;Username=postgres;Password=postgres"
+        },
+        record => new PostgreSqlCommandDefinition(
+            """
+            INSERT INTO app.processed_orders (order_id, payload)
+            VALUES (@order_id, @payload::jsonb)
+            """,
+            new
+            {
+                order_id = record.Id,
+                payload = JsonSerializer.Serialize(record)
+            }))
+    .Build();
+```
+
+## Dead-Letter Mapping Example
+
+```csharp
+var pipeline = Pipeline<OrderRecord>.New("orders")
+    .WithInMemorySource(new object())
+    .WithPostgreSqlDestination(
+        destinationOptions,
+        PostgreSqlTableMap<OrderRecord>.ForTable("app", "processed_orders")
+            .Map("order_id", record => record.Id)
+            .MapJson("payload", record => record))
+    .WithPostgreSqlDeadLetterDestination(
+        deadLetterOptions,
+        PostgreSqlTableMap<PipelineDeadLetterRecord<OrderRecord>>.ForTable("audit", "order_failures")
+            .Map("order_id", deadLetter => deadLetter.Record.Id)
+            .Map("fault_component", deadLetter => deadLetter.Fault.ComponentName)
+            .MapJson("record_json", deadLetter => deadLetter.Record)
+            .Map("dead_lettered_at_utc", deadLetter => deadLetter.DeadLetteredAtUtc))
+    .WithErrorHandler(_ => PipelineErrorAction.DeadLetter)
+    .Build();
+```
+
+## Connection Configuration
+
+The PostgreSQL transport supports:
+
+- `ConnectionString`
+- `ConfigureConnectionString`
+- `ConfigureDataSource`
+- externally supplied `NpgsqlDataSource`
+
+That gives consumers full control over pooling, timeouts, type mappings, and driver configuration without forcing Pipelinez to own connection setup.
+
+## Next Steps
+
+- read [PostgreSQL Transport](../transports/postgresql.md)
+- read [Architecture: PostgreSQL](../architecture/postgresql.md)
+- read [Dead-Lettering](../guides/dead-lettering.md)

--- a/docs/transports/kafka.md
+++ b/docs/transports/kafka.md
@@ -12,8 +12,6 @@ Audience: application developers and operators using the Kafka transport extensi
 
 ## Current Transport Status
 
-Kafka is the only transport extension currently implemented in this repository.
-
 Kafka support lives in:
 
 - `src/Pipelinez.Kafka`

--- a/docs/transports/postgresql.md
+++ b/docs/transports/postgresql.md
@@ -1,0 +1,130 @@
+# PostgreSQL
+
+Audience: application developers and operators using the PostgreSQL transport extension.
+
+## What This Covers
+
+- PostgreSQL destination setup
+- PostgreSQL dead-letter setup
+- consumer-owned schema mapping
+- custom SQL execution
+
+## Current Transport Status
+
+PostgreSQL support lives in:
+
+- `src/Pipelinez.PostgreSql`
+
+Current scope:
+
+- PostgreSQL destination writes
+- PostgreSQL dead-letter writes
+
+Current non-goal:
+
+- PostgreSQL source support
+
+## Consumer-Owned Schema
+
+The PostgreSQL transport does not require a Pipelinez-owned schema.
+
+Consumers choose:
+
+- schema name
+- table name
+- column names
+- whether to use generated insert SQL or custom SQL
+
+That means the transport can write into:
+
+- existing application tables
+- integration/outbox tables
+- audit tables
+- dead-letter review tables
+
+## Direct Table Mapping
+
+```csharp
+var destinationMap = PostgreSqlTableMap<OrderRecord>.ForTable("app", "processed_orders")
+    .Map("order_id", record => record.Id)
+    .MapJson("payload", record => record)
+    .Map("processed_at_utc", _ => DateTimeOffset.UtcNow);
+
+var pipeline = Pipeline<OrderRecord>.New("orders")
+    .WithInMemorySource(new object())
+    .WithPostgreSqlDestination(destinationOptions, destinationMap)
+    .Build();
+```
+
+The generated table-map path creates a parameterized `INSERT` statement and executes it through Dapper.
+
+## Custom SQL
+
+```csharp
+var pipeline = Pipeline<OrderRecord>.New("orders")
+    .WithInMemorySource(new object())
+    .WithPostgreSqlDestination(
+        destinationOptions,
+        record => new PostgreSqlCommandDefinition(
+            """
+            INSERT INTO app.processed_orders (order_id, payload)
+            VALUES (@order_id, @payload::jsonb)
+            """,
+            new
+            {
+                order_id = record.Id,
+                payload = JsonSerializer.Serialize(record)
+            }))
+    .Build();
+```
+
+This is the path to use when the consumer wants to own the SQL completely.
+
+## Dead-Letter Mapping
+
+Dead-letter support is available through both:
+
+- `PostgreSqlTableMap<PipelineDeadLetterRecord<T>>`
+- `Func<PipelineDeadLetterRecord<T>, PostgreSqlCommandDefinition>`
+
+Example:
+
+```csharp
+var deadLetterMap = PostgreSqlTableMap<PipelineDeadLetterRecord<OrderRecord>>.ForTable("audit", "order_failures")
+    .Map("order_id", deadLetter => deadLetter.Record.Id)
+    .Map("fault_component", deadLetter => deadLetter.Fault.ComponentName)
+    .MapJson("record_json", deadLetter => deadLetter.Record)
+    .MapJson("metadata_json", deadLetter => deadLetter.Metadata)
+    .Map("dead_lettered_at_utc", deadLetter => deadLetter.DeadLetteredAtUtc);
+```
+
+## Dapper Execution Model
+
+The PostgreSQL transport uses Dapper internally for execution.
+
+That choice keeps the transport:
+
+- lightweight
+- explicit
+- parameterized by default
+- compatible with consumer-owned SQL
+
+The public API does not expose Dapper types directly. Pipelinez owns the command abstraction and converts it to Dapper internally.
+
+## Connection Options
+
+Shared PostgreSQL options support:
+
+- `ConnectionString`
+- `ConfigureConnectionString`
+- `ConfigureDataSource`
+- `DataSource`
+- `CommandTimeoutSeconds`
+- `EnableSensitiveLogging`
+- `SerializerOptions`
+
+## Related Docs
+
+- [Getting Started: PostgreSQL Destination](../getting-started/postgresql-destination.md)
+- [Architecture: PostgreSQL](../architecture/postgresql.md)
+- [Dead-Lettering](../guides/dead-lettering.md)

--- a/scripts/Validate-Packages.ps1
+++ b/scripts/Validate-Packages.ps1
@@ -117,13 +117,20 @@ $resolvedPackageDirectory = (Resolve-Path -Path $PackageDirectory).Path
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 $coreProjectPath = Join-Path (Join-Path $repoRoot 'src') (Join-Path 'Pipelinez' 'Pipelinez.csproj')
 $kafkaProjectPath = Join-Path (Join-Path $repoRoot 'src') (Join-Path 'Pipelinez.Kafka' 'Pipelinez.Kafka.csproj')
+$postgresProjectPath = Join-Path (Join-Path $repoRoot 'src') (Join-Path 'Pipelinez.PostgreSql' 'Pipelinez.PostgreSql.csproj')
 
 $coreVersion = Get-PackageVersion -ProjectPath $coreProjectPath -RepositoryRoot $repoRoot
 $kafkaVersion = Get-PackageVersion -ProjectPath $kafkaProjectPath -RepositoryRoot $repoRoot
+$postgresVersion = Get-PackageVersion -ProjectPath $postgresProjectPath -RepositoryRoot $repoRoot
 
 if ($coreVersion -ne $kafkaVersion)
 {
     throw "Pipelinez and Pipelinez.Kafka package versions must match. Core: $coreVersion Kafka: $kafkaVersion"
+}
+
+if ($coreVersion -ne $postgresVersion)
+{
+    throw "Pipelinez, Pipelinez.Kafka, and Pipelinez.PostgreSql package versions must match. Core: $coreVersion Kafka: $kafkaVersion PostgreSql: $postgresVersion"
 }
 
 $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("pipelinez-package-smoke-" + [guid]::NewGuid().ToString('N'))
@@ -212,6 +219,39 @@ public sealed class KafkaSmokeRecord : PipelineRecord
 }
 "@ | Set-Content -Path (Join-Path $kafkaSmokeDirectory 'Program.cs')
     Invoke-DotNet -Arguments @('build', (Join-Path $kafkaSmokeDirectory 'KafkaSmoke.csproj'), '--configfile', $nugetConfigPath, '--configuration', 'Release')
+
+    $postgresSmokeDirectory = Join-Path $tempRoot 'PostgreSqlSmoke'
+    Invoke-DotNet -Arguments @('new', 'console', '--framework', 'net8.0', '--output', $postgresSmokeDirectory)
+    Invoke-DotNet -Arguments @('add', (Join-Path $postgresSmokeDirectory 'PostgreSqlSmoke.csproj'), 'package', 'Pipelinez.PostgreSql', '--version', $postgresVersion, '--source', $resolvedPackageDirectory)
+    @"
+using Pipelinez.Core;
+using Pipelinez.Core.Record;
+using Pipelinez.PostgreSql;
+using Pipelinez.PostgreSql.Configuration;
+using Pipelinez.PostgreSql.Mapping;
+
+var options = new PostgreSqlDestinationOptions
+{
+    ConnectionString = "Host=localhost;Database=pipelinez;Username=postgres;Password=postgres"
+};
+
+var pipeline = Pipeline<PostgreSqlSmokeRecord>.New("orders")
+    .WithInMemorySource(new object())
+    .WithPostgreSqlDestination(
+        options,
+        PostgreSqlTableMap<PostgreSqlSmokeRecord>.ForTable("app", "orders")
+            .Map("order_id", record => record.Id)
+            .MapJson("payload", record => record))
+    .Build();
+
+Console.WriteLine(pipeline.GetStatus().Status);
+
+public sealed class PostgreSqlSmokeRecord : PipelineRecord
+{
+    public required string Id { get; init; }
+}
+"@ | Set-Content -Path (Join-Path $postgresSmokeDirectory 'Program.cs')
+    Invoke-DotNet -Arguments @('build', (Join-Path $postgresSmokeDirectory 'PostgreSqlSmoke.csproj'), '--configfile', $nugetConfigPath, '--configuration', 'Release')
 
     Write-Host "Package smoke validation succeeded."
 }

--- a/src/Pipelinez.Kafka/PackageReadme.md
+++ b/src/Pipelinez.Kafka/PackageReadme.md
@@ -19,6 +19,11 @@ dotnet add package Pipelinez.Kafka
 
 `Pipelinez.Kafka` depends on `Pipelinez`, so you do not need to add both explicitly unless you prefer to do so.
 
+Related transport package in this repository:
+
+- `Pipelinez.PostgreSql`
+  PostgreSQL destination and dead-letter transport extensions
+
 ## Quick Example
 
 ```csharp

--- a/src/Pipelinez.PostgreSql/Client/IPostgreSqlCommandExecutor.cs
+++ b/src/Pipelinez.PostgreSql/Client/IPostgreSqlCommandExecutor.cs
@@ -1,0 +1,8 @@
+using Pipelinez.PostgreSql.Mapping;
+
+namespace Pipelinez.PostgreSql.Client;
+
+internal interface IPostgreSqlCommandExecutor
+{
+    Task ExecuteAsync(PostgreSqlCommandDefinition command, CancellationToken cancellationToken);
+}

--- a/src/Pipelinez.PostgreSql/Client/IPostgreSqlConnectionFactory.cs
+++ b/src/Pipelinez.PostgreSql/Client/IPostgreSqlConnectionFactory.cs
@@ -1,0 +1,8 @@
+using Npgsql;
+
+namespace Pipelinez.PostgreSql.Client;
+
+internal interface IPostgreSqlConnectionFactory : IAsyncDisposable
+{
+    ValueTask<NpgsqlConnection> OpenConnectionAsync(CancellationToken cancellationToken);
+}

--- a/src/Pipelinez.PostgreSql/Client/PostgreSqlConnectionFactory.cs
+++ b/src/Pipelinez.PostgreSql/Client/PostgreSqlConnectionFactory.cs
@@ -1,0 +1,55 @@
+using Ardalis.GuardClauses;
+using Npgsql;
+using Pipelinez.PostgreSql.Configuration;
+
+namespace Pipelinez.PostgreSql.Client;
+
+internal sealed class PostgreSqlConnectionFactory : IPostgreSqlConnectionFactory
+{
+    private readonly NpgsqlDataSource _dataSource;
+    private readonly bool _ownsDataSource;
+
+    internal PostgreSqlConnectionFactory(PostgreSqlOptions options)
+    {
+        var configuration = Guard.Against.Null(options, nameof(options));
+        configuration.ValidateCore(configuration.GetType().Name);
+
+        if (configuration.DataSource is not null)
+        {
+            _dataSource = configuration.DataSource;
+            _ownsDataSource = false;
+            return;
+        }
+
+        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(configuration.ConnectionString);
+        configuration.ConfigureConnectionString?.Invoke(connectionStringBuilder);
+
+        if (configuration.CommandTimeoutSeconds.HasValue)
+        {
+            connectionStringBuilder.CommandTimeout = configuration.CommandTimeoutSeconds.Value;
+        }
+
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(connectionStringBuilder.ConnectionString);
+        if (configuration.EnableSensitiveLogging)
+        {
+            dataSourceBuilder.EnableParameterLogging();
+        }
+
+        configuration.ConfigureDataSource?.Invoke(dataSourceBuilder);
+
+        _dataSource = dataSourceBuilder.Build();
+        _ownsDataSource = true;
+    }
+
+    public ValueTask<NpgsqlConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        return _dataSource.OpenConnectionAsync(cancellationToken);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return _ownsDataSource
+            ? _dataSource.DisposeAsync()
+            : ValueTask.CompletedTask;
+    }
+}

--- a/src/Pipelinez.PostgreSql/Client/PostgreSqlDapperCommandExecutor.cs
+++ b/src/Pipelinez.PostgreSql/Client/PostgreSqlDapperCommandExecutor.cs
@@ -1,0 +1,40 @@
+using Ardalis.GuardClauses;
+using Dapper;
+using Pipelinez.PostgreSql.Mapping;
+
+namespace Pipelinez.PostgreSql.Client;
+
+internal sealed class PostgreSqlDapperCommandExecutor : IPostgreSqlCommandExecutor, IAsyncDisposable
+{
+    private readonly IPostgreSqlConnectionFactory _connectionFactory;
+    private readonly int? _defaultCommandTimeoutSeconds;
+
+    internal PostgreSqlDapperCommandExecutor(
+        IPostgreSqlConnectionFactory connectionFactory,
+        int? defaultCommandTimeoutSeconds)
+    {
+        _connectionFactory = Guard.Against.Null(connectionFactory, nameof(connectionFactory));
+        _defaultCommandTimeoutSeconds = defaultCommandTimeoutSeconds;
+    }
+
+    public async Task ExecuteAsync(PostgreSqlCommandDefinition command, CancellationToken cancellationToken)
+    {
+        var validatedCommand = Guard.Against.Null(command, nameof(command)).Validate();
+
+        await using var connection = await _connectionFactory
+            .OpenConnectionAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        await connection.ExecuteAsync(new CommandDefinition(
+                validatedCommand.CommandText,
+                validatedCommand.Parameters,
+                commandTimeout: validatedCommand.CommandTimeoutSeconds ?? _defaultCommandTimeoutSeconds,
+                cancellationToken: cancellationToken))
+            .ConfigureAwait(false);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return _connectionFactory.DisposeAsync();
+    }
+}

--- a/src/Pipelinez.PostgreSql/Configuration/PostgreSqlDeadLetterOptions.cs
+++ b/src/Pipelinez.PostgreSql/Configuration/PostgreSqlDeadLetterOptions.cs
@@ -1,0 +1,17 @@
+namespace Pipelinez.PostgreSql.Configuration;
+
+/// <summary>
+/// Configures PostgreSQL writes for dead-letter records.
+/// </summary>
+public sealed class PostgreSqlDeadLetterOptions : PostgreSqlOptions
+{
+    /// <summary>
+    /// Validates the dead-letter options and returns the same instance when valid.
+    /// </summary>
+    /// <returns>The validated options instance.</returns>
+    public PostgreSqlDeadLetterOptions Validate()
+    {
+        ValidateCore(nameof(PostgreSqlDeadLetterOptions));
+        return this;
+    }
+}

--- a/src/Pipelinez.PostgreSql/Configuration/PostgreSqlDestinationOptions.cs
+++ b/src/Pipelinez.PostgreSql/Configuration/PostgreSqlDestinationOptions.cs
@@ -1,0 +1,17 @@
+namespace Pipelinez.PostgreSql.Configuration;
+
+/// <summary>
+/// Configures PostgreSQL destination writes for normal pipeline records.
+/// </summary>
+public sealed class PostgreSqlDestinationOptions : PostgreSqlOptions
+{
+    /// <summary>
+    /// Validates the destination options and returns the same instance when valid.
+    /// </summary>
+    /// <returns>The validated options instance.</returns>
+    public PostgreSqlDestinationOptions Validate()
+    {
+        ValidateCore(nameof(PostgreSqlDestinationOptions));
+        return this;
+    }
+}

--- a/src/Pipelinez.PostgreSql/Configuration/PostgreSqlOptions.cs
+++ b/src/Pipelinez.PostgreSql/Configuration/PostgreSqlOptions.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using Ardalis.GuardClauses;
+using Npgsql;
+
+namespace Pipelinez.PostgreSql.Configuration;
+
+/// <summary>
+/// Provides shared PostgreSQL connection and serialization settings used by PostgreSQL transport components.
+/// </summary>
+public abstract class PostgreSqlOptions
+{
+    /// <summary>
+    /// Gets or sets the connection string used when the transport builds its own <see cref="NpgsqlDataSource" />.
+    /// </summary>
+    public string? ConnectionString { get; init; }
+
+    /// <summary>
+    /// Gets or sets an optional callback that can customize the <see cref="NpgsqlConnectionStringBuilder" /> before the data source is built.
+    /// </summary>
+    public Action<NpgsqlConnectionStringBuilder>? ConfigureConnectionString { get; init; }
+
+    /// <summary>
+    /// Gets or sets an optional callback that can customize the <see cref="NpgsqlDataSourceBuilder" /> before the data source is built.
+    /// </summary>
+    public Action<NpgsqlDataSourceBuilder>? ConfigureDataSource { get; init; }
+
+    /// <summary>
+    /// Gets or sets an externally owned <see cref="NpgsqlDataSource" /> to use for command execution.
+    /// </summary>
+    /// <remarks>
+    /// When provided, <see cref="ConnectionString" />, <see cref="ConfigureConnectionString" />, and
+    /// <see cref="ConfigureDataSource" /> must not also be supplied.
+    /// </remarks>
+    public NpgsqlDataSource? DataSource { get; init; }
+
+    /// <summary>
+    /// Gets or sets the default command timeout in seconds for PostgreSQL commands executed by the transport.
+    /// </summary>
+    public int? CommandTimeoutSeconds { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether parameter logging should be enabled when the transport builds its own data source.
+    /// </summary>
+    public bool EnableSensitiveLogging { get; init; }
+
+    /// <summary>
+    /// Gets or sets the JSON serializer options used by generated JSON mappings.
+    /// </summary>
+    public JsonSerializerOptions SerializerOptions { get; init; } = new(JsonSerializerDefaults.Web);
+
+    internal void ValidateCore(string optionsName)
+    {
+        Guard.Against.NullOrWhiteSpace(optionsName, nameof(optionsName));
+        Guard.Against.Null(SerializerOptions, nameof(SerializerOptions));
+
+        if (CommandTimeoutSeconds is <= 0)
+        {
+            throw new InvalidOperationException($"{optionsName} command timeout must be greater than zero when provided.");
+        }
+
+        if (DataSource is not null)
+        {
+            if (!string.IsNullOrWhiteSpace(ConnectionString) ||
+                ConfigureConnectionString is not null ||
+                ConfigureDataSource is not null)
+            {
+                throw new InvalidOperationException(
+                    $"{optionsName} cannot combine an external NpgsqlDataSource with connection-string or data-source builder configuration.");
+            }
+
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(ConnectionString))
+        {
+            throw new InvalidOperationException(
+                $"{optionsName} requires either a ConnectionString or an external NpgsqlDataSource.");
+        }
+    }
+}

--- a/src/Pipelinez.PostgreSql/DeadLettering/PostgreSqlDeadLetterDestination.cs
+++ b/src/Pipelinez.PostgreSql/DeadLettering/PostgreSqlDeadLetterDestination.cs
@@ -1,0 +1,41 @@
+using Ardalis.GuardClauses;
+using Microsoft.Extensions.Logging;
+using Pipelinez.Core.DeadLettering;
+using Pipelinez.Core.Logging;
+using Pipelinez.Core.Record;
+using Pipelinez.PostgreSql.Client;
+using Pipelinez.PostgreSql.Configuration;
+using Pipelinez.PostgreSql.Mapping;
+
+namespace Pipelinez.PostgreSql.DeadLettering;
+
+internal sealed class PostgreSqlDeadLetterDestination<TRecord> : IPipelineDeadLetterDestination<TRecord>
+    where TRecord : PipelineRecord
+{
+    private readonly Func<PipelineDeadLetterRecord<TRecord>, PostgreSqlCommandDefinition> _commandFactory;
+    private readonly ILogger<PostgreSqlDeadLetterDestination<TRecord>> _logger;
+    private readonly IPostgreSqlCommandExecutor _executor;
+
+    internal PostgreSqlDeadLetterDestination(
+        PostgreSqlDeadLetterOptions options,
+        Func<PipelineDeadLetterRecord<TRecord>, PostgreSqlCommandDefinition> commandFactory,
+        IPostgreSqlCommandExecutor? executorOverride = null)
+    {
+        var validatedOptions = Guard.Against.Null(options, nameof(options)).Validate();
+        _commandFactory = Guard.Against.Null(commandFactory, nameof(commandFactory));
+        _logger = LoggingManager.Instance.CreateLogger<PostgreSqlDeadLetterDestination<TRecord>>();
+        _executor = executorOverride ?? new PostgreSqlDapperCommandExecutor(
+            new PostgreSqlConnectionFactory(validatedOptions),
+            validatedOptions.CommandTimeoutSeconds);
+    }
+
+    public async Task WriteAsync(PipelineDeadLetterRecord<TRecord> deadLetterRecord, CancellationToken cancellationToken)
+    {
+        Guard.Against.Null(deadLetterRecord, nameof(deadLetterRecord));
+        deadLetterRecord.Validate();
+
+        var command = _commandFactory(deadLetterRecord).Validate();
+        _logger.LogTrace("Writing PostgreSQL dead-letter record");
+        await _executor.ExecuteAsync(command, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Pipelinez.PostgreSql/Destination/PostgreSqlPipelineDestination.cs
+++ b/src/Pipelinez.PostgreSql/Destination/PostgreSqlPipelineDestination.cs
@@ -1,0 +1,48 @@
+using Ardalis.GuardClauses;
+using Microsoft.Extensions.Logging;
+using Pipelinez.Core.Destination;
+using Pipelinez.Core.Logging;
+using Pipelinez.Core.Record;
+using Pipelinez.PostgreSql.Client;
+using Pipelinez.PostgreSql.Configuration;
+using Pipelinez.PostgreSql.Mapping;
+
+namespace Pipelinez.PostgreSql.Destination;
+
+internal sealed class PostgreSqlPipelineDestination<TRecord> : PipelineDestination<TRecord>
+    where TRecord : PipelineRecord
+{
+    private readonly PostgreSqlDestinationOptions _options;
+    private readonly Func<TRecord, PostgreSqlCommandDefinition> _commandFactory;
+    private readonly ILogger<PostgreSqlPipelineDestination<TRecord>> _logger;
+    private readonly IPostgreSqlCommandExecutor? _executorOverride;
+    private IPostgreSqlCommandExecutor? _executor;
+
+    internal PostgreSqlPipelineDestination(
+        PostgreSqlDestinationOptions options,
+        Func<TRecord, PostgreSqlCommandDefinition> commandFactory,
+        IPostgreSqlCommandExecutor? executorOverride = null)
+    {
+        _options = Guard.Against.Null(options, nameof(options)).Validate();
+        _commandFactory = Guard.Against.Null(commandFactory, nameof(commandFactory));
+        _executorOverride = executorOverride;
+        _logger = LoggingManager.Instance.CreateLogger<PostgreSqlPipelineDestination<TRecord>>();
+    }
+
+    protected override void Initialize()
+    {
+        _logger.LogInformation("Initializing PostgreSQL pipeline destination");
+        _executor = _executorOverride ?? new PostgreSqlDapperCommandExecutor(
+            new PostgreSqlConnectionFactory(_options),
+            _options.CommandTimeoutSeconds);
+    }
+
+    protected override async Task ExecuteAsync(TRecord record, CancellationToken cancellationToken)
+    {
+        var command = _commandFactory(record).Validate();
+        await Executor.ExecuteAsync(command, cancellationToken).ConfigureAwait(false);
+    }
+
+    private IPostgreSqlCommandExecutor Executor =>
+        _executor ?? throw new InvalidOperationException("PostgreSQL destination has not been initialized.");
+}

--- a/src/Pipelinez.PostgreSql/Internal/PostgreSqlColumnMap.cs
+++ b/src/Pipelinez.PostgreSql/Internal/PostgreSqlColumnMap.cs
@@ -1,0 +1,6 @@
+namespace Pipelinez.PostgreSql.Internal;
+
+internal sealed record PostgreSqlColumnMap<TModel>(
+    string ColumnName,
+    Func<TModel, object?> ValueFactory,
+    PostgreSqlColumnValueKind ValueKind);

--- a/src/Pipelinez.PostgreSql/Internal/PostgreSqlColumnValueKind.cs
+++ b/src/Pipelinez.PostgreSql/Internal/PostgreSqlColumnValueKind.cs
@@ -1,0 +1,7 @@
+namespace Pipelinez.PostgreSql.Internal;
+
+internal enum PostgreSqlColumnValueKind
+{
+    Default,
+    Jsonb
+}

--- a/src/Pipelinez.PostgreSql/Internal/PostgreSqlIdentifier.cs
+++ b/src/Pipelinez.PostgreSql/Internal/PostgreSqlIdentifier.cs
@@ -1,0 +1,23 @@
+using Ardalis.GuardClauses;
+
+namespace Pipelinez.PostgreSql.Internal;
+
+internal static class PostgreSqlIdentifier
+{
+    public static string Quote(string identifier)
+    {
+        var value = Guard.Against.NullOrWhiteSpace(identifier, nameof(identifier)).Trim();
+
+        if (value.IndexOfAny(['\r', '\n', '\0', ';']) >= 0)
+        {
+            throw new InvalidOperationException($"Identifier '{identifier}' contains characters that are not supported in PostgreSQL identifier quoting.");
+        }
+
+        return "\"" + value.Replace("\"", "\"\"") + "\"";
+    }
+
+    public static string QuoteQualified(string schemaName, string tableName)
+    {
+        return $"{Quote(schemaName)}.{Quote(tableName)}";
+    }
+}

--- a/src/Pipelinez.PostgreSql/Internal/PostgreSqlMappedCommandFactory.cs
+++ b/src/Pipelinez.PostgreSql/Internal/PostgreSqlMappedCommandFactory.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using Ardalis.GuardClauses;
+using Dapper;
+using Pipelinez.PostgreSql.Mapping;
+
+namespace Pipelinez.PostgreSql.Internal;
+
+internal static class PostgreSqlMappedCommandFactory
+{
+    public static PostgreSqlCommandDefinition CreateCommand<TModel>(
+        PostgreSqlTableMap<TModel> tableMap,
+        TModel model,
+        JsonSerializerOptions serializerOptions,
+        int? defaultCommandTimeoutSeconds)
+    {
+        var validatedMap = Guard.Against.Null(tableMap, nameof(tableMap)).Validate();
+        Guard.Against.Null(serializerOptions, nameof(serializerOptions));
+
+        var parameters = new DynamicParameters();
+        var quotedColumns = new List<string>(validatedMap.Columns.Count);
+        var parameterExpressions = new List<string>(validatedMap.Columns.Count);
+
+        for (var index = 0; index < validatedMap.Columns.Count; index++)
+        {
+            var column = validatedMap.Columns[index];
+            var parameterName = $"p{index}";
+            quotedColumns.Add(PostgreSqlIdentifier.Quote(column.ColumnName));
+
+            var value = column.ValueFactory(model);
+            switch (column.ValueKind)
+            {
+                case PostgreSqlColumnValueKind.Jsonb:
+                    parameters.Add(parameterName, value is null ? null : JsonSerializer.Serialize(value, serializerOptions));
+                    parameterExpressions.Add($"@{parameterName}::jsonb");
+                    break;
+                default:
+                    parameters.Add(parameterName, value);
+                    parameterExpressions.Add($"@{parameterName}");
+                    break;
+            }
+        }
+
+        var commandText =
+            $"INSERT INTO {PostgreSqlIdentifier.QuoteQualified(validatedMap.SchemaName, validatedMap.TableName)} " +
+            $"({string.Join(", ", quotedColumns)}) VALUES ({string.Join(", ", parameterExpressions)})";
+
+        return new PostgreSqlCommandDefinition(commandText, parameters, defaultCommandTimeoutSeconds);
+    }
+}

--- a/src/Pipelinez.PostgreSql/Mapping/PostgreSqlCommandDefinition.cs
+++ b/src/Pipelinez.PostgreSql/Mapping/PostgreSqlCommandDefinition.cs
@@ -1,0 +1,62 @@
+using Ardalis.GuardClauses;
+
+namespace Pipelinez.PostgreSql.Mapping;
+
+/// <summary>
+/// Represents a parameterized PostgreSQL command that the transport can execute through Dapper.
+/// </summary>
+public sealed class PostgreSqlCommandDefinition
+{
+    /// <summary>
+    /// Initializes a new PostgreSQL command definition.
+    /// </summary>
+    /// <param name="commandText">The SQL command text to execute.</param>
+    /// <param name="parameters">The parameter object passed to Dapper.</param>
+    /// <param name="commandTimeoutSeconds">An optional command timeout override in seconds.</param>
+    public PostgreSqlCommandDefinition(string commandText, object? parameters, int? commandTimeoutSeconds = null)
+    {
+        CommandText = Guard.Against.NullOrWhiteSpace(commandText, nameof(commandText));
+        Parameters = parameters;
+
+        if (commandTimeoutSeconds is <= 0)
+        {
+            throw new InvalidOperationException("Command timeout must be greater than zero when provided.");
+        }
+
+        CommandTimeoutSeconds = commandTimeoutSeconds;
+    }
+
+    /// <summary>
+    /// Gets the parameterized SQL command text to execute.
+    /// </summary>
+    public string CommandText { get; }
+
+    /// <summary>
+    /// Gets the parameter object passed to Dapper for command execution.
+    /// </summary>
+    public object? Parameters { get; }
+
+    /// <summary>
+    /// Gets the optional command timeout override in seconds.
+    /// </summary>
+    public int? CommandTimeoutSeconds { get; }
+
+    /// <summary>
+    /// Validates the command definition and returns the same instance when valid.
+    /// </summary>
+    /// <returns>The validated command definition.</returns>
+    public PostgreSqlCommandDefinition Validate()
+    {
+        if (string.IsNullOrWhiteSpace(CommandText))
+        {
+            throw new InvalidOperationException("Command text is required.");
+        }
+
+        if (CommandTimeoutSeconds is <= 0)
+        {
+            throw new InvalidOperationException("Command timeout must be greater than zero when provided.");
+        }
+
+        return this;
+    }
+}

--- a/src/Pipelinez.PostgreSql/Mapping/PostgreSqlTableMap.cs
+++ b/src/Pipelinez.PostgreSql/Mapping/PostgreSqlTableMap.cs
@@ -1,0 +1,106 @@
+using Ardalis.GuardClauses;
+using Pipelinez.PostgreSql.Internal;
+
+namespace Pipelinez.PostgreSql.Mapping;
+
+/// <summary>
+/// Defines a strongly typed mapping from a model object to a PostgreSQL table.
+/// </summary>
+/// <typeparam name="TModel">The model type used to produce column values.</typeparam>
+public sealed class PostgreSqlTableMap<TModel>
+{
+    private readonly IReadOnlyList<PostgreSqlColumnMap<TModel>> _columns;
+
+    private PostgreSqlTableMap(
+        string schemaName,
+        string tableName,
+        IReadOnlyList<PostgreSqlColumnMap<TModel>> columns)
+    {
+        SchemaName = Guard.Against.NullOrWhiteSpace(schemaName, nameof(schemaName));
+        TableName = Guard.Against.NullOrWhiteSpace(tableName, nameof(tableName));
+        _columns = Guard.Against.Null(columns, nameof(columns));
+    }
+
+    /// <summary>
+    /// Gets the schema name of the destination table.
+    /// </summary>
+    public string SchemaName { get; }
+
+    /// <summary>
+    /// Gets the table name of the destination table.
+    /// </summary>
+    public string TableName { get; }
+
+    internal IReadOnlyList<PostgreSqlColumnMap<TModel>> Columns => _columns;
+
+    /// <summary>
+    /// Creates a new empty table map for the specified schema and table.
+    /// </summary>
+    /// <param name="schemaName">The schema name to target.</param>
+    /// <param name="tableName">The table name to target.</param>
+    /// <returns>A new table map instance.</returns>
+    public static PostgreSqlTableMap<TModel> ForTable(string schemaName, string tableName)
+    {
+        return new PostgreSqlTableMap<TModel>(schemaName, tableName, Array.Empty<PostgreSqlColumnMap<TModel>>());
+    }
+
+    /// <summary>
+    /// Adds a column mapping that writes a scalar or parameterized value directly.
+    /// </summary>
+    /// <typeparam name="TValue">The value type produced by the mapping.</typeparam>
+    /// <param name="columnName">The destination column name.</param>
+    /// <param name="valueFactory">The callback that produces the column value from the model.</param>
+    /// <returns>A new table map with the added column mapping.</returns>
+    public PostgreSqlTableMap<TModel> Map<TValue>(string columnName, Func<TModel, TValue> valueFactory)
+    {
+        Guard.Against.Null(valueFactory, nameof(valueFactory));
+        return AddColumn(new PostgreSqlColumnMap<TModel>(
+            Guard.Against.NullOrWhiteSpace(columnName, nameof(columnName)),
+            model => valueFactory(model),
+            PostgreSqlColumnValueKind.Default));
+    }
+
+    /// <summary>
+    /// Adds a column mapping that serializes the produced value as JSON and writes it as <c>jsonb</c>.
+    /// </summary>
+    /// <typeparam name="TValue">The value type produced by the mapping.</typeparam>
+    /// <param name="columnName">The destination column name.</param>
+    /// <param name="valueFactory">The callback that produces the value to serialize.</param>
+    /// <returns>A new table map with the added JSON column mapping.</returns>
+    public PostgreSqlTableMap<TModel> MapJson<TValue>(string columnName, Func<TModel, TValue> valueFactory)
+    {
+        Guard.Against.Null(valueFactory, nameof(valueFactory));
+        return AddColumn(new PostgreSqlColumnMap<TModel>(
+            Guard.Against.NullOrWhiteSpace(columnName, nameof(columnName)),
+            model => valueFactory(model),
+            PostgreSqlColumnValueKind.Jsonb));
+    }
+
+    /// <summary>
+    /// Validates the table map and returns the same instance when valid.
+    /// </summary>
+    /// <returns>The validated table map.</returns>
+    public PostgreSqlTableMap<TModel> Validate()
+    {
+        PostgreSqlIdentifier.QuoteQualified(SchemaName, TableName);
+
+        if (_columns.Count == 0)
+        {
+            throw new InvalidOperationException("A PostgreSQL table map must define at least one column mapping.");
+        }
+
+        foreach (var column in _columns)
+        {
+            PostgreSqlIdentifier.Quote(column.ColumnName);
+        }
+
+        return this;
+    }
+
+    private PostgreSqlTableMap<TModel> AddColumn(PostgreSqlColumnMap<TModel> column)
+    {
+        var columns = _columns.ToList();
+        columns.Add(column);
+        return new PostgreSqlTableMap<TModel>(SchemaName, TableName, columns);
+    }
+}

--- a/src/Pipelinez.PostgreSql/PackageReadme.md
+++ b/src/Pipelinez.PostgreSql/PackageReadme.md
@@ -1,0 +1,51 @@
+# Pipelinez.PostgreSql
+
+PostgreSQL transport extensions for Pipelinez.
+
+`Pipelinez.PostgreSql` adds:
+
+- `WithPostgreSqlDestination(...)`
+- `WithPostgreSqlDeadLetterDestination(...)`
+- consumer-owned table mapping through `PostgreSqlTableMap<T>`
+- custom parameterized SQL execution through `PostgreSqlCommandDefinition`
+- Dapper-backed PostgreSQL writes for normal and dead-letter flows
+
+## Install
+
+```bash
+dotnet add package Pipelinez.PostgreSql
+```
+
+`Pipelinez.PostgreSql` depends on `Pipelinez`, so you do not need to add both explicitly unless you prefer to do so.
+
+## Quick Example
+
+```csharp
+using Pipelinez.Core;
+using Pipelinez.Core.Record;
+using Pipelinez.PostgreSql;
+using Pipelinez.PostgreSql.Configuration;
+using Pipelinez.PostgreSql.Mapping;
+
+var pipeline = Pipeline<OrderRecord>.New("orders")
+    .WithInMemorySource(new object())
+    .WithPostgreSqlDestination(
+        new PostgreSqlDestinationOptions
+        {
+            ConnectionString = "Host=localhost;Database=pipelinez;Username=postgres;Password=postgres"
+        },
+        PostgreSqlTableMap<OrderRecord>.ForTable("app", "processed_orders")
+            .Map("order_id", record => record.Id)
+            .MapJson("payload", record => record))
+    .Build();
+
+public sealed class OrderRecord : PipelineRecord
+{
+    public required string Id { get; init; }
+}
+```
+
+## More Information
+
+- Repository: https://github.com/KenBerg75/Pipelinez
+- Docs: https://github.com/KenBerg75/Pipelinez/tree/main/docs

--- a/src/Pipelinez.PostgreSql/Pipelinez.PostgreSql.csproj
+++ b/src/Pipelinez.PostgreSql/Pipelinez.PostgreSql.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <IsPackable>true</IsPackable>
+        <PackageId>Pipelinez.PostgreSql</PackageId>
+        <Title>Pipelinez.PostgreSql</Title>
+        <Description>PostgreSQL destination and dead-letter transport extensions for Pipelinez with consumer-owned schema mapping and Dapper-backed execution.</Description>
+        <PackageTags>pipeline;postgresql;postgres;dapper;dead-letter;dotnet</PackageTags>
+        <PackageReadmeFile>PackageReadme.md</PackageReadmeFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Dapper" Version="2.1.35" />
+        <PackageReference Include="Npgsql" Version="8.0.3" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Pipelinez\Pipelinez.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="PackageReadme.md" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+</Project>

--- a/src/Pipelinez.PostgreSql/PostgreSqlPipelineBuilderExtensions.cs
+++ b/src/Pipelinez.PostgreSql/PostgreSqlPipelineBuilderExtensions.cs
@@ -1,0 +1,123 @@
+using Ardalis.GuardClauses;
+using Pipelinez.Core;
+using Pipelinez.Core.DeadLettering;
+using Pipelinez.Core.Record;
+using Pipelinez.PostgreSql.Configuration;
+using Pipelinez.PostgreSql.DeadLettering;
+using Pipelinez.PostgreSql.Destination;
+using Pipelinez.PostgreSql.Internal;
+using Pipelinez.PostgreSql.Mapping;
+
+namespace Pipelinez.PostgreSql;
+
+/// <summary>
+/// Provides PostgreSQL transport extension methods for <see cref="PipelineBuilder{T}" />.
+/// </summary>
+public static class PostgreSqlPipelineBuilderExtensions
+{
+    /// <summary>
+    /// Configures the pipeline to write successful records to PostgreSQL using a generated insert from a table map.
+    /// </summary>
+    /// <typeparam name="TRecord">The pipeline record type.</typeparam>
+    /// <param name="builder">The pipeline builder to configure.</param>
+    /// <param name="options">The PostgreSQL destination options.</param>
+    /// <param name="tableMap">The table map that defines the destination schema, table, and columns.</param>
+    /// <returns>The same builder for chaining.</returns>
+    public static PipelineBuilder<TRecord> WithPostgreSqlDestination<TRecord>(
+        this PipelineBuilder<TRecord> builder,
+        PostgreSqlDestinationOptions options,
+        PostgreSqlTableMap<TRecord> tableMap)
+        where TRecord : PipelineRecord
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(tableMap);
+
+        var validatedOptions = options.Validate();
+        var validatedMap = tableMap.Validate();
+
+        return builder.WithDestination(new PostgreSqlPipelineDestination<TRecord>(
+            validatedOptions,
+            record => PostgreSqlMappedCommandFactory.CreateCommand(
+                validatedMap,
+                Guard.Against.Null(record, nameof(record)),
+                validatedOptions.SerializerOptions,
+                validatedOptions.CommandTimeoutSeconds)));
+    }
+
+    /// <summary>
+    /// Configures the pipeline to write successful records to PostgreSQL using consumer-provided SQL.
+    /// </summary>
+    /// <typeparam name="TRecord">The pipeline record type.</typeparam>
+    /// <param name="builder">The pipeline builder to configure.</param>
+    /// <param name="options">The PostgreSQL destination options.</param>
+    /// <param name="commandFactory">The callback that creates a parameterized command definition for each record.</param>
+    /// <returns>The same builder for chaining.</returns>
+    public static PipelineBuilder<TRecord> WithPostgreSqlDestination<TRecord>(
+        this PipelineBuilder<TRecord> builder,
+        PostgreSqlDestinationOptions options,
+        Func<TRecord, PostgreSqlCommandDefinition> commandFactory)
+        where TRecord : PipelineRecord
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(commandFactory);
+
+        return builder.WithDestination(new PostgreSqlPipelineDestination<TRecord>(
+            options.Validate(),
+            record => Guard.Against.Null(commandFactory(record), nameof(commandFactory)).Validate()));
+    }
+
+    /// <summary>
+    /// Configures the pipeline to write dead-letter records to PostgreSQL using a generated insert from a table map.
+    /// </summary>
+    /// <typeparam name="TRecord">The pipeline record type contained in the dead-letter envelope.</typeparam>
+    /// <param name="builder">The pipeline builder to configure.</param>
+    /// <param name="options">The PostgreSQL dead-letter destination options.</param>
+    /// <param name="tableMap">The table map that defines the dead-letter schema, table, and columns.</param>
+    /// <returns>The same builder for chaining.</returns>
+    public static PipelineBuilder<TRecord> WithPostgreSqlDeadLetterDestination<TRecord>(
+        this PipelineBuilder<TRecord> builder,
+        PostgreSqlDeadLetterOptions options,
+        PostgreSqlTableMap<PipelineDeadLetterRecord<TRecord>> tableMap)
+        where TRecord : PipelineRecord
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(tableMap);
+
+        var validatedOptions = options.Validate();
+        var validatedMap = tableMap.Validate();
+
+        return builder.WithDeadLetterDestination(new PostgreSqlDeadLetterDestination<TRecord>(
+            validatedOptions,
+            deadLetterRecord => PostgreSqlMappedCommandFactory.CreateCommand(
+                validatedMap,
+                Guard.Against.Null(deadLetterRecord, nameof(deadLetterRecord)),
+                validatedOptions.SerializerOptions,
+                validatedOptions.CommandTimeoutSeconds)));
+    }
+
+    /// <summary>
+    /// Configures the pipeline to write dead-letter records to PostgreSQL using consumer-provided SQL.
+    /// </summary>
+    /// <typeparam name="TRecord">The pipeline record type contained in the dead-letter envelope.</typeparam>
+    /// <param name="builder">The pipeline builder to configure.</param>
+    /// <param name="options">The PostgreSQL dead-letter destination options.</param>
+    /// <param name="commandFactory">The callback that creates a parameterized command definition for each dead-letter record.</param>
+    /// <returns>The same builder for chaining.</returns>
+    public static PipelineBuilder<TRecord> WithPostgreSqlDeadLetterDestination<TRecord>(
+        this PipelineBuilder<TRecord> builder,
+        PostgreSqlDeadLetterOptions options,
+        Func<PipelineDeadLetterRecord<TRecord>, PostgreSqlCommandDefinition> commandFactory)
+        where TRecord : PipelineRecord
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(commandFactory);
+
+        return builder.WithDeadLetterDestination(new PostgreSqlDeadLetterDestination<TRecord>(
+            options.Validate(),
+            deadLetterRecord => Guard.Against.Null(commandFactory(deadLetterRecord), nameof(commandFactory)).Validate()));
+    }
+}

--- a/src/Pipelinez.PostgreSql/Properties/AssemblyInfo.cs
+++ b/src/Pipelinez.PostgreSql/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Pipelinez.PostgreSql.Tests")]

--- a/src/Pipelinez.sln
+++ b/src/Pipelinez.sln
@@ -20,6 +20,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pipelinez.Benchmarks", "benchmarks\Pipelinez.Benchmarks\Pipelinez.Benchmarks.csproj", "{DCF80839-94E8-4E52-A4E7-E70C307C543B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pipelinez.PostgreSql", "Pipelinez.PostgreSql\Pipelinez.PostgreSql.csproj", "{E6ED13DA-3159-40CC-87C6-E8A1C89D518C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pipelinez.PostgreSql.Tests", "tests\Pipelinez.PostgreSql.Tests\Pipelinez.PostgreSql.Tests.csproj", "{6AC3F72D-7498-4552-BD69-E1EDE331FC63}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -114,6 +118,30 @@ Global
 		{DCF80839-94E8-4E52-A4E7-E70C307C543B}.Release|x64.Build.0 = Release|Any CPU
 		{DCF80839-94E8-4E52-A4E7-E70C307C543B}.Release|x86.ActiveCfg = Release|Any CPU
 		{DCF80839-94E8-4E52-A4E7-E70C307C543B}.Release|x86.Build.0 = Release|Any CPU
+		{E6ED13DA-3159-40CC-87C6-E8A1C89D518C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6ED13DA-3159-40CC-87C6-E8A1C89D518C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6ED13DA-3159-40CC-87C6-E8A1C89D518C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E6ED13DA-3159-40CC-87C6-E8A1C89D518C}.Debug|x64.Build.0 = Debug|Any CPU
+		{E6ED13DA-3159-40CC-87C6-E8A1C89D518C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E6ED13DA-3159-40CC-87C6-E8A1C89D518C}.Debug|x86.Build.0 = Debug|Any CPU
+		{E6ED13DA-3159-40CC-87C6-E8A1C89D518C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6ED13DA-3159-40CC-87C6-E8A1C89D518C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6ED13DA-3159-40CC-87C6-E8A1C89D518C}.Release|x64.ActiveCfg = Release|Any CPU
+		{E6ED13DA-3159-40CC-87C6-E8A1C89D518C}.Release|x64.Build.0 = Release|Any CPU
+		{E6ED13DA-3159-40CC-87C6-E8A1C89D518C}.Release|x86.ActiveCfg = Release|Any CPU
+		{E6ED13DA-3159-40CC-87C6-E8A1C89D518C}.Release|x86.Build.0 = Release|Any CPU
+		{6AC3F72D-7498-4552-BD69-E1EDE331FC63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6AC3F72D-7498-4552-BD69-E1EDE331FC63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6AC3F72D-7498-4552-BD69-E1EDE331FC63}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6AC3F72D-7498-4552-BD69-E1EDE331FC63}.Debug|x64.Build.0 = Debug|Any CPU
+		{6AC3F72D-7498-4552-BD69-E1EDE331FC63}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6AC3F72D-7498-4552-BD69-E1EDE331FC63}.Debug|x86.Build.0 = Debug|Any CPU
+		{6AC3F72D-7498-4552-BD69-E1EDE331FC63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6AC3F72D-7498-4552-BD69-E1EDE331FC63}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6AC3F72D-7498-4552-BD69-E1EDE331FC63}.Release|x64.ActiveCfg = Release|Any CPU
+		{6AC3F72D-7498-4552-BD69-E1EDE331FC63}.Release|x64.Build.0 = Release|Any CPU
+		{6AC3F72D-7498-4552-BD69-E1EDE331FC63}.Release|x86.ActiveCfg = Release|Any CPU
+		{6AC3F72D-7498-4552-BD69-E1EDE331FC63}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -124,5 +152,6 @@ Global
 		{122264A5-5A16-4BB8-9E4D-B053AB6EB807} = {5EFA715F-5E86-4E93-83DC-A7A2E055B82C}
 		{6489F05B-AB04-4491-93D9-688961D08B9D} = {5EFA715F-5E86-4E93-83DC-A7A2E055B82C}
 		{DCF80839-94E8-4E52-A4E7-E70C307C543B} = {66320409-64EC-F7C5-3DEF-65E7510DAAD1}
+		{6AC3F72D-7498-4552-BD69-E1EDE331FC63} = {6148F783-9A51-48BB-BBB7-3A12E3B0A5DE}
 	EndGlobalSection
 EndGlobal

--- a/src/Pipelinez/PackageReadme.md
+++ b/src/Pipelinez/PackageReadme.md
@@ -20,6 +20,8 @@ Typed data pipelines for .NET.
   core runtime
 - `Pipelinez.Kafka`
   Kafka transport extensions
+- `Pipelinez.PostgreSql`
+  PostgreSQL destination and dead-letter transport extensions
 
 ## Install
 

--- a/src/Pipelinez/Properties/AssemblyInfo.cs
+++ b/src/Pipelinez/Properties/AssemblyInfo.cs
@@ -2,3 +2,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Pipelinez.Tests")]
 [assembly: InternalsVisibleTo("Pipelinez.Kafka")]
+[assembly: InternalsVisibleTo("Pipelinez.PostgreSql")]

--- a/src/tests/Pipelinez.PostgreSql.Tests/ApiApprovalTests.cs
+++ b/src/tests/Pipelinez.PostgreSql.Tests/ApiApprovalTests.cs
@@ -1,0 +1,38 @@
+using Pipelinez.PostgreSql;
+using Pipelinez.Testing.ApiApproval;
+
+namespace Pipelinez.PostgreSql.Tests;
+
+public class ApiApprovalTests
+{
+    private const string UpdateApiBaselinesEnvironmentVariable = "PIPELINEZ_UPDATE_API_BASELINES";
+
+    [Fact]
+    public void Pipelinez_PostgreSql_Public_Api_Matches_Approved_Baseline()
+    {
+        var approvedPath = GetApprovedPath();
+        var actual = ApiApprovalTextGenerator.Generate(typeof(PostgreSqlPipelineBuilderExtensions).Assembly);
+        if (ShouldUpdateApiBaselines())
+        {
+            File.WriteAllText(approvedPath, actual.Replace("\n", Environment.NewLine));
+        }
+
+        var approved = File.ReadAllText(approvedPath).Replace("\r\n", "\n");
+
+        Assert.Equal(approved, actual);
+    }
+
+    private static bool ShouldUpdateApiBaselines()
+    {
+        return string.Equals(
+            Environment.GetEnvironmentVariable(UpdateApiBaselinesEnvironmentVariable),
+            "1",
+            StringComparison.Ordinal);
+    }
+
+    private static string GetApprovedPath()
+    {
+        var projectDirectory = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", ".."));
+        return Path.Combine(projectDirectory, "ApprovedApi", "Pipelinez.PostgreSql.publicapi.txt");
+    }
+}

--- a/src/tests/Pipelinez.PostgreSql.Tests/ApprovedApi/Pipelinez.PostgreSql.publicapi.txt
+++ b/src/tests/Pipelinez.PostgreSql.Tests/ApprovedApi/Pipelinez.PostgreSql.publicapi.txt
@@ -1,0 +1,39 @@
+Assembly: Pipelinez.PostgreSql
+
+public class Pipelinez.PostgreSql.Configuration.PostgreSqlDeadLetterOptions : Pipelinez.PostgreSql.Configuration.PostgreSqlOptions
+  CTOR public Pipelinez.PostgreSql.Configuration.PostgreSqlDeadLetterOptions()
+  METHOD public Pipelinez.PostgreSql.Configuration.PostgreSqlDeadLetterOptions Validate()
+
+public class Pipelinez.PostgreSql.Configuration.PostgreSqlDestinationOptions : Pipelinez.PostgreSql.Configuration.PostgreSqlOptions
+  CTOR public Pipelinez.PostgreSql.Configuration.PostgreSqlDestinationOptions()
+  METHOD public Pipelinez.PostgreSql.Configuration.PostgreSqlDestinationOptions Validate()
+
+public abstract class Pipelinez.PostgreSql.Configuration.PostgreSqlOptions
+  PROPERTY public System.Nullable<int> CommandTimeoutSeconds { get; init; }
+  PROPERTY public System.Action<Npgsql.NpgsqlConnectionStringBuilder> ConfigureConnectionString { get; init; }
+  PROPERTY public System.Action<Npgsql.NpgsqlDataSourceBuilder> ConfigureDataSource { get; init; }
+  PROPERTY public string ConnectionString { get; init; }
+  PROPERTY public Npgsql.NpgsqlDataSource DataSource { get; init; }
+  PROPERTY public bool EnableSensitiveLogging { get; init; }
+  PROPERTY public System.Text.Json.JsonSerializerOptions SerializerOptions { get; init; }
+
+public class Pipelinez.PostgreSql.Mapping.PostgreSqlCommandDefinition
+  CTOR public Pipelinez.PostgreSql.Mapping.PostgreSqlCommandDefinition(string commandText, object parameters, System.Nullable<int> commandTimeoutSeconds = null)
+  PROPERTY public string CommandText { get; }
+  PROPERTY public System.Nullable<int> CommandTimeoutSeconds { get; }
+  PROPERTY public object Parameters { get; }
+  METHOD public Pipelinez.PostgreSql.Mapping.PostgreSqlCommandDefinition Validate()
+
+public class Pipelinez.PostgreSql.Mapping.PostgreSqlTableMap<TModel>
+  PROPERTY public string SchemaName { get; }
+  PROPERTY public string TableName { get; }
+  METHOD public static Pipelinez.PostgreSql.Mapping.PostgreSqlTableMap<TModel> ForTable(string schemaName, string tableName)
+  METHOD public Pipelinez.PostgreSql.Mapping.PostgreSqlTableMap<TModel> Map<TValue>(string columnName, System.Func<TModel, TValue> valueFactory)
+  METHOD public Pipelinez.PostgreSql.Mapping.PostgreSqlTableMap<TModel> MapJson<TValue>(string columnName, System.Func<TModel, TValue> valueFactory)
+  METHOD public Pipelinez.PostgreSql.Mapping.PostgreSqlTableMap<TModel> Validate()
+
+public static class Pipelinez.PostgreSql.PostgreSqlPipelineBuilderExtensions
+  METHOD public static Pipelinez.Core.PipelineBuilder<TRecord> WithPostgreSqlDeadLetterDestination<TRecord>(Pipelinez.Core.PipelineBuilder<TRecord> builder, Pipelinez.PostgreSql.Configuration.PostgreSqlDeadLetterOptions options, Pipelinez.PostgreSql.Mapping.PostgreSqlTableMap<Pipelinez.Core.DeadLettering.PipelineDeadLetterRecord<TRecord>> tableMap) where TRecord : Pipelinez.Core.Record.PipelineRecord
+  METHOD public static Pipelinez.Core.PipelineBuilder<TRecord> WithPostgreSqlDeadLetterDestination<TRecord>(Pipelinez.Core.PipelineBuilder<TRecord> builder, Pipelinez.PostgreSql.Configuration.PostgreSqlDeadLetterOptions options, System.Func<Pipelinez.Core.DeadLettering.PipelineDeadLetterRecord<TRecord>, Pipelinez.PostgreSql.Mapping.PostgreSqlCommandDefinition> commandFactory) where TRecord : Pipelinez.Core.Record.PipelineRecord
+  METHOD public static Pipelinez.Core.PipelineBuilder<TRecord> WithPostgreSqlDestination<TRecord>(Pipelinez.Core.PipelineBuilder<TRecord> builder, Pipelinez.PostgreSql.Configuration.PostgreSqlDestinationOptions options, Pipelinez.PostgreSql.Mapping.PostgreSqlTableMap<TRecord> tableMap) where TRecord : Pipelinez.Core.Record.PipelineRecord
+  METHOD public static Pipelinez.Core.PipelineBuilder<TRecord> WithPostgreSqlDestination<TRecord>(Pipelinez.Core.PipelineBuilder<TRecord> builder, Pipelinez.PostgreSql.Configuration.PostgreSqlDestinationOptions options, System.Func<TRecord, Pipelinez.PostgreSql.Mapping.PostgreSqlCommandDefinition> commandFactory) where TRecord : Pipelinez.Core.Record.PipelineRecord

--- a/src/tests/Pipelinez.PostgreSql.Tests/EndToEnd/Models/CollectingDestination.cs
+++ b/src/tests/Pipelinez.PostgreSql.Tests/EndToEnd/Models/CollectingDestination.cs
@@ -1,0 +1,21 @@
+using Pipelinez.Core.Destination;
+using Pipelinez.Core.Record;
+
+namespace Pipelinez.PostgreSql.Tests.EndToEnd.Models;
+
+internal sealed class CollectingDestination : PipelineDestination<TestPostgreSqlRecord>
+{
+    private readonly List<TestPostgreSqlRecord> _records = new();
+
+    public IReadOnlyList<TestPostgreSqlRecord> Records => _records;
+
+    protected override Task ExecuteAsync(TestPostgreSqlRecord record, CancellationToken cancellationToken)
+    {
+        _records.Add(record);
+        return Task.CompletedTask;
+    }
+
+    protected override void Initialize()
+    {
+    }
+}

--- a/src/tests/Pipelinez.PostgreSql.Tests/EndToEnd/Models/ConditionalFaultingPostgreSqlSegment.cs
+++ b/src/tests/Pipelinez.PostgreSql.Tests/EndToEnd/Models/ConditionalFaultingPostgreSqlSegment.cs
@@ -1,0 +1,18 @@
+using Pipelinez.Core.Record;
+using Pipelinez.Core.Segment;
+
+namespace Pipelinez.PostgreSql.Tests.EndToEnd.Models;
+
+internal sealed class ConditionalFaultingPostgreSqlSegment(string badValue) : PipelineSegment<TestPostgreSqlRecord>
+{
+    public override Task<TestPostgreSqlRecord> ExecuteAsync(TestPostgreSqlRecord record)
+    {
+        if (record.Value == badValue)
+        {
+            throw new InvalidOperationException($"Value '{badValue}' is configured to fail.");
+        }
+
+        record.Value += "|processed";
+        return Task.FromResult(record);
+    }
+}

--- a/src/tests/Pipelinez.PostgreSql.Tests/EndToEnd/Models/TestPostgreSqlRecord.cs
+++ b/src/tests/Pipelinez.PostgreSql.Tests/EndToEnd/Models/TestPostgreSqlRecord.cs
@@ -1,0 +1,10 @@
+using Pipelinez.Core.Record;
+
+namespace Pipelinez.PostgreSql.Tests.EndToEnd.Models;
+
+public sealed class TestPostgreSqlRecord : PipelineRecord
+{
+    public required string Id { get; init; }
+
+    public required string Value { get; set; }
+}

--- a/src/tests/Pipelinez.PostgreSql.Tests/EndToEnd/PostgreSqlPipelineDeadLetterTests.cs
+++ b/src/tests/Pipelinez.PostgreSql.Tests/EndToEnd/PostgreSqlPipelineDeadLetterTests.cs
@@ -1,0 +1,111 @@
+using Pipelinez.Core;
+using Pipelinez.Core.DeadLettering;
+using Pipelinez.Core.ErrorHandling;
+using Pipelinez.PostgreSql;
+using Pipelinez.PostgreSql.Mapping;
+using Pipelinez.PostgreSql.Tests.EndToEnd.Models;
+using Pipelinez.PostgreSql.Tests.Infrastructure;
+using Xunit;
+
+namespace Pipelinez.PostgreSql.Tests.EndToEnd;
+
+[Collection(PostgreSqlIntegrationCollection.Name)]
+public sealed class PostgreSqlPipelineDeadLetterTests(PostgreSqlTestCluster cluster)
+{
+    [Fact]
+    public async Task PostgreSqlDeadLetterDestination_TableMap_Writes_Faulted_Record_And_Allows_Later_Records_To_Continue()
+    {
+        var scenarioName = nameof(PostgreSqlDeadLetterDestination_TableMap_Writes_Faulted_Record_And_Allows_Later_Records_To_Continue);
+        var schemaName = PostgreSqlNameFactory.CreateSchemaName(scenarioName);
+        var tableName = PostgreSqlNameFactory.CreateTableName(scenarioName);
+        var destination = new CollectingDestination();
+
+        await cluster.ExecuteAsync($"""
+            CREATE SCHEMA "{schemaName}";
+            CREATE TABLE "{schemaName}"."{tableName}" (
+                "order_id" text NOT NULL,
+                "fault_component" text NOT NULL,
+                "record_json" jsonb NOT NULL,
+                "metadata_json" jsonb NOT NULL,
+                "dead_lettered_at_utc" timestamptz NOT NULL
+            );
+            """).ConfigureAwait(false);
+
+        var pipeline = Pipeline<TestPostgreSqlRecord>.New(scenarioName)
+            .WithInMemorySource(new object())
+            .AddSegment(new ConditionalFaultingPostgreSqlSegment("bad"), new object())
+            .WithDestination(destination)
+            .WithPostgreSqlDeadLetterDestination(
+                cluster.CreateDeadLetterOptions(),
+                PostgreSqlTableMap<PipelineDeadLetterRecord<TestPostgreSqlRecord>>.ForTable(schemaName, tableName)
+                    .Map("order_id", deadLetter => deadLetter.Record.Id)
+                    .Map("fault_component", deadLetter => deadLetter.Fault.ComponentName)
+                    .MapJson("record_json", deadLetter => deadLetter.Record)
+                    .MapJson("metadata_json", deadLetter => deadLetter.Metadata)
+                    .Map("dead_lettered_at_utc", deadLetter => deadLetter.DeadLetteredAtUtc))
+            .WithErrorHandler(_ => PipelineErrorAction.DeadLetter)
+            .Build();
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+        await pipeline.PublishAsync(new TestPostgreSqlRecord { Id = "bad-1", Value = "bad" }).ConfigureAwait(false);
+        await pipeline.PublishAsync(new TestPostgreSqlRecord { Id = "good-1", Value = "good" }).ConfigureAwait(false);
+        await pipeline.CompleteAsync().ConfigureAwait(false);
+        await pipeline.Completion.ConfigureAwait(false);
+
+        var completed = Assert.Single(destination.Records);
+        Assert.Equal("good-1", completed.Id);
+        Assert.Equal("good|processed", completed.Value);
+
+        var row = await cluster.QuerySingleAsync<(string OrderId, string FaultComponent, string Value)>(
+            $"""SELECT "order_id" AS "OrderId", "fault_component" AS "FaultComponent", "record_json"->>'value' AS "Value" FROM "{schemaName}"."{tableName}" """)
+            .ConfigureAwait(false);
+
+        Assert.Equal("bad-1", row.OrderId);
+        Assert.Equal(nameof(ConditionalFaultingPostgreSqlSegment), row.FaultComponent);
+        Assert.Equal("bad", row.Value);
+    }
+
+    [Fact]
+    public async Task PostgreSqlDeadLetterDestination_Custom_Command_Writes_Faulted_Record()
+    {
+        var scenarioName = nameof(PostgreSqlDeadLetterDestination_Custom_Command_Writes_Faulted_Record);
+        var schemaName = PostgreSqlNameFactory.CreateSchemaName(scenarioName);
+        var tableName = PostgreSqlNameFactory.CreateTableName(scenarioName);
+
+        await cluster.ExecuteAsync($"""
+            CREATE SCHEMA "{schemaName}";
+            CREATE TABLE "{schemaName}"."{tableName}" (
+                "record_id" text NOT NULL,
+                "fault_message" text NOT NULL
+            );
+            """).ConfigureAwait(false);
+
+        var pipeline = Pipeline<TestPostgreSqlRecord>.New(scenarioName)
+            .WithInMemorySource(new object())
+            .AddSegment(new ConditionalFaultingPostgreSqlSegment("bad"), new object())
+            .WithInMemoryDestination("ignored")
+            .WithPostgreSqlDeadLetterDestination(
+                cluster.CreateDeadLetterOptions(),
+                deadLetter => new PostgreSqlCommandDefinition(
+                    $"""INSERT INTO "{schemaName}"."{tableName}" ("record_id", "fault_message") VALUES (@record_id, @fault_message)""",
+                    new
+                    {
+                        record_id = deadLetter.Record.Id,
+                        fault_message = deadLetter.Fault.Message
+                    }))
+            .WithErrorHandler(_ => PipelineErrorAction.DeadLetter)
+            .Build();
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+        await pipeline.PublishAsync(new TestPostgreSqlRecord { Id = "bad-2", Value = "bad" }).ConfigureAwait(false);
+        await pipeline.CompleteAsync().ConfigureAwait(false);
+        await pipeline.Completion.ConfigureAwait(false);
+
+        var row = await cluster.QuerySingleAsync<(string RecordId, string FaultMessage)>(
+            $"""SELECT "record_id" AS "RecordId", "fault_message" AS "FaultMessage" FROM "{schemaName}"."{tableName}" """)
+            .ConfigureAwait(false);
+
+        Assert.Equal("bad-2", row.RecordId);
+        Assert.Contains("configured to fail", row.FaultMessage, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/tests/Pipelinez.PostgreSql.Tests/EndToEnd/PostgreSqlPipelineDestinationTests.cs
+++ b/src/tests/Pipelinez.PostgreSql.Tests/EndToEnd/PostgreSqlPipelineDestinationTests.cs
@@ -1,0 +1,100 @@
+using Pipelinez.Core;
+using Pipelinez.PostgreSql;
+using Pipelinez.PostgreSql.Mapping;
+using Pipelinez.PostgreSql.Tests.EndToEnd.Models;
+using Pipelinez.PostgreSql.Tests.Infrastructure;
+using Xunit;
+
+namespace Pipelinez.PostgreSql.Tests.EndToEnd;
+
+[Collection(PostgreSqlIntegrationCollection.Name)]
+public sealed class PostgreSqlPipelineDestinationTests(PostgreSqlTestCluster cluster)
+{
+    [Fact]
+    public async Task PostgreSqlDestination_TableMap_Writes_Record_To_Consumer_Owned_Table()
+    {
+        var scenarioName = nameof(PostgreSqlDestination_TableMap_Writes_Record_To_Consumer_Owned_Table);
+        var schemaName = PostgreSqlNameFactory.CreateSchemaName(scenarioName);
+        var tableName = PostgreSqlNameFactory.CreateTableName(scenarioName);
+
+        await cluster.ExecuteAsync($"""
+            CREATE SCHEMA "{schemaName}";
+            CREATE TABLE "{schemaName}"."{tableName}" (
+                "order_id" text NOT NULL,
+                "payload" jsonb NOT NULL,
+                "processed_at_utc" timestamptz NOT NULL
+            );
+            """).ConfigureAwait(false);
+
+        var pipeline = Pipeline<TestPostgreSqlRecord>.New(scenarioName)
+            .WithInMemorySource(new object())
+            .WithPostgreSqlDestination(
+                cluster.CreateDestinationOptions(),
+                PostgreSqlTableMap<TestPostgreSqlRecord>.ForTable(schemaName, tableName)
+                    .Map("order_id", record => record.Id)
+                    .MapJson("payload", record => record)
+                    .Map("processed_at_utc", _ => DateTimeOffset.UtcNow))
+            .Build();
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+        await pipeline.PublishAsync(new TestPostgreSqlRecord
+        {
+            Id = "A-100",
+            Value = "good"
+        }).ConfigureAwait(false);
+        await pipeline.CompleteAsync().ConfigureAwait(false);
+        await pipeline.Completion.ConfigureAwait(false);
+
+        var row = await cluster.QuerySingleAsync<(string OrderId, string Value)>(
+            $"""SELECT "order_id" AS "OrderId", "payload"->>'value' AS "Value" FROM "{schemaName}"."{tableName}" """)
+            .ConfigureAwait(false);
+
+        Assert.Equal("A-100", row.OrderId);
+        Assert.Equal("good", row.Value);
+    }
+
+    [Fact]
+    public async Task PostgreSqlDestination_Custom_Command_Writes_Record_To_Consumer_Owned_Table()
+    {
+        var scenarioName = nameof(PostgreSqlDestination_Custom_Command_Writes_Record_To_Consumer_Owned_Table);
+        var schemaName = PostgreSqlNameFactory.CreateSchemaName(scenarioName);
+        var tableName = PostgreSqlNameFactory.CreateTableName(scenarioName);
+
+        await cluster.ExecuteAsync($"""
+            CREATE SCHEMA "{schemaName}";
+            CREATE TABLE "{schemaName}"."{tableName}" (
+                "external_id" text NOT NULL,
+                "status_value" text NOT NULL
+            );
+            """).ConfigureAwait(false);
+
+        var pipeline = Pipeline<TestPostgreSqlRecord>.New(scenarioName)
+            .WithInMemorySource(new object())
+            .WithPostgreSqlDestination(
+                cluster.CreateDestinationOptions(),
+                record => new PostgreSqlCommandDefinition(
+                    $"""INSERT INTO "{schemaName}"."{tableName}" ("external_id", "status_value") VALUES (@external_id, @status_value)""",
+                    new
+                    {
+                        external_id = record.Id,
+                        status_value = record.Value
+                    }))
+            .Build();
+
+        await pipeline.StartPipelineAsync().ConfigureAwait(false);
+        await pipeline.PublishAsync(new TestPostgreSqlRecord
+        {
+            Id = "B-200",
+            Value = "processed"
+        }).ConfigureAwait(false);
+        await pipeline.CompleteAsync().ConfigureAwait(false);
+        await pipeline.Completion.ConfigureAwait(false);
+
+        var row = await cluster.QuerySingleAsync<(string ExternalId, string StatusValue)>(
+            $"""SELECT "external_id" AS "ExternalId", "status_value" AS "StatusValue" FROM "{schemaName}"."{tableName}" """)
+            .ConfigureAwait(false);
+
+        Assert.Equal("B-200", row.ExternalId);
+        Assert.Equal("processed", row.StatusValue);
+    }
+}

--- a/src/tests/Pipelinez.PostgreSql.Tests/GlobalUsings.cs
+++ b/src/tests/Pipelinez.PostgreSql.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/tests/Pipelinez.PostgreSql.Tests/Infrastructure/PostgreSqlIntegrationCollection.cs
+++ b/src/tests/Pipelinez.PostgreSql.Tests/Infrastructure/PostgreSqlIntegrationCollection.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace Pipelinez.PostgreSql.Tests.Infrastructure;
+
+public static class PostgreSqlIntegrationCollection
+{
+    public const string Name = "PostgreSqlIntegration";
+}
+
+[CollectionDefinition(PostgreSqlIntegrationCollection.Name)]
+public sealed class PostgreSqlIntegrationCollectionDefinition : ICollectionFixture<PostgreSqlTestCluster>
+{
+}

--- a/src/tests/Pipelinez.PostgreSql.Tests/Infrastructure/PostgreSqlNameFactory.cs
+++ b/src/tests/Pipelinez.PostgreSql.Tests/Infrastructure/PostgreSqlNameFactory.cs
@@ -1,0 +1,26 @@
+namespace Pipelinez.PostgreSql.Tests.Infrastructure;
+
+public static class PostgreSqlNameFactory
+{
+    public static string CreateSchemaName(string scenarioName)
+    {
+        return CreateName("schema", scenarioName);
+    }
+
+    public static string CreateTableName(string scenarioName)
+    {
+        return CreateName("table", scenarioName);
+    }
+
+    private static string CreateName(string prefix, string scenarioName)
+    {
+        var normalized = new string(
+            scenarioName
+                .ToLowerInvariant()
+                .Select(c => char.IsLetterOrDigit(c) ? c : '_')
+                .ToArray())
+            .Trim('_');
+
+        return $"{prefix}_{normalized}_{Guid.NewGuid():N}";
+    }
+}

--- a/src/tests/Pipelinez.PostgreSql.Tests/Infrastructure/PostgreSqlTestCluster.cs
+++ b/src/tests/Pipelinez.PostgreSql.Tests/Infrastructure/PostgreSqlTestCluster.cs
@@ -1,0 +1,97 @@
+using Dapper;
+using Npgsql;
+using Pipelinez.PostgreSql.Configuration;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Pipelinez.PostgreSql.Tests.Infrastructure;
+
+public sealed class PostgreSqlTestCluster : IAsyncLifetime, IAsyncDisposable
+{
+    private readonly PostgreSqlTestClusterOptions _options;
+    private readonly PostgreSqlContainer _container;
+
+    public PostgreSqlTestCluster()
+        : this(PostgreSqlTestClusterOptions.LoadFromEnvironment())
+    {
+    }
+
+    internal PostgreSqlTestCluster(PostgreSqlTestClusterOptions options)
+    {
+        _options = options;
+
+        var builder = new PostgreSqlBuilder(_options.Image)
+            .WithDatabase(_options.Database)
+            .WithUsername(_options.Username)
+            .WithPassword(_options.Password);
+
+        if (_options.ReuseContainer)
+        {
+            builder = builder.WithReuse(true);
+        }
+
+        _container = builder.Build();
+    }
+
+    public string ConnectionString => _container.GetConnectionString();
+
+    public async Task InitializeAsync()
+    {
+        using var cancellation = new CancellationTokenSource(_options.StartupTimeout);
+        await _container.StartAsync(cancellation.Token).ConfigureAwait(false);
+    }
+
+    public Task DisposeAsync()
+    {
+        return ((IAsyncDisposable)this).DisposeAsync().AsTask();
+    }
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        await _container.DisposeAsync().ConfigureAwait(false);
+    }
+
+    public PostgreSqlDestinationOptions CreateDestinationOptions()
+    {
+        return new PostgreSqlDestinationOptions
+        {
+            ConnectionString = ConnectionString
+        };
+    }
+
+    public PostgreSqlDeadLetterOptions CreateDeadLetterOptions()
+    {
+        return new PostgreSqlDeadLetterOptions
+        {
+            ConnectionString = ConnectionString
+        };
+    }
+
+    public async Task ExecuteAsync(string sql)
+    {
+        await using var connection = new NpgsqlConnection(ConnectionString);
+        await connection.OpenAsync().ConfigureAwait(false);
+        await connection.ExecuteAsync(sql).ConfigureAwait(false);
+    }
+
+    public async Task ExecuteAsync(string sql, object? parameters)
+    {
+        await using var connection = new NpgsqlConnection(ConnectionString);
+        await connection.OpenAsync().ConfigureAwait(false);
+        await connection.ExecuteAsync(sql, parameters).ConfigureAwait(false);
+    }
+
+    public async Task<T> QuerySingleAsync<T>(string sql, object? parameters = null)
+    {
+        await using var connection = new NpgsqlConnection(ConnectionString);
+        await connection.OpenAsync().ConfigureAwait(false);
+        return await connection.QuerySingleAsync<T>(sql, parameters).ConfigureAwait(false);
+    }
+
+    public async Task<T?> QuerySingleOrDefaultAsync<T>(string sql, object? parameters = null)
+    {
+        await using var connection = new NpgsqlConnection(ConnectionString);
+        await connection.OpenAsync().ConfigureAwait(false);
+        return await connection.QuerySingleOrDefaultAsync<T>(sql, parameters).ConfigureAwait(false);
+    }
+}

--- a/src/tests/Pipelinez.PostgreSql.Tests/Infrastructure/PostgreSqlTestClusterOptions.cs
+++ b/src/tests/Pipelinez.PostgreSql.Tests/Infrastructure/PostgreSqlTestClusterOptions.cs
@@ -1,0 +1,50 @@
+namespace Pipelinez.PostgreSql.Tests.Infrastructure;
+
+public sealed class PostgreSqlTestClusterOptions
+{
+    public const string DefaultImage = "postgres:16-alpine";
+    public const string DefaultDatabase = "pipelinez_tests";
+    public const string DefaultUsername = "postgres";
+    public const string DefaultPassword = "postgres";
+    public static readonly TimeSpan DefaultStartupTimeout = TimeSpan.FromMinutes(2);
+
+    public string Image { get; init; } = DefaultImage;
+    public string Database { get; init; } = DefaultDatabase;
+    public string Username { get; init; } = DefaultUsername;
+    public string Password { get; init; } = DefaultPassword;
+    public TimeSpan StartupTimeout { get; init; } = DefaultStartupTimeout;
+    public bool ReuseContainer { get; init; }
+
+    public static PostgreSqlTestClusterOptions LoadFromEnvironment()
+    {
+        return new PostgreSqlTestClusterOptions
+        {
+            Image = GetEnvironmentValue("PIPELINEZ_POSTGRESQL_TEST_IMAGE", DefaultImage),
+            Database = GetEnvironmentValue("PIPELINEZ_POSTGRESQL_TEST_DATABASE", DefaultDatabase),
+            Username = GetEnvironmentValue("PIPELINEZ_POSTGRESQL_TEST_USERNAME", DefaultUsername),
+            Password = GetEnvironmentValue("PIPELINEZ_POSTGRESQL_TEST_PASSWORD", DefaultPassword),
+            StartupTimeout = GetEnvironmentSeconds("PIPELINEZ_POSTGRESQL_TEST_STARTUP_TIMEOUT_SECONDS", DefaultStartupTimeout),
+            ReuseContainer = GetEnvironmentBool("PIPELINEZ_POSTGRESQL_TEST_REUSE_CONTAINER")
+        };
+    }
+
+    private static string GetEnvironmentValue(string variableName, string fallback)
+    {
+        var value = Environment.GetEnvironmentVariable(variableName);
+        return string.IsNullOrWhiteSpace(value) ? fallback : value;
+    }
+
+    private static TimeSpan GetEnvironmentSeconds(string variableName, TimeSpan fallback)
+    {
+        var value = Environment.GetEnvironmentVariable(variableName);
+        return int.TryParse(value, out var seconds) && seconds > 0
+            ? TimeSpan.FromSeconds(seconds)
+            : fallback;
+    }
+
+    private static bool GetEnvironmentBool(string variableName)
+    {
+        var value = Environment.GetEnvironmentVariable(variableName);
+        return bool.TryParse(value, out var parsed) && parsed;
+    }
+}

--- a/src/tests/Pipelinez.PostgreSql.Tests/Pipelinez.PostgreSql.Tests.csproj
+++ b/src/tests/Pipelinez.PostgreSql.Tests/Pipelinez.PostgreSql.Tests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Dapper" Version="2.1.35" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+        <PackageReference Include="Npgsql" Version="8.0.3" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Pipelinez\Pipelinez.csproj" />
+        <ProjectReference Include="..\..\Pipelinez.PostgreSql\Pipelinez.PostgreSql.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Compile Include="..\TestCommon\ApiApproval\ApiApprovalTextGenerator.cs" Link="ApiApproval\ApiApprovalTextGenerator.cs" />
+        <None Include="ApprovedApi\Pipelinez.PostgreSql.publicapi.txt" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
+</Project>

--- a/src/tests/Pipelinez.PostgreSql.Tests/Unit/PostgreSqlTableMapTests.cs
+++ b/src/tests/Pipelinez.PostgreSql.Tests/Unit/PostgreSqlTableMapTests.cs
@@ -1,0 +1,80 @@
+using Dapper;
+using Npgsql;
+using Pipelinez.Core.DeadLettering;
+using Pipelinez.Core.FaultHandling;
+using Pipelinez.PostgreSql.Client;
+using Pipelinez.PostgreSql.Configuration;
+using Pipelinez.PostgreSql.Internal;
+using Pipelinez.PostgreSql.Mapping;
+using Pipelinez.PostgreSql.Tests.EndToEnd.Models;
+using Xunit;
+
+namespace Pipelinez.PostgreSql.Tests.Unit;
+
+public sealed class PostgreSqlTableMapTests
+{
+    [Fact]
+    public void PostgreSqlTableMap_Generated_Command_Uses_Quoted_Identifiers_And_Parameters()
+    {
+        var tableMap = PostgreSqlTableMap<TestPostgreSqlRecord>.ForTable("app data", "processed-orders")
+            .Map("order id", record => record.Id)
+            .MapJson("payload", record => record);
+
+        var command = PostgreSqlMappedCommandFactory.CreateCommand(
+            tableMap,
+            new TestPostgreSqlRecord
+            {
+                Id = "A-100",
+                Value = "good"
+            },
+            new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web),
+            defaultCommandTimeoutSeconds: 30);
+
+        Assert.Equal(
+            "INSERT INTO \"app data\".\"processed-orders\" (\"order id\", \"payload\") VALUES (@p0, @p1::jsonb)",
+            command.CommandText);
+
+        var parameters = Assert.IsType<DynamicParameters>(command.Parameters);
+        Assert.Equal("A-100", parameters.Get<string>("p0"));
+        Assert.Contains("\"id\":\"A-100\"", parameters.Get<string>("p1"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PostgreSqlDestinationOptions_Validate_Rejects_Ambiguous_DataSource_Configuration()
+    {
+        using var dataSource = NpgsqlDataSource.Create("Host=localhost;Database=test;Username=postgres;Password=postgres");
+
+        var options = new PostgreSqlDestinationOptions
+        {
+            DataSource = dataSource,
+            ConnectionString = "Host=localhost;Database=test;Username=postgres;Password=postgres"
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => options.Validate());
+        Assert.Contains("cannot combine", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PostgreSqlConnectionFactory_Does_Not_Dispose_Externally_Owned_DataSource()
+    {
+        await using var dataSource = NpgsqlDataSource.Create("Host=localhost;Database=test;Username=postgres;Password=postgres");
+        var factory = new PostgreSqlConnectionFactory(new PostgreSqlDestinationOptions
+        {
+            DataSource = dataSource
+        });
+
+        await factory.DisposeAsync().ConfigureAwait(false);
+
+        using var command = dataSource.CreateCommand("SELECT 1");
+        Assert.Equal("SELECT 1", command.CommandText);
+    }
+
+    [Fact]
+    public void PostgreSqlTableMap_Validate_Requires_At_Least_One_Column()
+    {
+        var tableMap = PostgreSqlTableMap<TestPostgreSqlRecord>.ForTable("app", "orders");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => tableMap.Validate());
+        Assert.Contains("at least one column", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary

- Added a new `Pipelinez.PostgreSql` package with PostgreSQL destination support
- Added two consumer mapping paths for PostgreSQL writes:
  - generated insert SQL from a `PostgreSqlTableMap<TRecord>`
  - fully custom parameterized SQL through `PostgreSqlCommandDefinition`
- Added PostgreSQL dead-letter destination support with both table-mapped and custom-command paths
- Implemented PostgreSQL execution on top of `Npgsql` and Dapper while keeping transport internals non-public
- Added full connection configuration support, including connection string, builder hooks, and externally supplied `NpgsqlDataSource`
- Added a dedicated `Pipelinez.PostgreSql.Tests` project with API approval, unit, and Docker-backed integration coverage
- Updated packaging, CI/release workflows, smoke-package validation, and consumer documentation for the new package

## Validation

- [x] `dotnet build src/Pipelinez.sln`
- [x] `dotnet test src/Pipelinez.sln --logger "console;verbosity=minimal"`

## Release Impact

- [ ] Patch
- [x] Minor
- [ ] Major
- [ ] No release impact

Notes:

- This adds a new transport package and consumer-facing feature area without introducing breaking changes to the existing `Pipelinez` or `Pipelinez.Kafka` packages.
- Package/release plumbing was also extended so `Pipelinez.PostgreSql` is packed and validated alongside the existing packages.

## Public API

- [ ] No public API changes
- [x] Public API changes were intentional and the approved baselines were updated
- [ ] New unstable public APIs are marked preview
- [ ] Obsoletions include a migration path

## Documentation

- [ ] No documentation updates were needed
- [x] Consumer-facing docs were updated for behavior or API changes