### PR TITLE
Fixing syntax error in benchmarking

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -246,7 +246,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: docs: update benchmark results
+          commit-message: "docs: update benchmark results"
           branch: automation/benchmark-results-${{ github.run_id }}
           delete-branch: true
           title: "docs: update benchmark results"


### PR DESCRIPTION
## Summary

- fix the YAML syntax error in `.github/workflows/benchmarks.yaml`
- quote the `commit-message` value passed to `peter-evans/create-pull-request@v7` so GitHub Actions can parse the workflow correctly
- restore benchmark workflow validation for the benchmark-results PR publishing step

## Validation

- [ ] `dotnet build src/Pipelinez.sln`
- [ ] `dotnet test src/Pipelinez.sln --logger "console;verbosity=minimal"`
- [ ] `./scripts/Validate-Packages.ps1 -PackageDirectory artifacts/packages` when package metadata, public APIs, or release behavior changed

Additional validation completed for this PR:

- [x] reviewed the workflow diff and confirmed the invalid YAML was the unquoted `commit-message: docs: update benchmark results` entry
- [x] updated the value to `commit-message: "docs: update benchmark results"`

## Release Impact

- [ ] Patch
- [ ] Minor
- [ ] Major
- [x] No release impact

Notes:

- this is a workflow-only fix to restore GitHub Actions parsing
- there is no package, runtime, or behavioral impact for library consumers

## Public API

- [x] No public API changes
- [ ] Public API changes were intentional and the approved baselines were updated
- [ ] New unstable public APIs are marked preview
- [ ] Obsoletions include a migration path

## Documentation

- [x] No documentation updates were needed
- [ ] Consumer-facing docs were updated for behavior or API changes
