### PR TITLE
adding security tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Chicago
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      dotnet-root-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: nuget
+    directory: /src
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: America/Chicago
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      dotnet-source-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "10:00"
+      timezone: America/Chicago
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,7 @@
+fail-on-severity: high
+fail-on-scopes:
+  - runtime
+vulnerability-check: true
+license-check: false
+show-openssf-scorecard: true
+show-patched-versions: true

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,55 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  analyze:
+    name: Analyze C#
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: csharp
+          build-mode: manual
+
+      - name: Restore
+        run: dotnet restore src/Pipelinez.sln
+
+      - name: Build
+        run: dotnet build src/Pipelinez.sln --configuration Release --no-restore
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,30 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Review Dependency Changes
+        uses: actions/dependency-review-action@v4
+        with:
+          config-file: ./.github/dependency-review-config.yml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,6 +84,15 @@ jobs:
         shell: pwsh
         run: ./scripts/Validate-Packages.ps1 -PackageDirectory artifacts/packages -PackageVersion ${{ steps.version.outputs.package_version }}
 
+      - name: Generate Package SBOM
+        uses: anchore/sbom-action@v0.24.0
+        with:
+          path: artifacts/packages
+          format: spdx-json
+          output-file: artifacts/packages/pipelinez-packages.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
       - name: Upload Packages
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,40 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "30 7 * * 1"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  scorecard:
+    name: Scorecard
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      id-token: write
+      issues: read
+      pull-requests: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload Scorecard Results
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: scorecard-results.sarif

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,20 @@ That usually means some combination of:
 - `documentation/ApiStability.md`
 - examples under `src/examples`
 
+## Dependency And Security Automation
+
+Dependency updates are managed through Dependabot and are expected to follow the same validation path as human-authored changes.
+
+Maintainer expectations:
+
+- review Dependabot pull requests for release-note impact before merging
+- prefer grouped dependency updates unless a security advisory requires an isolated hotfix
+- keep GitHub Actions updates small and verify workflow permissions before merging
+- treat dependency review failures as blocking unless the advisory is not applicable and the exception is documented in the pull request
+- check CodeQL and OpenSSF Scorecard findings before release branches or release tags are created
+
+Release package artifacts include an SPDX JSON SBOM generated from the packed NuGet artifacts. If release packaging changes, confirm the SBOM is still uploaded with the package artifact and attached to tag-based GitHub Releases.
+
 ## Pull Requests
 
 Keep pull requests focused and make public API changes explicit in the description. If your PR changes consumer-facing behavior, call that out directly so reviewers can evaluate compatibility impact separately from implementation details.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Typed, observable record-processing pipelines for .NET.
 [![NuGet Kafka](https://img.shields.io/nuget/v/Pipelinez.Kafka.svg)](https://www.nuget.org/packages/Pipelinez.Kafka)
 [![NuGet PostgreSQL](https://img.shields.io/nuget/v/Pipelinez.PostgreSql.svg)](https://www.nuget.org/packages/Pipelinez.PostgreSql)
 [![CI](https://github.com/KenBerg75/Pipelinez/actions/workflows/CI.yaml/badge.svg)](https://github.com/KenBerg75/Pipelinez/actions/workflows/CI.yaml)
+[![CodeQL](https://github.com/KenBerg75/Pipelinez/actions/workflows/codeql.yaml/badge.svg)](https://github.com/KenBerg75/Pipelinez/actions/workflows/codeql.yaml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/KenBerg75/Pipelinez/badge)](https://scorecard.dev/viewer/?uri=github.com/KenBerg75/Pipelinez)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-8.0-512BD4)](https://dotnet.microsoft.com/)
 
@@ -311,6 +313,7 @@ Current implemented capabilities include:
 - Docker-backed Kafka integration coverage
 - Docker-backed PostgreSQL destination and dead-letter integration coverage
 - public API approval tests and repository-level API stability guidance
+- Dependabot, Dependency Review, CodeQL, OpenSSF Scorecard, and release SBOM automation
 
 ## API Stability
 
@@ -324,7 +327,7 @@ See [`documentation/ApiStability.md`](documentation/ApiStability.md) for the ful
 
 ## Releases
 
-Pipelinez uses SemVer-style versions and publishes `Pipelinez` and `Pipelinez.Kafka` with aligned package versions.
+Pipelinez uses SemVer-style versions and publishes `Pipelinez`, `Pipelinez.Kafka`, and `Pipelinez.PostgreSql` with aligned package versions.
 
 - stable releases use tags like `v1.2.3`
 - preview releases use tags like `v1.3.0-preview.1`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,3 +29,15 @@ Please include:
 ## Disclosure
 
 Maintainers will review the report, coordinate a fix, and publish release notes or an advisory when appropriate. Vulnerability disclosure timing should remain human-controlled and should not be delegated to automated or agentic workflows.
+
+## Automated Security Controls
+
+The repository uses source-controlled automation to reduce supply-chain and code security risk:
+
+- Dependabot monitors NuGet packages, .NET tools, and GitHub Actions.
+- Dependency Review evaluates dependency changes on pull requests and blocks high-severity runtime vulnerabilities.
+- CodeQL analyzes the C# source on pull requests, pushes to `main`, scheduled runs, and manual dispatch.
+- OpenSSF Scorecard runs on a schedule and uploads SARIF results to GitHub code scanning.
+- Release validation generates an SPDX JSON SBOM from the packed NuGet artifacts and publishes it with release artifacts.
+
+Repository-level GitHub security settings still need to remain enabled by maintainers, including Dependabot alerts, Dependabot security updates, secret scanning, push protection when available, code scanning, and private vulnerability reporting.

--- a/documentation/Overview.md
+++ b/documentation/Overview.md
@@ -873,7 +873,7 @@ The solution now includes two test layers.
 - option validation and generated SQL safety
 - public API approval coverage for the PostgreSQL package
 
-At the time of this overview update, `dotnet test src\\Pipelinez.sln` passes with both the core and Kafka integration suites green.
+At the time of this overview update, `dotnet test src\\Pipelinez.sln` passes with the core, Kafka, and PostgreSQL test suites green.
 
 ## Current State
 
@@ -895,6 +895,7 @@ The major architectural work called out in the earlier planning docs has been im
 - explicit PostgreSQL destination and dead-letter transport support
 - explicit flow-control policies with publish results, saturation status, and pressure metrics
 - explicit operational tooling with health snapshots, health checks, meter metrics, and correlation-aware diagnostics
+- explicit dependency and security automation with Dependabot, Dependency Review, CodeQL, OpenSSF Scorecard, and release SBOM generation
 
 The remaining work is mostly future evolution work rather than foundational cleanup. Likely areas include broader transport coverage, schema-registry integration tests, and further runtime ergonomics.
 
@@ -902,8 +903,8 @@ The remaining work is mostly future evolution work rather than foundational clea
 
 Pipelinez now also has explicit public API governance in place.
 
-- the repository treats `Pipelinez` and `Pipelinez.Kafka` as intentional consumer contracts
-- public API approval tests snapshot the compiled surface of both assemblies
+- the repository treats `Pipelinez`, `Pipelinez.Kafka`, and `Pipelinez.PostgreSql` as intentional consumer contracts
+- public API approval tests snapshot the compiled surface of all public package assemblies
 - accidental API changes now fail the normal test suite, which means they are also caught by the existing PR and CI workflows
 - contributor guidance now distinguishes stable, preview, and internal-only surface area
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -40,6 +40,7 @@ This folder contains the main documentation set for Pipelinez.
 
 - [Troubleshooting](operations/troubleshooting.md)
 - [Repository Topics](operations/repository-topics.md)
+- [Security Automation](operations/security-automation.md)
 
 ## Architecture
 

--- a/documentation/operations/security-automation.md
+++ b/documentation/operations/security-automation.md
@@ -1,0 +1,76 @@
+# Security Automation
+
+Pipelinez uses GitHub-native automation to keep dependency drift visible, block risky dependency changes, and publish security signals for maintainers.
+
+## What Runs
+
+| Automation | Trigger | Purpose |
+| --- | --- | --- |
+| Dependabot | Weekly | Opens NuGet, .NET tool, and GitHub Actions update pull requests. |
+| Dependency Review | Pull requests | Reviews dependency changes and fails high-severity runtime vulnerability introductions. |
+| CodeQL | Pull requests, `main`, weekly, manual | Performs C# static analysis and publishes code scanning results. |
+| OpenSSF Scorecard | Weekly, branch protection changes, manual | Evaluates repository supply-chain posture and publishes SARIF results. |
+| Release SBOM | Release validation | Generates an SPDX JSON SBOM from packed NuGet artifacts. |
+
+## Dependabot
+
+Dependabot is configured in `.github/dependabot.yml`.
+
+The configuration covers:
+
+- the repository root for `.NET` tool updates such as DocFX
+- the `src` tree for project and test package references
+- GitHub Actions workflow dependencies
+
+Dependabot pull requests should be reviewed like any other pull request. Grouped dependency updates are preferred for routine maintenance, but security updates may be handled independently when a vulnerable package needs a faster merge.
+
+## Dependency Review
+
+Dependency Review runs on pull requests and uses `.github/dependency-review-config.yml`.
+
+The current policy is intentionally focused:
+
+- fail on `high` or `critical` runtime vulnerabilities
+- keep license checking disabled until the project adopts a formal license policy
+- show OpenSSF package scorecard context where GitHub can provide it
+- show patched versions when vulnerability data includes them
+
+If a failure is not exploitable in Pipelinez, document the reasoning in the pull request before adding any exception.
+
+## CodeQL
+
+CodeQL runs with a manual .NET build so analysis sees the same compile path as CI.
+
+The workflow restores and builds `src/Pipelinez.sln` in `Release` before analysis. This avoids relying on CodeQL autobuild heuristics and makes failures easier to correlate with normal CI failures.
+
+Review CodeQL alerts before releases. A new alert should be triaged as one of:
+
+- true positive requiring a fix
+- false positive with a short explanation
+- accepted risk with clear release-note and maintainer context
+
+## OpenSSF Scorecard
+
+OpenSSF Scorecard runs weekly and after branch protection changes.
+
+The workflow publishes results through the OpenSSF API and uploads SARIF to GitHub code scanning. The score should be treated as a maintenance signal rather than an absolute release gate; score drops should trigger review, especially around branch protection, pinned actions, security policy, and token permissions.
+
+## Release SBOM
+
+The release workflow generates `pipelinez-packages.spdx.json` from the packed NuGet artifacts after package validation succeeds.
+
+The SBOM is included in the `pipelinez-packages` workflow artifact and is attached to tag-based GitHub Releases alongside the NuGet packages and symbol packages.
+
+## Manual Repository Settings
+
+Source control cannot enable every GitHub security feature. Maintainers should confirm these repository settings are enabled:
+
+- Dependabot alerts
+- Dependabot security updates
+- dependency graph
+- secret scanning
+- push protection, when available
+- code scanning
+- private vulnerability reporting
+
+Branch protection or repository rules should require the normal PR build, dependency review, and CodeQL checks once the workflows have completed at least one successful run.

--- a/documentation/toc.yml
+++ b/documentation/toc.yml
@@ -40,6 +40,8 @@
   items:
     - name: Troubleshooting
       href: operations/troubleshooting.md
+    - name: Security Automation
+      href: operations/security-automation.md
 - name: Architecture
   items:
     - name: Runtime


### PR DESCRIPTION
```markdown
## Summary

- add dependency and security automation for the repository
- configure Dependabot for NuGet, .NET tools, and GitHub Actions updates
- add Dependency Review for pull requests with high-severity runtime vulnerability blocking
- add CodeQL C# scanning with a manual .NET build path
- add OpenSSF Scorecard scanning with SARIF upload to code scanning
- generate an SPDX JSON SBOM during release package validation
- update maintainer and security documentation to describe the new automation and required GitHub repository settings

## Validation

- [x] `dotnet build src/Pipelinez.sln --configuration Release`
- [x] `dotnet test src/Pipelinez.sln --configuration Release --no-build --logger "console;verbosity=minimal"`
- [x] `dotnet docfx docs/docfx.json`
- [x] `git diff --check`

## Release Impact

- [x] Patch
- [ ] Minor
- [ ] Major
- [ ] No release impact

Notes:

- no runtime or public API behavior changes
- release artifacts now include an SPDX JSON SBOM generated from the packed NuGet artifacts
- repository maintainers should enable/confirm Dependabot alerts, Dependabot security updates, secret scanning, push protection, code scanning, and private vulnerability reporting after merge

## Public API

- [x] No public API changes
- [ ] Public API changes were intentional and the approved baselines were updated
- [ ] New unstable public APIs are marked preview
- [ ] Obsoletions include a migration path

## Documentation

- [ ] No documentation updates were needed
- [x] Consumer-facing docs were updated for behavior or API changes
```