### PR TITLE
Fixing syntax error in benchmarking azure

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -148,28 +148,46 @@ jobs:
 
   azure-service-bus:
     name: Azure Service Bus Benchmarks
-    if: ${{ secrets.PIPELINEZ_ASB_CONNECTION_STRING != '' }}
     runs-on: ubuntu-latest
+    env:
+      PIPELINEZ_ASB_CONNECTION_STRING: ${{ secrets.PIPELINEZ_ASB_CONNECTION_STRING }}
 
     steps:
+      - name: Check Azure Service Bus Benchmark Configuration
+        id: config
+        shell: bash
+        run: |
+          if [ -n "${PIPELINEZ_ASB_CONNECTION_STRING}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip Azure Service Bus Benchmarks
+        if: ${{ steps.config.outputs.enabled != 'true' }}
+        run: echo "Skipping Azure Service Bus benchmarks because PIPELINEZ_ASB_CONNECTION_STRING is not configured."
+
       - name: Checkout
+        if: ${{ steps.config.outputs.enabled == 'true' }}
         uses: actions/checkout@v6
 
       - name: Setup .NET
+        if: ${{ steps.config.outputs.enabled == 'true' }}
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 
       - name: Restore Benchmark Project
+        if: ${{ steps.config.outputs.enabled == 'true' }}
         run: dotnet restore $BENCHMARK_PROJECT/Pipelinez.Benchmarks.csproj
 
       - name: Build Benchmark Project
+        if: ${{ steps.config.outputs.enabled == 'true' }}
         run: dotnet build $BENCHMARK_PROJECT/Pipelinez.Benchmarks.csproj --configuration Release --no-restore
 
       - name: Run Azure Service Bus Benchmarks
+        if: ${{ steps.config.outputs.enabled == 'true' }}
         shell: bash
-        env:
-          PIPELINEZ_ASB_CONNECTION_STRING: ${{ secrets.PIPELINEZ_ASB_CONNECTION_STRING }}
         run: |
           set -euo pipefail
           suite="azure-service-bus"
@@ -199,6 +217,7 @@ jobs:
           EOF
 
       - name: Upload Azure Service Bus Benchmark Artifacts
+        if: ${{ steps.config.outputs.enabled == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: benchmarks-azure-service-bus
@@ -215,7 +234,7 @@ jobs:
       ${{
         needs.in-memory.result == 'success' &&
         needs.docker-backed.result == 'success' &&
-        (needs.azure-service-bus.result == 'success' || needs.azure-service-bus.result == 'skipped')
+        needs.azure-service-bus.result == 'success'
       }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- fix the benchmark workflow so it no longer uses `secrets` in a job-level `if:` expression
- move Azure Service Bus benchmark secret handling into the job environment and detect configuration in a dedicated setup step
- conditionally run Azure Service Bus benchmark steps only when `PIPELINEZ_ASB_CONNECTION_STRING` is configured
- keep the Azure benchmark job successful with a clear skip message when the secret is absent
- align the benchmark-results PR publishing job with the new Azure benchmark job behavior

## Validation

- [ ] `dotnet build src/Pipelinez.sln`
- [ ] `dotnet test src/Pipelinez.sln --logger "console;verbosity=minimal"`
- [ ] `./scripts/Validate-Packages.ps1 -PackageDirectory artifacts/packages` when package metadata, public APIs, or release behavior changed

Additional validation completed for this PR:

- [x] reviewed the failing workflow expression and confirmed GitHub Actions does not allow `secrets` in that `if:` context
- [x] updated the workflow to use step outputs for conditional execution inside the Azure Service Bus benchmark job
- [x] verified the downstream `publish-results-pr` dependency condition matches the new job behavior

## Release Impact

- [ ] Patch
- [ ] Minor
- [ ] Major
- [x] No release impact

Notes:

- this is a GitHub Actions workflow fix only
- there is no package, runtime, or consumer-facing behavior change

## Public API

- [x] No public API changes
- [ ] Public API changes were intentional and the approved baselines were updated
- [ ] New unstable public APIs are marked preview
- [ ] Obsoletions include a migration path

## Documentation

- [x] No documentation updates were needed
- [ ] Consumer-facing docs were updated for behavior or API changes
